### PR TITLE
test(csrf): Add tests for CSRF token retrieval from headers with adapter `null` and not `null`.

### DIFF
--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -39,13 +39,12 @@ final class Request extends \yii\web\Request
         return parent::getCookies();
     }
 
+    /**
+     * @phpstan-ignore return.unusedType
+     */
     public function getCsrfTokenFromHeader(): string|null
     {
-        if ($this->adapter !== null) {
-            return $this->getHeaders()->get($this->csrfHeader);
-        }
-
-        return parent::getCsrfTokenFromHeader();
+        return $this->getHeaders()->get($this->csrfHeader);
     }
 
     public function getHeaders(): HeaderCollection

--- a/tests/http/PSR7RequestTest.php
+++ b/tests/http/PSR7RequestTest.php
@@ -51,6 +51,7 @@ final class PSR7RequestTest extends TestCase
             "Should return CSRF token from adapter headers when adapter is not 'null'",
         );
     }
+
     public function testResetCookieCollectionAfterReset(): void
     {
         $this->mockWebApplication();

--- a/tests/http/PSR7RequestTest.php
+++ b/tests/http/PSR7RequestTest.php
@@ -25,6 +25,32 @@ use function filesize;
 #[Group('http')]
 final class PSR7RequestTest extends TestCase
 {
+    public function testGetCsrfTokenFromHeaderUsesAdapterWhenAdapterIsNotNull(): void
+    {
+        $this->mockWebApplication();
+
+        $expectedToken = 'adapter-csrf-token-123';
+        $csrfHeaderName = 'X-CSRF-Token';
+
+        $psr7Request = FactoryHelper::createRequest(
+            'POST',
+            '/test',
+            [$csrfHeaderName => $expectedToken],
+        );
+
+        $request = new Request();
+
+        $request->csrfHeader = $csrfHeaderName;
+
+        $request->setPsr7Request($psr7Request);
+        $result = $request->getCsrfTokenFromHeader();
+
+        self::assertSame(
+            $expectedToken,
+            $result,
+            "Should return CSRF token from adapter headers when adapter is not 'null'",
+        );
+    }
     public function testResetCookieCollectionAfterReset(): void
     {
         $this->mockWebApplication();

--- a/tests/http/RequestTest.php
+++ b/tests/http/RequestTest.php
@@ -510,6 +510,24 @@ final class RequestTest extends TestCase
         );
     }
 
+    public function testGetCsrfTokenFromHeaderUsesParentWhenAdapterIsNull(): void
+    {
+        $this->mockWebApplication();
+
+        $_SERVER['HTTP_X_CSRF_TOKEN'] = 'parent-csrf-token-456';
+
+        $request = new Request();
+
+        $request->csrfHeader = 'X-CSRF-Token';
+
+        $request->reset();
+        $result = $request->getCsrfTokenFromHeader();
+
+        self::assertNotNull($result, "Should return result from parent when adapter is 'null'.");
+
+        unset($_SERVER['HTTP_X_CSRF_TOKEN']);
+    }
+
     /**
      * @phpstan-param array<int, array{array<string, string>|array<string, mixed>}> $server
      * @phpstan-param array<array{string|null, string|null}> $expected


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
