### PR TITLE
Introduce `ServerRequestCreator` and `UploadedFileCreator` class implementation with tests.

### DIFF
--- a/src/creator/ServerRequestCreator.php
+++ b/src/creator/ServerRequestCreator.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\psrbridge\creator;
+
+use Psr\Http\Message\{
+    ServerRequestFactoryInterface,
+    ServerRequestInterface,
+    StreamFactoryInterface,
+    UploadedFileFactoryInterface,
+    UploadedFileInterface,
+};
+use Throwable;
+
+use function fopen;
+use function is_string;
+
+/**
+ * PSR-7 ServerRequest creator for SAPI and worker environments.
+ *
+ * Provides a factory for creating {@see ServerRequestInterface} instances from PHP global variables, enabling seamless
+ * interoperability between PSR-7 compatible HTTP stacks and Yii2 applications.
+ *
+ * This class delegates the creation of server requests, streams, and uploaded files to the provided PSR-7 factories,
+ * supporting both traditional SAPI and worker-based environments.
+ *
+ * It ensures strict type safety and immutability throughout the request creation process.
+ *
+ * The creation process includes.
+ * - Attaching the request body stream from 'php://input' for compatibility with raw payloads.
+ * - Extracting HTTP method and URI from global variables.
+ * - Handling uploaded files via {@see UploadedFileCreator} when present.
+ * - Populating cookies, parsed body, and query parameters from PHP globals.
+ *
+ * Key features.
+ * - Automatic handling of uploaded files and body streams.
+ * - Designed for compatibility with SAPI and worker runtimes.
+ * - Exception-safe body stream attachment.
+ * - Immutable, type-safe request creation from PHP globals.
+ * - PSR-7 factory integration for server requests, streams, and uploaded files.
+ *
+ * @phpstan-type UnknownFileInput array<mixed>
+ * @phpstan-type FilesArray array<UploadedFileInterface|UnknownFileInput>
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class ServerRequestCreator
+{
+    /**
+     * Creates a new instance of the {@see ServerRequestCreator} class.
+     *
+     * @param ServerRequestFactoryInterface $serverRequestFactory Factory to create server requests.
+     * @param StreamFactoryInterface $streamFactory Factory to create streams.
+     * @param UploadedFileFactoryInterface $uploadedFileFactory Factory to create uploaded files.
+     */
+    public function __construct(
+        private readonly ServerRequestFactoryInterface $serverRequestFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+        private readonly UploadedFileFactoryInterface $uploadedFileFactory,
+    ) {}
+
+    /**
+     * Creates a {@see ServerRequestInterface} instance from PHP global variables.
+     *
+     * Provides a factory method for building a PSR-7 server request using the current SAPI or worker environment
+     * globals.
+     *
+     * This method extracts the HTTP method and URI from '$_SERVER¿, attaches cookies, parsed body, and query
+     * parameters, and automatically handles uploaded files when present. The request body stream is attached from
+     * 'php://input' for compatibility with raw payloads.
+     *
+     * @return ServerRequestInterface PSR-7 ServerRequestInterface created from PHP globals.
+     *
+     * Usage example:
+     * ```php
+     * $creator = new ServerRequestCreator($serverRequestFactory, $streamFactory, $uploadedFileFactory);
+     * $request = $creator->createFromGlobals();
+     * ```
+     */
+    public function createFromGlobals(): ServerRequestInterface
+    {
+        $method = isset($_SERVER['REQUEST_METHOD']) && is_string($_SERVER['REQUEST_METHOD'])
+            ? $_SERVER['REQUEST_METHOD']
+            : 'GET';
+        $uri = isset($_SERVER['REQUEST_URI']) && is_string($_SERVER['REQUEST_URI'])
+            ? $_SERVER['REQUEST_URI']
+            : '/';
+
+        $request = $this->serverRequestFactory
+            ->createServerRequest($method, $uri, $_SERVER)
+            ->withCookieParams($_COOKIE)
+            ->withParsedBody($_POST)
+            ->withQueryParams($_GET);
+
+        /** @phpstan-var FilesArray $_FILES */
+        if ($_FILES !== []) {
+            $uploadedFileCreator = new UploadedFileCreator($this->uploadedFileFactory, $this->streamFactory);
+
+            /** @phpstan-var array<array<mixed>|UploadedFileInterface> $uploadedFileFromGlobals */
+            $uploadedFileFromGlobals = $uploadedFileCreator->createFromGlobals($_FILES);
+            $request = $request->withUploadedFiles($uploadedFileFromGlobals);
+        }
+
+        return $this->withBodyStream($request);
+    }
+
+    /**
+     * Attaches the request body stream from 'php://input' to the provided {@see ServerRequestInterface} instance.
+     *
+     * Attempts to open the 'php://input' stream in read-only binary mode and, if successful, creates a PSR-7 stream
+     * using the configured {@see StreamFactoryInterface}. The resulting stream is then attached to the request as the
+     * body. If the stream cannot be opened or an exception occurs, the original request is returned unchanged.
+     *
+     * This method ensures exception-safe and immutable attachment of the request body stream for compatibility with
+     * raw payloads in SAPI and worker environments.
+     *
+     * @param ServerRequestInterface $request PSR-7 ServerRequestInterface instance to attach the body stream to.
+     *
+     * @return ServerRequestInterface ServerRequestInterface with the body stream attached, or the original request if
+     * the stream cannot be opened.
+     */
+    private function withBodyStream(ServerRequestInterface $request): ServerRequestInterface
+    {
+        try {
+            $handle = fopen('php://input', 'rb');
+
+            if ($handle !== false) {
+                $stream = $this->streamFactory->createStreamFromResource($handle);
+
+                return $request->withBody($stream);
+            }
+        } catch (Throwable) {
+        }
+
+        return $request;
+    }
+}

--- a/src/creator/UploadedFileCreator.php
+++ b/src/creator/UploadedFileCreator.php
@@ -1,0 +1,488 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\psrbridge\creator;
+
+use Psr\Http\Message\{StreamFactoryInterface, UploadedFileFactoryInterface, UploadedFileInterface};
+use yii\base\InvalidArgumentException;
+use yii2\extensions\psrbridge\exception\Message;
+
+use function array_key_exists;
+use function array_map;
+use function is_array;
+use function is_int;
+use function is_string;
+
+/**
+ * PSR-7 UploadedFile creation utility for SAPI and worker environments.
+ *
+ * Provides a factory for creating {@see UploadedFileInterface} instances from PHP file arrays, enabling seamless
+ * interoperability between PSR-7 compatible HTTP stacks and Yii2 applications.
+ *
+ * This class delegates the creation of uploaded files and file trees to the provided PSR-7 factories, supporting both
+ * traditional SAPI and worker-based environments. It ensures strict type safety and immutability throughout the file
+ * creation process, handling both single and multiple file uploads.
+ *
+ * The creation process includes.
+ * - Building nested file trees for multiple file uploads.
+ * - Creating PSR-7 {@see UploadedFileInterface} instances from file arrays and global variables.
+ * - Exception-safe conversion and validation of file input structures.
+ * - Immutable, type-safe file creation from PHP globals and arrays.
+ * - Validating file specification arrays for required and optional keys.
+ *
+ * Key features.
+ * - Automatic handling of single and multiple uploaded files.
+ * - Designed for compatibility with SAPI and worker runtimes.
+ * - Exception-safe file spec validation and conversion.
+ * - Immutable, type-safe uploaded file creation from PHP globals.
+ * - PSR-7 factory integration for uploaded files and streams.
+ *
+ * @phpstan-type TmpName array<array<mixed>|string>
+ * @phpstan-type TmpSize array<array<mixed>|int>
+ * @phpstan-type TmpError array<array<mixed>|int>
+ * @phpstan-type Name array<array<mixed>|string|null>
+ * @phpstan-type Type array<array<mixed>|string|null>
+ * @phpstan-type UnknownFileInput array<mixed>
+ * @phpstan-type FilesArray array<UploadedFileInterface|UnknownFileInput>
+ * @phpstan-type FileSpec array{tmp_name: string, size: int, error: int, name?: string|null, type?: string|null}
+ * @phpstan-type MultiFileSpec array{
+ *   tmp_name: TmpName,
+ *   size: TmpSize,
+ *   error: TmpError,
+ *   name?: Name|null,
+ *   type?: Type|null,
+ * }
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class UploadedFileCreator
+{
+    /**
+     * Optional keys for file specification.
+     */
+    private const OPTIONAL_KEYS = ['name', 'type'];
+
+    /**
+     * Required keys for file specification.
+     */
+    private const REQUIRED_KEYS = ['tmp_name', 'size', 'error'];
+
+    /**
+     * Creates a new instance of the {@see UploadedFileCreator} class.
+     *
+     * @param UploadedFileFactoryInterface $uploadedFileFactory Factory to create uploaded files.
+     * @param StreamFactoryInterface $streamFactory Factory to create streams.
+     */
+    public function __construct(
+        private readonly UploadedFileFactoryInterface $uploadedFileFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+    ) {}
+
+    /**
+     * Creates a UploadedFileInterface instance from a file specification array.
+     *
+     * Validates the input file specification and delegates stream and uploaded file creation to the configured PSR-7
+     * factories.
+     *
+     * This method ensures strict type safety and immutability when converting PHP file arrays to PSR-7 uploaded file
+     * objects.
+     *
+     * @param array $file File specification array containing required keys ('tmp_name', 'size', 'error') and optional
+     * keys ('name', 'type').
+     *
+     * @return UploadedFileInterface PSR-7 {@see UploadedFileInterface} instance created from the file specification
+     * array.
+     *
+     * @phpstan-param FileSpec $file
+     *
+     * Usage example:
+     * ```php
+     * $file = [
+     *     'tmp_name' => '/path/to/temp/file',
+     *     'size' => 12345,
+     *     'error' => 0,
+     *     'name' => 'example.txt',
+     *     'type' => 'text/plain',
+     * ];
+     *
+     * $uploadedFile = $creator->createFromArray($file);
+     * ```
+     */
+    public function createFromArray(array $file): UploadedFileInterface
+    {
+        $this->validateFileSpec($file);
+
+        $stream = $this->streamFactory->createStreamFromFile($file['tmp_name']);
+
+        return $this->uploadedFileFactory->createUploadedFile(
+            $stream,
+            $file['size'],
+            $file['error'],
+            $file['name'] ?? null,
+            $file['type'] ?? null,
+        );
+    }
+
+    /**
+     * Creates UploadedFileInterface instances from PHP global files array.
+     *
+     * Iterates over the provided files array and processes each entry using {@see processFileInput},
+     *
+     * This method enables seamless conversion of PHP global file structures to PSR-7 {@see UploadedFileInterface}
+     * objects, supporting both single and multiple file uploads in SAPI and worker environments.
+     *
+     * @param array $files Array of uploaded file specifications or PSR-7 {@see UploadedFileInterface} instances.
+     *
+     * @return array Array of processed uploaded files as PSR-7 {@see UploadedFileInterface} instances or nested file
+     * trees as appropriate.
+     *
+     * @phpstan-param FilesArray $files
+     *
+     * @phpstan-return FilesArray
+     *
+     * Usage example:
+     * ```php
+     * $files = $creator->createFromGlobals($_FILES);
+     * ```
+     */
+    public function createFromGlobals(array $files = []): array
+    {
+        return array_map(
+            function (array|UploadedFileInterface $file) {
+                return $this->processFileInput($file);
+            },
+            $files,
+        );
+    }
+
+    /**
+     * Builds a nested file tree from PHP file specification arrays for multiple file uploads.
+     *
+     * Iterates recursively over the provided file specification arrays ('tmp_name', 'size', 'error', 'name', 'type'),
+     * constructing a tree of PSR-7 {@see UploadedFileInterface} instances or nested arrays for each file input.
+     *
+     * This method validates the structure and types of each input array, ensuring strict type safety and consistency
+     * when handling both single and multiple file uploads. For array values, it recurses into subtrees; for scalar
+     * values, it creates a single uploaded file instance using {@see createSingleFileFromArrays}.
+     *
+     * @param array $tmpNames Array of temporary file names or nested arrays for uploaded files.
+     * @param array $sizes Array of file sizes or nested arrays matching the structure of $tmpNames.
+     * @param array $errors Array of error codes or nested arrays matching the structure of $tmpNames.
+     * @param array $names Array of file names or nested arrays matching the structure of $tmpNames.
+     * @param array $types Array of file types or nested arrays matching the structure of $tmpNames.
+     *
+     * @throws InvalidArgumentException if one or more arguments are invalid, of incorrect type or format.
+     *
+     * @return array Nested array of PSR-7 {@see UploadedFileInterface} instances or file trees.
+     *
+     * @phpstan-param TmpName $tmpNames
+     * @phpstan-param TmpSize $sizes
+     * @phpstan-param TmpError $errors
+     * @phpstan-param Name $names
+     * @phpstan-param Type $types
+     *
+     * @phpstan-return FilesArray
+     */
+    private function buildFileTree(
+        array $tmpNames,
+        array $sizes,
+        array $errors,
+        array $names = [],
+        array $types = [],
+    ): array {
+        $tree = [];
+
+        foreach ($tmpNames as $key => $tmpName) {
+            if (is_array($tmpName)) {
+                if (array_key_exists($key, $sizes) === false || is_array($sizes[$key]) === false) {
+                    throw new InvalidArgumentException(Message::MISMATCHED_ARRAY_STRUCTURE_SIZES->getMessage($key));
+                }
+
+                if (array_key_exists($key, $errors) === false || is_array($errors[$key]) === false) {
+                    throw new InvalidArgumentException(Message::MISMATCHED_ARRAY_STRUCTURE_ERRORS->getMessage($key));
+                }
+
+                /** @phpstan-var TmpName $subTmpNames */
+                $subTmpNames = $tmpName;
+                /** @phpstan-var TmpSize $subSizes */
+                $subSizes = $sizes[$key];
+                /** @phpstan-var TmpError $subErrors */
+                $subErrors = $errors[$key];
+                /** @phpstan-var Name $subNames */
+                $subNames = array_key_exists($key, $names) && is_array($names[$key]) ? $names[$key] : [];
+                /** @phpstan-var Type $subTypes */
+                $subTypes = array_key_exists($key, $types) && is_array($types[$key]) ? $types[$key] : [];
+
+                $tree[$key] = $this->buildFileTree($subTmpNames, $subSizes, $subErrors, $subNames, $subTypes);
+            } else {
+                if (array_key_exists($key, $sizes) === false || is_int($sizes[$key]) === false) {
+                    throw new InvalidArgumentException(
+                        Message::SIZE_MUST_BE_INTEGER->getMessage($key),
+                    );
+                }
+
+                if (array_key_exists($key, $errors) === false || is_int($errors[$key]) === false) {
+                    throw new InvalidArgumentException(
+                        Message::ERROR_MUST_BE_INTEGER->getMessage($key),
+                    );
+                }
+
+                $tree[$key] = $this->createSingleFileFromArrays(
+                    $tmpName,
+                    $sizes[$key],
+                    $errors[$key],
+                    array_key_exists($key, $names) && is_string($names[$key]) ? $names[$key] : null,
+                    array_key_exists($key, $types) && is_string($types[$key]) ? $types[$key] : null,
+                );
+            }
+        }
+
+        return $tree;
+    }
+
+    /**
+     * Builds a nested tree of PSR-7 {@see UploadedFileInterface} instances for multiple file uploads.
+     *
+     * Validates the provided multi-file specification array and delegates the construction of the file tree to
+     * {@see buildFileTree}, ensuring strict type safety and consistency for both single and multiple file uploads.
+     *
+     * This method is used to process PHP file arrays containing nested structures for multiple uploaded files,
+     * returning a tree of PSR-7 {@see UploadedFileInterface} instances or nested arrays as appropriate.
+     *
+     * @param array $files Multi-file specification array containing 'tmp_name', 'size', 'error', and optional 'name',
+     * 'type' keys.
+     *
+     * @return array Nested array of PSR-7 {@see UploadedFileInterface} instances or file trees.
+     *
+     * @phpstan-param MultiFileSpec $files
+     *
+     * @phpstan-return FilesArray
+     *
+     * Usage example:
+     * ```php
+     * $tree = $creator->createMultipleUploadedFiles($files);
+     * ```
+     */
+    private function createMultipleUploadedFiles(array $files): array
+    {
+        $this->validateMultiFileSpec($files);
+
+        return $this->buildFileTree(
+            $files['tmp_name'],
+            $files['size'],
+            $files['error'],
+            $files['name'] ?? [],
+            $files['type'] ?? [],
+        );
+    }
+
+    /**
+     * Creates a PSR-7 {@see UploadedFileInterface} instance from single file specification arrays.
+     *
+     * Validates that the provided temporary file name is a string and delegates the creation of the uploaded file
+     * to the configured PSR-7 factories.
+     *
+     * This method ensures strict type safety and immutability for single file uploads, supporting both SAPI and worker
+     * environments.
+     *
+     * @param string $tmpName Temporary file name for the uploaded file.
+     * @param int $size Size of the uploaded file in bytes.
+     * @param int $error Error code associated with the file upload.
+     * @param string|null $name Optional original file name as provided by the client.
+     * @param string|null $type Optional media type of the uploaded file as provided by the client.
+     *
+     * @return UploadedFileInterface PSR-7 {@see UploadedFileInterface} instance created from the file specification.
+     */
+    private function createSingleFileFromArrays(
+        string $tmpName,
+        int $size,
+        int $error,
+        string|null $name = null,
+        string|null $type = null,
+    ): UploadedFileInterface {
+        return $this->uploadedFileFactory->createUploadedFile(
+            $this->streamFactory->createStreamFromFile($tmpName),
+            $size,
+            $error,
+            $name,
+            $type,
+        );
+    }
+
+    /**
+     * Determines whether the provided file specification array contains all required keys.
+     *
+     * Iterates over the required keys ('tmp_name', 'size', 'error') and checks for their presence in the input array.
+     *
+     * This method is used to validate file specification arrays before processing them as uploaded files, ensuring
+     * strict type safety and consistency in the file creation workflow.
+     *
+     * @param array $file File specification array to validate for required keys.
+     *
+     * @return bool `true` if all required keys are present; `false` otherwise.
+     *
+     * @phpstan-param UnknownFileInput $file
+     */
+    private function hasRequiredKeys(array $file): bool
+    {
+        foreach (self::REQUIRED_KEYS as $key) {
+            if (array_key_exists($key, $file) === false) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Determines whether the provided file specification array represents a multiple file upload.
+     *
+     * Checks if the 'tmp_name' key exists and its value is an array, indicating a multiple file upload structure as
+     * produced by PHP for input fields with the 'multiple' attribute.
+     *
+     * This method is used to distinguish between single and multiple file upload specifications, ensuring correct
+     * processing and conversion to PSR-7 {@see UploadedFileInterface} instances.
+     *
+     * @param array $file File specification array to check for multiple file upload structure.
+     *
+     * @return bool `true` if the file specification represents a multiple file upload; `false` otherwise.
+     *
+     * @phpstan-param UnknownFileInput $file
+     */
+    private function isMultipleFileUpload(array $file): bool
+    {
+        return array_key_exists('tmp_name', $file) && is_array($file['tmp_name']);
+    }
+
+    /**
+     * Processes a file input and returns a PSR-7 {@see UploadedFileInterface} instance or a nested array of uploaded
+     * files.
+     *
+     * Determines the type of file input and delegate processing to the appropriate creation method.
+     *
+     * - If the input is already an {@see UploadedFileInterface} instance, it is returned as-is.
+     * - If required keys are missing, the input is treated as a global files array and processed recursively.
+     * - For multiple file uploads, the input is converted to a nested array of uploaded files. For single file
+     *   specifications, a PSR-7 {@see UploadedFileInterface} instance is created.
+     *
+     * This method ensures strict type safety and immutability when converting PHP file arrays to PSR-7 uploaded file
+     * objects, supporting both single and multiple file uploads in SAPI and worker environments.
+     *
+     * @param array|UploadedFileInterface $file File input to process, which may be a file specification array or an
+     * uploaded file instance.
+     *
+     * @return array|UploadedFileInterface PSR-7 {@see UploadedFileInterface} instance or nested array of uploaded
+     * files.
+     *
+     * @phpstan-param UnknownFileInput|UploadedFileInterface $file
+     *
+     * @phpstan-return array<mixed>|UploadedFileInterface
+     */
+    private function processFileInput(array|UploadedFileInterface $file): array|UploadedFileInterface
+    {
+        if ($file instanceof UploadedFileInterface) {
+            return $file;
+        }
+
+        if ($this->hasRequiredKeys($file) === false) {
+            /** @var FilesArray $file */
+            return $this->createFromGlobals($file);
+        }
+
+        if ($this->isMultipleFileUpload($file)) {
+            /** @var MultiFileSpec $file */
+            return $this->createMultipleUploadedFiles($file);
+        }
+
+        /** @var FileSpec $file */
+        return $this->createFromArray($file);
+    }
+
+    /**
+     * Validates a file specification array for required and optional keys.
+     *
+     * Ensures strict type safety and consistency by verifying the presence and types of required keys ('tmp_name',
+     * 'size', 'error') and optional keys ('name', 'type') in the file specification array before processing it as an
+     * uploaded file.
+     *
+     * @param array $file File specification array to validate for required and optional keys.
+     *
+     * @throws InvalidArgumentException if one or more arguments are invalid, of incorrect type or format.
+     *
+     * @phpstan-param UnknownFileInput $file
+     */
+    private function validateFileSpec(array $file): void
+    {
+        foreach (self::REQUIRED_KEYS as $requiredKey) {
+            if (array_key_exists($requiredKey, $file) === false) {
+                throw new InvalidArgumentException(
+                    Message::MISSING_REQUIRED_KEY_IN_FILE_SPEC->getMessage($requiredKey, 'validateFileSpec()'),
+                );
+            }
+        }
+
+        if (isset($file['tmp_name']) === false || is_string($file['tmp_name']) === false) {
+            throw new InvalidArgumentException(
+                Message::TMP_NAME_MUST_BE_STRING->getMessage(),
+            );
+        }
+
+        if (isset($file['size']) === false || is_int($file['size']) === false) {
+            throw new InvalidArgumentException(
+                Message::SIZE_MUST_BE_INTEGER->getMessage(),
+            );
+        }
+
+        if (isset($file['error']) === false || is_int($file['error']) === false) {
+            throw new InvalidArgumentException(
+                Message::ERROR_MUST_BE_INTEGER->getMessage(),
+            );
+        }
+
+        if (array_key_exists('name', $file) && $file['name'] !== null && is_string($file['name']) === false) {
+            throw new InvalidArgumentException(
+                Message::NAME_MUST_BE_STRING_OR_NULL->getMessage(),
+            );
+        }
+
+        if (array_key_exists('type', $file) && $file['type'] !== null && is_string($file['type']) === false) {
+            throw new InvalidArgumentException(
+                Message::TYPE_MUST_BE_STRING_OR_NULL->getMessage(),
+            );
+        }
+    }
+
+    /**
+     * Validates a multiple file specification array for required and optional keys.
+     *
+     * Ensures strict type safety and consistency by verifying that all required keys ('tmp_name', 'size', 'error')
+     * are present and their values are arrays, as expected for multiple file uploads. Also checks that optional keys
+     * ('name', 'type') are either arrays or null when present.
+     *
+     * @param array $files Multiple file specification array to validate for required and optional keys.
+     *
+     * @throws InvalidArgumentException if one or more arguments are invalid, missing, or of incorrect type or format.
+     *
+     * @phpstan-param UnknownFileInput $files
+     */
+    private function validateMultiFileSpec(array $files): void
+    {
+        foreach (self::REQUIRED_KEYS as $key) {
+            if (array_key_exists($key, $files) === false || is_array($files[$key]) === false) {
+                throw new InvalidArgumentException(
+                    Message::MISSING_OR_INVALID_ARRAY_IN_MULTI_SPEC->getMessage($key, 'validateMultiFileSpec()'),
+                );
+            }
+        }
+
+        foreach (self::OPTIONAL_KEYS as $key) {
+            if (array_key_exists($key, $files) && $files[$key] !== null && is_array($files[$key]) === false) {
+                throw new InvalidArgumentException(
+                    Message::INVALID_OPTIONAL_ARRAY_IN_MULTI_SPEC->getMessage($key, 'validateMultiFileSpec()'),
+                );
+            }
+        }
+    }
+}

--- a/src/creator/UploadedFileCreator.php
+++ b/src/creator/UploadedFileCreator.php
@@ -198,17 +198,28 @@ final class UploadedFileCreator
         array $errors,
         array $names = [],
         array $types = [],
+        int $depth = 0,
     ): array {
+        if ($depth > 10) {
+            throw new InvalidArgumentException(
+                Message::MAXIMUM_NESTING_DEPTH_EXCEEDED->getMessage($depth),
+            );
+        }
+
         $tree = [];
 
         foreach ($tmpNames as $key => $tmpName) {
             if (is_array($tmpName)) {
                 if (array_key_exists($key, $sizes) === false || is_array($sizes[$key]) === false) {
-                    throw new InvalidArgumentException(Message::MISMATCHED_ARRAY_STRUCTURE_SIZES->getMessage($key));
+                    throw new InvalidArgumentException(
+                        Message::MISMATCHED_ARRAY_STRUCTURE_SIZES->getMessage($key),
+                    );
                 }
 
                 if (array_key_exists($key, $errors) === false || is_array($errors[$key]) === false) {
-                    throw new InvalidArgumentException(Message::MISMATCHED_ARRAY_STRUCTURE_ERRORS->getMessage($key));
+                    throw new InvalidArgumentException(
+                        Message::MISMATCHED_ARRAY_STRUCTURE_ERRORS->getMessage($key),
+                    );
                 }
 
                 /** @phpstan-var TmpName $subTmpNames */
@@ -222,7 +233,14 @@ final class UploadedFileCreator
                 /** @phpstan-var Type $subTypes */
                 $subTypes = array_key_exists($key, $types) && is_array($types[$key]) ? $types[$key] : [];
 
-                $tree[$key] = $this->buildFileTree($subTmpNames, $subSizes, $subErrors, $subNames, $subTypes);
+                $tree[$key] = $this->buildFileTree(
+                    $subTmpNames,
+                    $subSizes,
+                    $subErrors,
+                    $subNames,
+                    $subTypes,
+                    $depth + 1,
+                );
             } else {
                 if (array_key_exists($key, $sizes) === false || is_int($sizes[$key]) === false) {
                     throw new InvalidArgumentException(

--- a/src/creator/UploadedFileCreator.php
+++ b/src/creator/UploadedFileCreator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace yii2\extensions\psrbridge\creator;
 
 use Psr\Http\Message\{StreamFactoryInterface, UploadedFileFactoryInterface, UploadedFileInterface};
+use Throwable;
 use yii\base\InvalidArgumentException;
 use yii2\extensions\psrbridge\exception\Message;
 
@@ -114,7 +115,13 @@ final class UploadedFileCreator
     {
         $this->validateFileSpec($file);
 
-        $stream = $this->streamFactory->createStreamFromFile($file['tmp_name']);
+        try {
+            $stream = $this->streamFactory->createStreamFromFile($file['tmp_name']);
+        } catch (Throwable $e) {
+            throw new InvalidArgumentException(
+                Message::FAILED_CREATE_STREAM_FROM_TMP_FILE->getMessage($file['tmp_name']),
+            );
+        }
 
         return $this->uploadedFileFactory->createUploadedFile(
             $stream,

--- a/src/exception/Message.php
+++ b/src/exception/Message.php
@@ -82,6 +82,13 @@ enum Message: string
     "Expected 'array' or 'null'.";
 
     /**
+     * Error when the maximum nesting depth for file uploads is exceeded.
+     *
+     * Format: "Maximum nesting depth exceeded for file uploads (limit: '%d')."
+     */
+    case MAXIMUM_NESTING_DEPTH_EXCEEDED = "Maximum nesting depth exceeded for file uploads (limit: '%d').";
+
+    /**
      * Error when the array structure for errors does not match the expected format.
      *
      * Format: "Mismatched array structure for 'errors' at key '%s'."

--- a/src/exception/Message.php
+++ b/src/exception/Message.php
@@ -67,6 +67,13 @@ enum Message: string
     case FAIL_PARSING_REQUEST_BODY = "Unable to parse request body; '%s'.";
 
     /**
+     * Error when a stream cannot be created from a temporary file.
+     *
+     * Format: "Failed to create stream from temporary file '%s'."
+     */
+    case FAILED_CREATE_STREAM_FROM_TMP_FILE = "Failed to create stream from temporary file '%s'.";
+
+    /**
      * Error when an optional array is invalid in multiple file specification.
      *
      * Format: "Invalid optional '%s' array in multiple file specification for '%s'. Expected 'array' or 'null'."

--- a/src/exception/Message.php
+++ b/src/exception/Message.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace yii2\extensions\psrbridge\exception;
 
+use function sprintf;
+
 /**
  * Represents standardized error messages for HTTP exceptions.
  *
@@ -51,11 +53,62 @@ enum Message: string
     case COOKIE_VALIDATION_KEY_REQUIRED = 'Cookie validation key must be provided.';
 
     /**
+     * Error when 'error' is not an integer in file specification.
+     *
+     * Format: "'error' must be an integer in file specification."
+     */
+    case ERROR_MUST_BE_INTEGER = "'error' must be an 'integer' in file specification.";
+
+    /**
      * Error when the request body can’t be parsed.
      *
      * Format: "Unable to parse request body; '%s'"
      */
     case FAIL_PARSING_REQUEST_BODY = "Unable to parse request body; '%s'.";
+
+    /**
+     * Error when an optional array is invalid in multiple file specification.
+     *
+     * Format: "Invalid optional '%s' array in multiple file specification for '%s'. Expected 'array' or 'null'."
+     */
+    case INVALID_OPTIONAL_ARRAY_IN_MULTI_SPEC = "Invalid optional '%s' array in multiple file specification for '%s'. " .
+    "Expected 'array' or 'null'.";
+
+    /**
+     * Error when the array structure for errors does not match the expected format.
+     *
+     * Format: "Mismatched array structure for 'errors' at key '%s'."
+     */
+    case MISMATCHED_ARRAY_STRUCTURE_ERRORS = "Mismatched array structure for 'errors' at key '%s'.";
+
+    /**
+     * Error when the array structure for sizes does not match the expected format.
+     *
+     * Format: "Mismatched array structure for 'sizes' at key '%s'."
+     */
+    case MISMATCHED_ARRAY_STRUCTURE_SIZES = "Mismatched array structure for 'sizes' at key '%s'.";
+
+    /**
+     * Error when a required array is missing or invalid in multiple file specification.
+     *
+     * Format: "Missing or invalid '%s' array in multiple file specification for '%s'."
+     */
+    case MISSING_OR_INVALID_ARRAY_IN_MULTI_SPEC = "Missing or invalid '%s' array in multiple file specification for " .
+    "'%s'.";
+
+    /**
+     * Error when a required key is missing in file specification.
+     *
+     * Format: "Missing required key '%s' in file specification for '%s'."
+     */
+    case MISSING_REQUIRED_KEY_IN_FILE_SPEC = "Missing required key '%s' in file specification for '%s'.";
+
+    /**
+     * Error when 'name' is not a string or null in file specification.
+     *
+     * Format: "'name' must be a string or null in file specification."
+     */
+    case NAME_MUST_BE_STRING_OR_NULL = "'name' must be a 'string' or 'null' in file specification.";
 
     /**
      * Error when the PSR-7 request adapter is not set.
@@ -67,9 +120,9 @@ enum Message: string
     /**
      * Error when the response stream is not in the expected format.
      *
-     * Format: "Response stream must be an array with exactly 3 elements: [handle, begin, end]."
+     * Format: "Response stream must be an 'array' with exactly '3' elements: ['handle', 'begin', 'end']."
      */
-    case RESPONSE_STREAM_FORMAT_INVALID = "Response stream must be an array with exactly '3' elements: " .
+    case RESPONSE_STREAM_FORMAT_INVALID = "Response stream must be an 'array' with exactly '3' elements: " .
     "['handle', 'begin', 'end'].";
 
     /**
@@ -77,15 +130,37 @@ enum Message: string
      *
      * Format: "Stream handle must be a valid resource."
      */
-    case RESPONSE_STREAM_HANDLE_INVALID = 'Stream handle must be a valid resource.';
+    case RESPONSE_STREAM_HANDLE_INVALID = "Stream handle must be a valid 'resource'.";
 
     /**
      * Error when the response stream range values are invalid.
      *
-     * Format: "Response stream range values must be valid: 'begin' >= '0' and 'end' >= 'begin'."
+     * Format: "Response stream range values must be valid: ('begin' >= '0' and 'end' >= 'begin').
+     * Received: (begin='%d', end='%d')."
      */
     case RESPONSE_STREAM_RANGE_INVALID = 'Response stream range values must be valid: ' .
     "('begin' >= '0' and 'end' >= 'begin'). Received: (begin='%d', end='%d'.)";
+
+    /**
+     * Error when 'size' is not an integer in file specification.
+     *
+     * Format: "'size' must be an 'integer' in file specification."
+     */
+    case SIZE_MUST_BE_INTEGER = "'size' must be an 'integer' in file specification.";
+
+    /**
+     * Error when 'tmp_name' is not a string in file specification.
+     *
+     * Format: "'tmp_name' must be a 'string' in file specification."
+     */
+    case TMP_NAME_MUST_BE_STRING = "'tmp_name' must be a 'string' in file specification.";
+
+    /**
+     * Error when 'type' is not a string or null in file specification.
+     *
+     * Format: "'type' must be a 'string' or 'null' in file specification."
+     */
+    case TYPE_MUST_BE_STRING_OR_NULL = "'type' must be a 'string' or 'null' in file specification.";
 
     /**
      * Error when output has already been emitted.

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,14 +4,37 @@ declare(strict_types=1);
 
 namespace yii2\extensions\psrbridge\tests;
 
+use RuntimeException;
 use Yii;
-use yii\console\Application as ConsoleApplication;
 use yii\helpers\ArrayHelper;
-use yii\web\Application as WebApplication;
 use yii2\extensions\psrbridge\http\Request;
+
+use function fclose;
+use function tmpfile;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * Temporary file one used in tests.
+     *
+     * @phpstan-var resource|false|null
+     */
+    protected $tmpFile1 = null;
+
+    /**
+     * Temporary file two in tests.
+     *
+     * @phpstan-var resource|false|null
+     */
+    protected $tmpFile2 = null;
+
+    /**
+     * Temporary file two in tests.
+     *
+     * @phpstan-var resource|false|null
+     */
+    protected $tmpFile3 = null;
+
     /**
      * @phpstan-var array<mixed, mixed>
      */
@@ -36,6 +59,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         parent::setUp();
 
         $this->originalServer = $_SERVER;
+
         $_SERVER = [];
     }
 
@@ -47,7 +71,61 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $_POST = [];
         $_SERVER = $this->originalServer;
 
+        if ($this->tmpFile1 !== null && $this->tmpFile1 !== false) {
+            fclose($this->tmpFile1);
+        }
+
+        if ($this->tmpFile2 !== null && $this->tmpFile2 !== false) {
+            fclose($this->tmpFile2);
+        }
+
+        if ($this->tmpFile3 !== null && $this->tmpFile3 !== false) {
+            fclose($this->tmpFile3);
+        }
+
         parent::tearDown();
+    }
+
+    /**
+     * @phpstan-return resource
+     */
+    protected function getTmpFile1()
+    {
+        $this->tmpFile1 = tmpfile();
+
+        if ($this->tmpFile1 === false || $this->tmpFile1 === null) {
+            throw new RuntimeException('Failed to create temporary file one.');
+        }
+
+        return $this->tmpFile1;
+    }
+
+    /**
+     * @phpstan-return resource
+     */
+    protected function getTmpFile2()
+    {
+        $this->tmpFile2 = tmpfile();
+
+        if ($this->tmpFile2 === false || $this->tmpFile2 === null) {
+            throw new RuntimeException('Failed to create temporary file two.');
+        }
+
+        return $this->tmpFile2;
+    }
+
+    /**
+     * @phpstan-return resource
+     */
+    protected function getTmpFile3()
+    {
+        $this->tmpFile3 = tmpfile();
+
+        if ($this->tmpFile3 === false || $this->tmpFile3 === null) {
+            throw new RuntimeException('Failed to create temporary file two.');
+        }
+
+        return $this->tmpFile3;
     }
 
     /**
@@ -55,7 +133,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      */
     protected function mockApplication($config = []): void
     {
-        new ConsoleApplication(
+        new \yii\console\Application(
             ArrayHelper::merge(
                 [
                     'id' => 'testapp',
@@ -77,7 +155,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      */
     protected function mockWebApplication($config = []): void
     {
-        new WebApplication(
+        new \yii\web\Application(
             ArrayHelper::merge(
                 [
                     'id' => 'testapp',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,30 +15,16 @@ use function tmpfile;
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
     /**
-     * Temporary file one used in tests.
-     *
-     * @phpstan-var resource|false|null
-     */
-    protected $tmpFile1 = null;
-
-    /**
-     * Temporary file two in tests.
-     *
-     * @phpstan-var resource|false|null
-     */
-    protected $tmpFile2 = null;
-
-    /**
-     * Temporary file two in tests.
-     *
-     * @phpstan-var resource|false|null
-     */
-    protected $tmpFile3 = null;
-
-    /**
      * @phpstan-var array<mixed, mixed>
      */
     private array $originalServer = [];
+
+    /**
+     * Temporary file resources used during tests.
+     *
+     * @phpstan-var array<resource>
+     */
+    private array $tmpFiles = [];
 
     public static function tearDownAfterClass(): void
     {
@@ -71,61 +57,39 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $_POST = [];
         $_SERVER = $this->originalServer;
 
-        if ($this->tmpFile1 !== null && $this->tmpFile1 !== false) {
-            fclose($this->tmpFile1);
-        }
-
-        if ($this->tmpFile2 !== null && $this->tmpFile2 !== false) {
-            fclose($this->tmpFile2);
-        }
-
-        if ($this->tmpFile3 !== null && $this->tmpFile3 !== false) {
-            fclose($this->tmpFile3);
-        }
+        $this->closeTmpFile(...$this->tmpFiles);
 
         parent::tearDown();
     }
 
     /**
-     * @phpstan-return resource
+     * Closes the temporary file resource if it is a valid resource.
+     *
+     * @param resource ...$tmpFile The temporary file resources to close.
      */
-    protected function getTmpFile1()
+    protected function closeTmpFile(...$tmpFile): void
     {
-        $this->tmpFile1 = tmpfile();
-
-        if ($this->tmpFile1 === false || $this->tmpFile1 === null) {
-            throw new RuntimeException('Failed to create temporary file one.');
+        foreach ($tmpFile as $file) {
+            if (is_resource($file)) {
+                fclose($file);
+            }
         }
-
-        return $this->tmpFile1;
     }
 
     /**
      * @phpstan-return resource
      */
-    protected function getTmpFile2()
+    protected function createTmpFile()
     {
-        $this->tmpFile2 = tmpfile();
+        $tmpFile = tmpfile();
 
-        if ($this->tmpFile2 === false || $this->tmpFile2 === null) {
-            throw new RuntimeException('Failed to create temporary file two.');
+        if ($tmpFile === false) {
+            throw new RuntimeException('Failed to create temporary file.');
         }
 
-        return $this->tmpFile2;
-    }
+        $this->tmpFiles[] = $tmpFile;
 
-    /**
-     * @phpstan-return resource
-     */
-    protected function getTmpFile3()
-    {
-        $this->tmpFile3 = tmpfile();
-
-        if ($this->tmpFile3 === false || $this->tmpFile3 === null) {
-            throw new RuntimeException('Failed to create temporary file three.');
-        }
-
-        return $this->tmpFile3;
+        return $tmpFile;
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -122,7 +122,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $this->tmpFile3 = tmpfile();
 
         if ($this->tmpFile3 === false || $this->tmpFile3 === null) {
-            throw new RuntimeException('Failed to create temporary file two.');
+            throw new RuntimeException('Failed to create temporary file three.');
         }
 
         return $this->tmpFile3;

--- a/tests/creator/ServerRequestCreatorTest.php
+++ b/tests/creator/ServerRequestCreatorTest.php
@@ -1,0 +1,603 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\psrbridge\tests\creator;
+
+use PHPUnit\Framework\Attributes\Group;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UploadedFileInterface;
+use RuntimeException;
+use yii2\extensions\psrbridge\creator\ServerRequestCreator;
+use yii2\extensions\psrbridge\tests\support\FactoryHelper;
+use yii2\extensions\psrbridge\tests\TestCase;
+
+use function stream_get_meta_data;
+
+#[Group('http')]
+#[Group('creator')]
+final class ServerRequestCreatorTest extends TestCase
+{
+    public function testCreateFromGlobalsWithBodyStream(): void
+    {
+        $creator = new ServerRequestCreator(
+            FactoryHelper::createServerRequestFactory(),
+            FactoryHelper::createStreamFactory(),
+            FactoryHelper::createUploadedFileFactory(),
+        );
+
+        $request = $creator->createFromGlobals();
+        $body = $request->getBody();
+
+        self::assertTrue($body->isReadable(), "'Body' stream should be readable.");
+    }
+
+    public function testCreateFromGlobalsWithBodyStreamException(): void
+    {
+        $failingStreamFactory = new class implements StreamFactoryInterface {
+            public function createStream(string $content = ''): StreamInterface
+            {
+                throw new RuntimeException('Stream creation failed.');
+            }
+
+            public function createStreamFromFile(string $filename, string $mode = 'r'): StreamInterface
+            {
+                throw new RuntimeException('Stream creation failed.');
+            }
+
+            public function createStreamFromResource($resource): StreamInterface
+            {
+                throw new RuntimeException('Stream creation failed.');
+            }
+        };
+
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_SERVER['REQUEST_URI'] = '/test';
+
+        $creator = new ServerRequestCreator(
+            FactoryHelper::createServerRequestFactory(),
+            $failingStreamFactory,
+            FactoryHelper::createUploadedFileFactory(),
+        );
+
+        $request = $creator->createFromGlobals();
+
+        self::assertSame(
+            'POST',
+            $request->getMethod(),
+            "Should preserve request 'method' when body stream creation fails.",
+        );
+        self::assertSame(
+            '/test',
+            (string) $request->getUri(),
+            "Should preserve request 'URI' when body stream creation fails.",
+        );
+        self::assertInstanceOf(
+            StreamInterface::class,
+            $request->getBody(),
+            "Should return a valid 'body' stream even if creation fails.",
+        );
+    }
+
+    public function testCreateFromGlobalsWithComplexScenario(): void
+    {
+        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+
+        $_SERVER = [
+            'REQUEST_METHOD' => 'PUT',
+            'REQUEST_URI' => '/api/profile/update?force=true',
+            'HTTP_AUTHORIZATION' => 'Bearer token123',
+        ];
+        $_COOKIE['session'] = 'sess_abc123';
+        $_POST = [
+            'name' => 'John Doe',
+            'bio' => 'Software developer',
+        ];
+        $_GET['force'] = 'true';
+        $_FILES = [
+            'photo' => [
+                'error' => UPLOAD_ERR_OK,
+                'name' => 'avatar.png',
+                'size' => 1500,
+                'tmp_name' => $tempPath,
+                'type' => 'image/png',
+            ],
+        ];
+
+        $creator = new ServerRequestCreator(
+            FactoryHelper::createServerRequestFactory(),
+            FactoryHelper::createStreamFactory(),
+            FactoryHelper::createUploadedFileFactory(),
+        );
+
+        $request = $creator->createFromGlobals();
+
+        self::assertSame(
+            'PUT',
+            $request->getMethod(),
+            "Should preserve 'PUT' method from complex scenario.",
+        );
+        self::assertSame(
+            '/api/profile/update?force=true',
+            (string) $request->getUri(),
+            "Should preserve complex 'URI' from scenario.",
+        );
+        self::assertSame(
+            'Bearer token123',
+            $request->getServerParams()['HTTP_AUTHORIZATION'] ?? '',
+            "Should preserve 'HTTP_AUTHORIZATION' header in 'server params'.",
+        );
+        self::assertSame(
+            'sess_abc123',
+            $request->getCookieParams()['session'] ?? '',
+            "Should preserve 'session' cookie.",
+        );
+
+        $parsedBody = $request->getParsedBody();
+
+        self::assertIsArray(
+            $parsedBody,
+            "'Parsed body' should be an array in complex scenario.",
+        );
+        self::assertSame(
+            'John Doe',
+            $parsedBody['name'] ?? '',
+            "Should preserve 'name' from 'POST' data.",
+        );
+        self::assertSame(
+            'Software developer',
+            $parsedBody['bio'] ?? '',
+            "Should preserve 'bio' from 'POST' data.",
+        );
+        self::assertSame(
+            'true',
+            $request->getQueryParams()['force'] ?? '',
+            "Should preserve 'force' query parameter.",
+        );
+
+        $uploadedFiles = $request->getUploadedFiles();
+
+        $photoFile = $uploadedFiles['photo'] ?? null;
+
+        self::assertInstanceOf(
+            UploadedFileInterface::class,
+            $photoFile,
+            "Should have 'photo' file as instance of 'UploadedFileInterface'.",
+        );
+        self::assertSame(
+            'avatar.png',
+            $photoFile->getClientFilename(),
+            "Should preserve 'photo' filename in complex scenario.",
+        );
+        self::assertSame(
+            'image/png',
+            $photoFile->getClientMediaType(),
+            "Should preserve 'photo' media type in complex scenario.",
+        );
+        self::assertSame(
+            1500,
+            $photoFile->getSize(),
+            "Should preserve 'photo' size in complex scenario.",
+        );
+    }
+
+    public function testCreateFromGlobalsWithCookieParams(): void
+    {
+        $_COOKIE = [
+            'language' => 'en',
+            'session_id' => 'abc123',
+            'theme' => 'dark',
+        ];
+
+        $creator = new ServerRequestCreator(
+            FactoryHelper::createServerRequestFactory(),
+            FactoryHelper::createStreamFactory(),
+            FactoryHelper::createUploadedFileFactory(),
+        );
+
+        $request = $creator->createFromGlobals();
+        $cookieParams = $request->getCookieParams();
+
+        self::assertCount(
+            3,
+            $cookieParams,
+            "Should have all cookies from '\$_COOKIE'.",
+        );
+        self::assertSame(
+            'en',
+            $cookieParams['language'] ?? '',
+            "Should preserve 'language' cookie value.",
+        );
+        self::assertSame(
+            'abc123',
+            $cookieParams['session_id'] ?? '',
+            "Should preserve 'session_id' cookie value.",
+        );
+        self::assertSame(
+            'dark',
+            $cookieParams['theme'] ?? '',
+            "Should preserve 'theme' cookie value.",
+        );
+    }
+
+    public function testCreateFromGlobalsWithDefaultValues(): void
+    {
+        $creator = new ServerRequestCreator(
+            FactoryHelper::createServerRequestFactory(),
+            FactoryHelper::createStreamFactory(),
+            FactoryHelper::createUploadedFileFactory(),
+        );
+
+        $request = $creator->createFromGlobals();
+
+        self::assertSame(
+            'GET',
+            $request->getMethod(),
+            "Should use default 'GET' method when 'REQUEST_METHOD' is not set.",
+        );
+        self::assertSame(
+            '/',
+            (string) $request->getUri(),
+            "Should use default root 'URI' when 'REQUEST_URI' is not set.",
+        );
+        self::assertEmpty(
+            $request->getCookieParams(),
+            "Should have empty 'cookie params' when '\$_COOKIE' is empty.",
+        );
+        self::assertEmpty(
+            $request->getParsedBody(),
+            "Should have empty 'parsed body' when '\$_POST' is empty.",
+        );
+        self::assertEmpty(
+            $request->getQueryParams(),
+            "Should have empty 'query params' when '\$_GET' is empty.",
+        );
+        self::assertEmpty(
+            $request->getUploadedFiles(),
+            "Should have empty 'uploaded files' when '\$_FILES' is empty.",
+        );
+    }
+
+    public function testCreateFromGlobalsWithInvalidRequestMethod(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = null;
+
+        $creator = new ServerRequestCreator(
+            FactoryHelper::createServerRequestFactory(),
+            FactoryHelper::createStreamFactory(),
+            FactoryHelper::createUploadedFileFactory(),
+        );
+
+        $request = $creator->createFromGlobals();
+
+        self::assertSame(
+            'GET',
+            $request->getMethod(),
+            "Should default to 'GET' when 'REQUEST_METHOD' is not a string.",
+        );
+    }
+
+    public function testCreateFromGlobalsWithInvalidRequestUri(): void
+    {
+        $_SERVER['REQUEST_URI'] = null;
+
+        $creator = new ServerRequestCreator(
+            FactoryHelper::createServerRequestFactory(),
+            FactoryHelper::createStreamFactory(),
+            FactoryHelper::createUploadedFileFactory(),
+        );
+
+        $request = $creator->createFromGlobals();
+
+        self::assertSame(
+            '/',
+            (string) $request->getUri(),
+            "Should default to root 'URI' when 'REQUEST_URI' is not a string.",
+        );
+    }
+
+    public function testCreateFromGlobalsWithMultipleUploadedFiles(): void
+    {
+        $tempPath1 = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tempPath2 = stream_get_meta_data($this->getTmpFile2())['uri'];
+
+        $_FILES = [
+            'documents' => [
+                'name' => [
+                    'doc1.pdf',
+                    'doc2.txt',
+                ],
+                'type' => [
+                    'application/pdf',
+                    'text/plain',
+                ],
+                'tmp_name' => [
+                    $tempPath1,
+                    $tempPath2,
+                ],
+                'error' => [
+                    \UPLOAD_ERR_OK,
+                    \UPLOAD_ERR_OK,
+                ],
+                'size' => [
+                    2048,
+                    512,
+                ],
+            ],
+        ];
+
+        $creator = new ServerRequestCreator(
+            FactoryHelper::createServerRequestFactory(),
+            FactoryHelper::createStreamFactory(),
+            FactoryHelper::createUploadedFileFactory(),
+        );
+
+        $request = $creator->createFromGlobals();
+        $uploadedFiles = $request->getUploadedFiles();
+
+        self::assertCount(
+            1,
+            $uploadedFiles,
+            "Should have 'documents' array in 'uploaded files'.",
+        );
+        self::assertArrayHasKey(
+            'documents',
+            $uploadedFiles,
+            "Should have 'documents' key in 'uploaded files'.",
+        );
+
+        $documentsArray = $uploadedFiles['documents'] ?? null;
+
+        self::assertIsArray(
+            $documentsArray,
+            "Should have array of 'uploaded files' for multiple files.",
+        );
+        self::assertCount(
+            2,
+            $documentsArray,
+            "Should have two 'uploaded files' in 'documents' array.",
+        );
+
+        $firstFile = $documentsArray[0] ?? null;
+
+        self::assertInstanceOf(
+            UploadedFileInterface::class,
+            $firstFile,
+            "First file should be an instance of 'UploadedFileInterface'.",
+        );
+        self::assertSame(
+            'doc1.pdf',
+            $firstFile->getClientFilename(),
+            "Should preserve first file 'name'.",
+        );
+        self::assertSame(
+            'application/pdf',
+            $firstFile->getClientMediaType(),
+            "Should preserve first file 'media type'.",
+        );
+        self::assertSame(
+            2048,
+            $firstFile->getSize(),
+            "Should preserve first file 'size'.",
+        );
+
+        $secondFile = $documentsArray[1] ?? null;
+
+        self::assertInstanceOf(
+            UploadedFileInterface::class,
+            $secondFile,
+            "Second file should be an instance of 'UploadedFileInterface'.",
+        );
+        self::assertSame(
+            'doc2.txt',
+            $secondFile->getClientFilename(),
+            "Should preserve second file 'name'.",
+        );
+        self::assertSame(
+            'text/plain',
+            $secondFile->getClientMediaType(),
+            "Should preserve second file 'media type'.",
+        );
+        self::assertSame(
+            512,
+            $secondFile->getSize(),
+            "Should preserve second file 'size'.",
+        );
+    }
+
+    public function testCreateFromGlobalsWithNonStringServerValues(): void
+    {
+        $_SERVER = [
+            'REQUEST_METHOD' => 123,
+            'REQUEST_URI' => [],
+        ];
+
+        $creator = new ServerRequestCreator(
+            FactoryHelper::createServerRequestFactory(),
+            FactoryHelper::createStreamFactory(),
+            FactoryHelper::createUploadedFileFactory(),
+        );
+
+        $request = $creator->createFromGlobals();
+
+        self::assertSame(
+            'GET',
+            $request->getMethod(),
+            "Should use default 'GET' method when 'REQUEST_METHOD' is not string.",
+        );
+        self::assertSame(
+            '/',
+            (string) $request->getUri(),
+            "Should use default root 'URI' when 'REQUEST_URI' is not string.",
+        );
+    }
+
+    public function testCreateFromGlobalsWithNoUploadedFiles(): void
+    {
+        $creator = new ServerRequestCreator(
+            FactoryHelper::createServerRequestFactory(),
+            FactoryHelper::createStreamFactory(),
+            FactoryHelper::createUploadedFileFactory(),
+        );
+
+        $request = $creator->createFromGlobals();
+
+        self::assertEmpty($request->getUploadedFiles(), "Should have empty 'uploaded files' when '\$_FILES' is empty.");
+    }
+
+    public function testCreateFromGlobalsWithParsedBody(): void
+    {
+        $_POST = [
+            'age' => '30',
+            'email' => 'john@example.com',
+            'username' => 'john_doe',
+        ];
+
+        $creator = new ServerRequestCreator(
+            FactoryHelper::createServerRequestFactory(),
+            FactoryHelper::createStreamFactory(),
+            FactoryHelper::createUploadedFileFactory(),
+        );
+
+        $request = $creator->createFromGlobals();
+        $parsedBody = $request->getParsedBody();
+
+        self::assertIsArray($parsedBody, "Should return 'parsed body' as array when '\$_POST' contains data.");
+        self::assertCount(3, $parsedBody, "Should have all fields from '\$_POST'.");
+        self::assertSame('30', $parsedBody['age'] ?? '', "Should preserve 'age' from '\$_POST'.");
+        self::assertSame('john@example.com', $parsedBody['email'] ?? '', "Should preserve 'email' from '\$_POST'.");
+        self::assertSame('john_doe', $parsedBody['username'] ?? '', "Should preserve 'username' from '\$_POST'.");
+    }
+
+    public function testCreateFromGlobalsWithQueryParams(): void
+    {
+        $_GET = [
+            'category' => 'electronics',
+            'price_max' => '500',
+            'price_min' => '100',
+            'sort' => 'price_asc',
+        ];
+
+        $creator = new ServerRequestCreator(
+            FactoryHelper::createServerRequestFactory(),
+            FactoryHelper::createStreamFactory(),
+            FactoryHelper::createUploadedFileFactory(),
+        );
+
+        $request = $creator->createFromGlobals();
+        $queryParams = $request->getQueryParams();
+
+        self::assertCount(4, $queryParams, "Should have all 'query parameters' from '\$_GET'.");
+        self::assertSame('electronics', $queryParams['category'] ?? '', "Should preserve 'category' query parameter.");
+        self::assertSame('500', $queryParams['price_max'] ?? '', "Should preserve 'price_max' query parameter.");
+        self::assertSame('100', $queryParams['price_min'] ?? '', "Should preserve 'price_min' query parameter.");
+        self::assertSame('price_asc', $queryParams['sort'] ?? '', "Should preserve 'sort' query parameter.");
+    }
+
+    public function testCreateFromGlobalsWithServerValues(): void
+    {
+        $_SERVER = [
+            'HTTP_HOST' => 'example.com',
+            'HTTPS' => 'on',
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_URI' => '/api/users?page=1',
+        ];
+
+        $creator = new ServerRequestCreator(
+            FactoryHelper::createServerRequestFactory(),
+            FactoryHelper::createStreamFactory(),
+            FactoryHelper::createUploadedFileFactory(),
+        );
+
+        $request = $creator->createFromGlobals();
+
+        self::assertArrayHasKey(
+            'HTTP_HOST',
+            $request->getServerParams(),
+            "Should include 'server parameters' from '\$_SERVER'.",
+        );
+        self::assertSame(
+            'example.com',
+            $request->getServerParams()['HTTP_HOST'] ?? '',
+            "Should preserve 'server parameter' values from '\$_SERVER'.",
+        );
+        self::assertSame(
+            'on',
+            $request->getServerParams()['HTTPS'] ?? '',
+            "Should preserve 'HTTPS' server parameter from '\$_SERVER'.",
+        );
+        self::assertSame(
+            'POST',
+            $request->getMethod(),
+            "Should use 'REQUEST_METHOD' from '\$_SERVER' when set.",
+        );
+        self::assertSame(
+            '/api/users?page=1',
+            (string) $request->getUri(),
+            "Should use 'REQUEST_URI' from '\$_SERVER' when set.",
+        );
+    }
+
+    public function testCreateFromGlobalsWithSingleUploadedFile(): void
+    {
+        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+
+        $_FILES['avatar'] = [
+            'name' => 'profile.jpg',
+            'type' => 'image/jpeg',
+            'tmp_name' => $tempPath,
+            'error' => UPLOAD_ERR_OK,
+            'size' => 1024,
+        ];
+
+        $creator = new ServerRequestCreator(
+            FactoryHelper::createServerRequestFactory(),
+            FactoryHelper::createStreamFactory(),
+            FactoryHelper::createUploadedFileFactory(),
+        );
+
+        $request = $creator->createFromGlobals();
+        $uploadedFiles = $request->getUploadedFiles();
+
+        self::assertCount(
+            1,
+            $uploadedFiles,
+            "Should have one 'uploaded file' when '\$_FILES' contains single file.",
+        );
+        self::assertArrayHasKey(
+            'avatar',
+            $uploadedFiles,
+            "Should have 'avatar' key in 'uploaded files'.",
+        );
+
+        $uploadedFile = $uploadedFiles['avatar'] ?? null;
+
+        self::assertInstanceOf(
+            UploadedFileInterface::class,
+            $uploadedFile,
+            "Should have avatar file as \'UploadedFileInterface\' instance.",
+        );
+
+        self::assertSame(
+            'profile.jpg',
+            $uploadedFile->getClientFilename(),
+            'Should preserve client filename from \'$_FILES\'.',
+        );
+        self::assertSame(
+            'image/jpeg',
+            $uploadedFile->getClientMediaType(),
+            'Should preserve client media type from \'$_FILES\'.',
+        );
+        self::assertSame(
+            1024,
+            $uploadedFile->getSize(),
+            'Should preserve file size from \'$_FILES\'.',
+        );
+        self::assertSame(
+            UPLOAD_ERR_OK,
+            $uploadedFile->getError(),
+            'Should preserve error code from \'$_FILES\'.',
+        );
+    }
+}

--- a/tests/creator/ServerRequestCreatorTest.php
+++ b/tests/creator/ServerRequestCreatorTest.php
@@ -82,7 +82,8 @@ final class ServerRequestCreatorTest extends TestCase
 
     public function testCreateFromGlobalsWithComplexScenario(): void
     {
-        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tmpFile = $this->createTmpFile();
+        $tmpPath = stream_get_meta_data($tmpFile)['uri'];
 
         $_SERVER = [
             'REQUEST_METHOD' => 'PUT',
@@ -97,10 +98,10 @@ final class ServerRequestCreatorTest extends TestCase
         $_GET['force'] = 'true';
         $_FILES = [
             'photo' => [
-                'error' => UPLOAD_ERR_OK,
+                'error' => \UPLOAD_ERR_OK,
                 'name' => 'avatar.png',
                 'size' => 1500,
-                'tmp_name' => $tempPath,
+                'tmp_name' => $tmpPath,
                 'type' => 'image/png',
             ],
         ];
@@ -299,8 +300,11 @@ final class ServerRequestCreatorTest extends TestCase
 
     public function testCreateFromGlobalsWithMultipleUploadedFiles(): void
     {
-        $tempPath1 = stream_get_meta_data($this->getTmpFile1())['uri'];
-        $tempPath2 = stream_get_meta_data($this->getTmpFile2())['uri'];
+        $tmpFile1 = $this->createTmpFile();
+        $tmpPath1 = stream_get_meta_data($tmpFile1)['uri'];
+
+        $tmpFile2 = $this->createTmpFile();
+        $tmpPath2 = stream_get_meta_data($tmpFile2)['uri'];
 
         $_FILES = [
             'documents' => [
@@ -313,8 +317,8 @@ final class ServerRequestCreatorTest extends TestCase
                     'text/plain',
                 ],
                 'tmp_name' => [
-                    $tempPath1,
-                    $tempPath2,
+                    $tmpPath1,
+                    $tmpPath2,
                 ],
                 'error' => [
                     \UPLOAD_ERR_OK,
@@ -541,13 +545,14 @@ final class ServerRequestCreatorTest extends TestCase
 
     public function testCreateFromGlobalsWithSingleUploadedFile(): void
     {
-        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tmpFile = $this->createTmpFile();
+        $tmpPath = stream_get_meta_data($tmpFile)['uri'];
 
         $_FILES['avatar'] = [
             'name' => 'profile.jpg',
             'type' => 'image/jpeg',
-            'tmp_name' => $tempPath,
-            'error' => UPLOAD_ERR_OK,
+            'tmp_name' => $tmpPath,
+            'error' => \UPLOAD_ERR_OK,
             'size' => 1024,
         ];
 
@@ -595,7 +600,7 @@ final class ServerRequestCreatorTest extends TestCase
             'Should preserve file size from \'$_FILES\'.',
         );
         self::assertSame(
-            UPLOAD_ERR_OK,
+            \UPLOAD_ERR_OK,
             $uploadedFile->getError(),
             'Should preserve error code from \'$_FILES\'.',
         );

--- a/tests/creator/UploadedFileCreatorTest.php
+++ b/tests/creator/UploadedFileCreatorTest.php
@@ -820,6 +820,29 @@ final class UploadedFileCreatorTest extends TestCase
         $creator->createFromArray($fileSpec);
     }
 
+    public function testThrowExceptionWhenTmpFileDoesNotExist(): void
+    {
+        $nonExistentPath = '/tmp/non_existent_file_' . uniqid();
+
+        $fileSpec = [
+            'tmp_name' => $nonExistentPath,
+            'size' => 1024,
+            'error' => UPLOAD_ERR_OK,
+            'name' => 'test.txt',
+            'type' => 'text/plain',
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(Message::FAILED_CREATE_STREAM_FROM_TMP_FILE->getMessage($nonExistentPath));
+
+        $creator->createFromArray($fileSpec);
+    }
+
     public function testThrowExceptionWhenTmpNameIsNotString(): void
     {
         $fileSpec = [

--- a/tests/creator/UploadedFileCreatorTest.php
+++ b/tests/creator/UploadedFileCreatorTest.php
@@ -1,0 +1,960 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\psrbridge\tests\creator;
+
+use PHPUnit\Framework\Attributes\Group;
+use Psr\Http\Message\UploadedFileInterface;
+use yii\base\InvalidArgumentException;
+use yii2\extensions\psrbridge\creator\UploadedFileCreator;
+use yii2\extensions\psrbridge\exception\Message;
+use yii2\extensions\psrbridge\tests\support\FactoryHelper;
+use yii2\extensions\psrbridge\tests\TestCase;
+
+use function stream_get_meta_data;
+
+#[Group('http')]
+#[Group('creator')]
+
+final class UploadedFileCreatorTest extends TestCase
+{
+    public function testCreateFromArrayWithMinimalFileSpec(): void
+    {
+        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+
+        $fileSpec = [
+            'tmp_name' => $tempPath,
+            'size' => 512,
+            'error' => UPLOAD_ERR_OK,
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $uploadedFile = $creator->createFromArray($fileSpec);
+
+        self::assertNull(
+            $uploadedFile->getClientFilename(),
+            "Should return 'null' for client filename when not specified.",
+        );
+        self::assertNull(
+            $uploadedFile->getClientMediaType(),
+            "Should return 'null' for 'client media type' when not specified.",
+        );
+        self::assertSame(
+            512,
+            $uploadedFile->getSize(),
+            "Should preserve 'file size' from minimal specification.",
+        );
+        self::assertSame(
+            UPLOAD_ERR_OK,
+            $uploadedFile->getError(),
+            "Should preserve 'error code' from minimal specification.",
+        );
+    }
+
+    public function testCreateFromArrayWithNullOptionalFields(): void
+    {
+        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+
+        $fileSpec = [
+            'tmp_name' => $tempPath,
+            'size' => 256,
+            'error' => UPLOAD_ERR_OK,
+            'name' => null,
+            'type' => null,
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $uploadedFile = $creator->createFromArray($fileSpec);
+
+        self::assertNull(
+            $uploadedFile->getClientFilename(),
+            "Should return 'null' for 'client filename' when explicitly set to 'null'.",
+        );
+        self::assertNull(
+            $uploadedFile->getClientMediaType(),
+            "Should return 'null' for 'client media type' when explicitly set to 'null'.",
+        );
+        self::assertSame(
+            256,
+            $uploadedFile->getSize(),
+            "Should preserve 'file size' when optional fields are 'null'.",
+        );
+    }
+
+    public function testCreateFromArrayWithValidFileSpec(): void
+    {
+        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+
+        $fileSpec = [
+            'tmp_name' => $tempPath,
+            'size' => 1024,
+            'error' => UPLOAD_ERR_OK,
+            'name' => 'test.txt',
+            'type' => 'text/plain',
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $uploadedFile = $creator->createFromArray($fileSpec);
+
+        self::assertSame(
+            'test.txt',
+            $uploadedFile->getClientFilename(),
+            "Should preserve 'client filename' from file specification.",
+        );
+        self::assertSame(
+            'text/plain',
+            $uploadedFile->getClientMediaType(),
+            "Should preserve 'client media type' from file specification.",
+        );
+        self::assertSame(
+            1024,
+            $uploadedFile->getSize(),
+            "Should preserve 'file size' from file specification.",
+        );
+        self::assertSame(
+            UPLOAD_ERR_OK,
+            $uploadedFile->getError(),
+            "Should preserve 'error code' from file specification.",
+        );
+    }
+
+    public function testCreateFromGlobalsWithEmptyArray(): void
+    {
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        self::assertEmpty(
+            $creator->createFromGlobals([]),
+            "Should return empty 'array' when no files are provided.",
+        );
+    }
+
+    public function testCreateFromGlobalsWithExistingUploadedFileInterface(): void
+    {
+        $existingUploadedFile = FactoryHelper::createUploadedFile(
+            'existing.txt',
+            'text/plain',
+            '/tmp/existing',
+            UPLOAD_ERR_OK,
+            1024,
+        );
+
+        $files = [
+            'existing' => $existingUploadedFile,
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $result = $creator->createFromGlobals($files);
+
+        self::assertCount(
+            1,
+            $result,
+            "Should return 'array' with existing 'UploadedFileInterface' instance.",
+        );
+        self::assertSame(
+            $existingUploadedFile,
+            $result['existing'] ?? null,
+            "Should preserve existing 'UploadedFileInterface' instance in result 'array'.",
+        );
+    }
+
+    public function testCreateFromGlobalsWithMixedFileStructures(): void
+    {
+        $tempPath1 = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tempPath2 = stream_get_meta_data($this->getTmpFile2())['uri'];
+        $tempPath3 = stream_get_meta_data($this->getTmpFile3())['uri'];
+
+        $files = [
+            'single' => [
+                'tmp_name' => $tempPath1,
+                'size' => 1024,
+                'error' => UPLOAD_ERR_OK,
+                'name' => 'single.txt',
+                'type' => 'text/plain',
+            ],
+            'multiple' => [
+                'tmp_name' => [
+                    $tempPath2,
+                    $tempPath3,
+                ],
+                'size' => [
+                    2048,
+                    1536,
+                ],
+                'error' => [
+                    UPLOAD_ERR_OK,
+                    UPLOAD_ERR_OK,
+                ],
+                'name' => [
+                    'multi1.pdf',
+                    'multi2.doc',
+                ],
+                'type' => [
+                    'application/pdf',
+                    'application/msword',
+                ],
+            ],
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $result = $creator->createFromGlobals($files);
+
+        self::assertCount(
+            2,
+            $result,
+            "Should return 'array' with both 'single' and 'multiple' keys.",
+        );
+
+        $singleFile = $result['single'] ?? null;
+
+        self::assertInstanceOf(
+            UploadedFileInterface::class,
+            $singleFile,
+            "Should return instance of 'UploadedFileInterface' for 'single' file.",
+        );
+        self::assertSame(
+            'single.txt',
+            $singleFile->getClientFilename(),
+            "Should preserve 'client filename' for 'single' file.",
+        );
+        self::assertSame(
+            1024,
+            $singleFile->getSize(),
+            "Should preserve 'file size' for 'single' file.",
+        );
+
+        $multipleFiles = $result['multiple'] ?? null;
+
+        self::assertIsArray(
+            $multipleFiles,
+            "Should return 'array' for 'multiple' files.",
+        );
+        self::assertCount(
+            2,
+            $multipleFiles,
+            "Should have two files in 'multiple' arrays.",
+        );
+
+        $firstMultiple = $multipleFiles[0] ?? null;
+
+        self::assertInstanceOf(
+            UploadedFileInterface::class,
+            $firstMultiple,
+            "Should return instance of 'UploadedFileInterface' for first file in 'multiple'.",
+        );
+        self::assertSame(
+            'multi1.pdf',
+            $firstMultiple->getClientFilename(),
+            "Should preserve 'client filename' for first file in 'multiple'.",
+        );
+        self::assertSame(
+            2048,
+            $firstMultiple->getSize(),
+            "Should preserve 'file size' for first file in 'multiple'.",
+        );
+
+        $secondMultiple = $multipleFiles[1] ?? null;
+
+        self::assertInstanceOf(
+            UploadedFileInterface::class,
+            $secondMultiple,
+            "Should return instance of 'UploadedFileInterface' for second file in 'multiple'.",
+        );
+        self::assertSame(
+            'multi2.doc',
+            $secondMultiple->getClientFilename(),
+            "Should preserve 'client filename' for second file in 'multiple'.",
+        );
+        self::assertSame(
+            1536,
+            $secondMultiple->getSize(),
+            "Should preserve 'file size' for second file in 'multiple'.",
+        );
+    }
+
+    public function testCreateFromGlobalsWithMultipleFiles(): void
+    {
+        $tempPath1 = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tempPath2 = stream_get_meta_data($this->getTmpFile2())['uri'];
+
+        $files = [
+            'documents' => [
+                'tmp_name' => [
+                    $tempPath1,
+                    $tempPath2,
+                ],
+                'size' => [
+                    2048,
+                    1536,
+                ],
+                'error' => [
+                    UPLOAD_ERR_OK,
+                    UPLOAD_ERR_OK,
+                ],
+                'name' => [
+                    'doc1.txt',
+                    'doc2.pdf',
+                ],
+                'type' => [
+                    'text/plain',
+                    'application/pdf',
+                ],
+            ],
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $result = $creator->createFromGlobals($files);
+
+        self::assertCount(
+            1,
+            $result,
+            "Should return 'array' with 'documents' key.",
+        );
+        self::assertArrayHasKey(
+            'documents',
+            $result,
+            "Should preserve 'documents' key from input.",
+        );
+
+        $documentsArray = $result['documents'] ?? null;
+
+        self::assertIsArray(
+            $documentsArray,
+            "Should return 'array' of files for 'documents' upload.",
+        );
+        self::assertCount(
+            2,
+            $documentsArray,
+            "Should have two files in 'documents' arrays.",
+        );
+
+        $firstFile = $documentsArray[0] ?? null;
+
+        self::assertInstanceOf(
+            UploadedFileInterface::class,
+            $firstFile,
+            "Should return instance of 'UploadedFileInterface' for first file in 'documents'.",
+        );
+        self::assertSame(
+            'doc1.txt',
+            $firstFile->getClientFilename(),
+            "Should preserve 'client filename' for first file in 'documents'.",
+        );
+        self::assertSame(
+            'text/plain',
+            $firstFile->getClientMediaType(),
+            "Should preserve 'client media type' for first file in 'documents'.",
+        );
+        self::assertSame(
+            2048,
+            $firstFile->getSize(),
+            "Should preserve 'file size' for first file in 'documents'.",
+        );
+
+        $secondFile = $documentsArray[1] ?? null;
+
+        self::assertInstanceOf(
+            UploadedFileInterface::class,
+            $secondFile,
+            "Should return instance of 'UploadedFileInterface' for second file in 'documents'.",
+        );
+        self::assertSame(
+            'doc2.pdf',
+            $secondFile->getClientFilename(),
+            "Should preserve 'client filename' for second file in 'documents'.",
+        );
+        self::assertSame(
+            'application/pdf',
+            $secondFile->getClientMediaType(),
+            "Should preserve 'client media type' for second file in 'documents'.",
+        );
+        self::assertSame(
+            1536,
+            $secondFile->getSize(),
+            "Should preserve 'file size' for second file in 'documents'.",
+        );
+    }
+
+    public function testCreateFromGlobalsWithNestedStructure(): void
+    {
+        $tempPath1 = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tempPath2 = stream_get_meta_data($this->getTmpFile2())['uri'];
+
+        $files = [
+            'nested' => [
+                'level1' => [
+                    'tmp_name' => $tempPath1,
+                    'size' => 1024,
+                    'error' => UPLOAD_ERR_OK,
+                    'name' => 'nested1.txt',
+                    'type' => 'text/plain',
+                ],
+                'level2' => [
+                    'level3' => [
+                        'tmp_name' => [$tempPath2],
+                        'size' => [512],
+                        'error' => [UPLOAD_ERR_OK],
+                        'name' => ['nested2.jpg'],
+                        'type' => ['image/jpeg'],
+                    ],
+                ],
+            ],
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $result = $creator->createFromGlobals($files);
+
+        self::assertCount(
+            1,
+            $result,
+            "Should return array with 'nested' key.",
+        );
+        self::assertArrayHasKey(
+            'nested',
+            $result,
+            "Should preserve 'nested' key from input.",
+        );
+
+        $nestedLevel = $result['nested'] ?? null;
+
+        self::assertIsArray(
+            $nestedLevel,
+            "Should return nested 'array' structure for 'nested' key.",
+        );
+        self::assertArrayHasKey(
+            'level1',
+            $nestedLevel,
+            "Should have 'level1' in nested structure.",
+        );
+        self::assertArrayHasKey(
+            'level2',
+            $nestedLevel,
+            "Should have 'level2' in nested structure.",
+        );
+
+        $level1File = $nestedLevel['level1'] ?? null;
+
+        self::assertInstanceOf(
+            UploadedFileInterface::class,
+            $level1File,
+            "Should return instance of 'UploadedFileInterface' for 'level1' file.",
+        );
+        self::assertSame(
+            'nested1.txt',
+            $level1File->getClientFilename(),
+            "Should preserve 'client filename' in 'level1'.",
+        );
+        self::assertSame(
+            1024,
+            $level1File->getSize(),
+            "Should preserve 'file size' in 'level1'.",
+        );
+
+        $level2Structure = $nestedLevel['level2'] ?? null;
+
+        self::assertIsArray(
+            $level2Structure,
+            "Should return 'array' for 'level2'.",
+        );
+        self::assertArrayHasKey(
+            'level3',
+            $level2Structure,
+            "Should have 'level3' in 'level2' structure.",
+        );
+
+        $level3Array = $level2Structure['level3'] ?? null;
+
+        self::assertIsArray(
+            $level3Array,
+            "Should return 'array' for 'level3'.",
+        );
+        self::assertCount(
+            1,
+            $level3Array,
+            "Should have one file in 'level3' array.",
+        );
+
+        $level3File = $level3Array[0] ?? null;
+
+        self::assertInstanceOf(
+            UploadedFileInterface::class,
+            $level3File,
+            "Should return instance of 'UploadedFileInterface' for 'level3' file.",
+        );
+        self::assertSame(
+            'nested2.jpg',
+            $level3File->getClientFilename(),
+            "Should preserve 'client filename' in 'level3'.",
+        );
+        self::assertSame(
+            'image/jpeg',
+            $level3File->getClientMediaType(),
+            "Should preserve 'client media type' in 'level3'.",
+        );
+        self::assertSame(
+            512,
+            $level3File->getSize(),
+            "Should preserve 'file size' in 'level3'.",
+        );
+    }
+
+    public function testCreateFromGlobalsWithSingleFile(): void
+    {
+        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+
+        $files = [
+            'upload' => [
+                'tmp_name' => $tempPath,
+                'size' => 1024,
+                'error' => UPLOAD_ERR_OK,
+                'name' => 'document.pdf',
+                'type' => 'application/pdf',
+            ],
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $result = $creator->createFromGlobals($files);
+
+        self::assertCount(
+            1,
+            $result,
+            "Should return 'array' with one file ('upload' key).",
+        );
+        self::assertArrayHasKey(
+            'upload',
+            $result,
+            "Should preserve 'upload' key from input.",
+        );
+
+        $uploadedFile = $result['upload'] ?? null;
+
+        self::assertInstanceOf(
+            UploadedFileInterface::class,
+            $uploadedFile,
+            "Should return instance of 'UploadedFileInterface' for 'upload' file.",
+        );
+        self::assertSame(
+            'document.pdf',
+            $uploadedFile->getClientFilename(),
+            "Should preserve 'client filename' from 'upload' file.",
+        );
+        self::assertSame(
+            'application/pdf',
+            $uploadedFile->getClientMediaType(),
+            "Should preserve 'client media type' from 'upload' file.",
+        );
+        self::assertSame(
+            1024,
+            $uploadedFile->getSize(),
+            "Should preserve 'file size' from 'upload' file.",
+        );
+    }
+
+    public function testThrowExceptionInBuildFileTreeRecursion(): void
+    {
+        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+
+        $files = [
+            'documents' => [
+                'tmp_name' => [
+                    'category' => [
+                        'subcategory' => $tempPath,
+                    ],
+                ],
+                'size' => [
+                    'category' => [],
+                ],
+                'error' => [
+                    'category' => [
+                        'subcategory' => UPLOAD_ERR_OK,
+                    ],
+                ],
+            ],
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::SIZE_MUST_BE_INTEGER->getMessage('subcategory'),
+        );
+
+        $creator->createFromGlobals($files);
+    }
+
+    public function testThrowExceptionInBuildFileTreeWithMismatchedArrayStructureError(): void
+    {
+        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+
+        $files = [
+            'documents' => [
+                'tmp_name' => [
+                    'level1' => [$tempPath],
+                ],
+                'size' => [
+                    'level1' => [1024],
+                ],
+                'error' => [
+                    'level1' => UPLOAD_ERR_OK,
+                ],
+            ],
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::MISMATCHED_ARRAY_STRUCTURE_ERRORS->getMessage('level1'),
+        );
+
+        $creator->createFromGlobals($files);
+    }
+
+    public function testThrowExceptionInBuildFileTreeWithMismatchedArrayStructureSize(): void
+    {
+        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+
+        $files = [
+            'documents' => [
+                'tmp_name' => [
+                    'level1' => [$tempPath],
+                ],
+                'size' => [
+                    'level1' => 1024,
+                ],
+                'error' => [
+                    'level1' => [UPLOAD_ERR_OK],
+                ],
+            ],
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::MISMATCHED_ARRAY_STRUCTURE_SIZES->getMessage('level1'),
+        );
+
+        $creator->createFromGlobals($files);
+    }
+
+    public function testThrowExceptionWhenErrorIsNotInteger(): void
+    {
+        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+
+        $fileSpec = [
+            'tmp_name' => $tempPath,
+            'size' => 1024,
+            'error' => 'invalid',
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(Message::ERROR_MUST_BE_INTEGER->getMessage('error'));
+
+        // @phpstan-ignore-next-line
+        $creator->createFromArray($fileSpec);
+    }
+
+    public function testThrowExceptionWhenMissingSize(): void
+    {
+        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+
+        $fileSpec = [
+            'tmp_name' => $tempPath,
+            'error' => UPLOAD_ERR_OK,
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::MISSING_REQUIRED_KEY_IN_FILE_SPEC->getMessage('size', 'validateFileSpec()'),
+        );
+
+        // @phpstan-ignore-next-line
+        $creator->createFromArray($fileSpec);
+    }
+    public function testThrowExceptionWhenMissingTmpNameInFileSpec(): void
+    {
+        $fileSpec = [
+            'size' => 1024,
+            'error' => UPLOAD_ERR_OK,
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::MISSING_REQUIRED_KEY_IN_FILE_SPEC->getMessage('tmp_name', 'validateFileSpec()'),
+        );
+
+        // @phpstan-ignore-next-line
+        $creator->createFromArray($fileSpec);
+    }
+
+    public function testThrowExceptionWhenNameIsNotArrayOrNullInMultiFileSpec(): void
+    {
+        $tempPath1 = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tempPath2 = stream_get_meta_data($this->getTmpFile2())['uri'];
+
+        $files = [
+            'invalid' => [
+                'tmp_name' => [$tempPath1, $tempPath2],
+                'size' => [2048, 1536],
+                'error' => [UPLOAD_ERR_OK, UPLOAD_ERR_OK],
+                'name' => 'not_array', // should be array or 'null' when 'tmp_name' is array
+            ],
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::INVALID_OPTIONAL_ARRAY_IN_MULTI_SPEC->getMessage('name', 'validateMultiFileSpec()'),
+        );
+
+        $creator->createFromGlobals($files);
+    }
+
+    public function testThrowExceptionWhenNameIsNotStringOrNull(): void
+    {
+        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+
+        $fileSpec = [
+            'tmp_name' => $tempPath,
+            'size' => 1024,
+            'error' => UPLOAD_ERR_OK,
+            'name' => 123,
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(Message::NAME_MUST_BE_STRING_OR_NULL->getMessage('name'));
+
+        // @phpstan-ignore-next-line
+        $creator->createFromArray($fileSpec);
+    }
+
+    public function testThrowExceptionWhenSizeIsNotInteger(): void
+    {
+        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+
+        $fileSpec = [
+            'tmp_name' => $tempPath,
+            'size' => 'invalid',
+            'error' => UPLOAD_ERR_OK,
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(Message::SIZE_MUST_BE_INTEGER->getMessage('size'));
+
+        // @phpstan-ignore-next-line
+        $creator->createFromArray($fileSpec);
+    }
+
+    public function testThrowExceptionWhenTmpNameIsNotString(): void
+    {
+        $fileSpec = [
+            'tmp_name' => 123,
+            'size' => 1024,
+            'error' => UPLOAD_ERR_OK,
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(Message::TMP_NAME_MUST_BE_STRING->getMessage('tmp_name'));
+
+        // @phpstan-ignore-next-line
+        $creator->createFromArray($fileSpec);
+    }
+
+    public function testThrowExceptionWhenTypeIsNotStringOrNull(): void
+    {
+        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+
+        $fileSpec = [
+            'tmp_name' => $tempPath,
+            'size' => 1024,
+            'error' => UPLOAD_ERR_OK,
+            'type' => 123,
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(Message::TYPE_MUST_BE_STRING_OR_NULL->getMessage('type'));
+
+        // @phpstan-ignore-next-line
+        $creator->createFromArray($fileSpec);
+    }
+
+    public function testThrowExceptionWithMismatchedErrorsArray(): void
+    {
+        $tempPath1 = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tempPath2 = stream_get_meta_data($this->getTmpFile2())['uri'];
+
+        $files = [
+            'invalid' => [
+                'tmp_name' => [$tempPath1, $tempPath2],
+                'size' => [2048, 1536],
+                'error' => [UPLOAD_ERR_OK], // Missing error for second file
+            ],
+        ];
+
+        $uploadedFileFactory = FactoryHelper::createUploadedFileFactory();
+        $streamFactory = FactoryHelper::createStreamFactory();
+
+        $creator = new UploadedFileCreator($uploadedFileFactory, $streamFactory);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(Message::ERROR_MUST_BE_INTEGER->getMessage('error'));
+
+        $creator->createFromGlobals($files);
+    }
+
+    public function testThrowExceptionWithMismatchedSizesArray(): void
+    {
+        $tempPath1 = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tempPath2 = stream_get_meta_data($this->getTmpFile2())['uri'];
+
+        $files = [
+            'invalid' => [
+                'tmp_name' => [$tempPath1, $tempPath2],
+                'size' => [2048], // Missing size for second file
+                'error' => [UPLOAD_ERR_OK, UPLOAD_ERR_OK],
+            ],
+        ];
+
+        $uploadedFileFactory = FactoryHelper::createUploadedFileFactory();
+        $streamFactory = FactoryHelper::createStreamFactory();
+
+        $creator = new UploadedFileCreator($uploadedFileFactory, $streamFactory);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(Message::SIZE_MUST_BE_INTEGER->getMessage('size'));
+
+        $creator->createFromGlobals($files);
+    }
+
+    public function testThrowsExceptionWhenMissingError(): void
+    {
+        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+
+        $fileSpec = [
+            'tmp_name' => $tempPath,
+            'size' => 1024,
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::MISSING_REQUIRED_KEY_IN_FILE_SPEC->getMessage('error', 'validateFileSpec()'),
+        );
+
+        // @phpstan-ignore-next-line
+        $creator->createFromArray($fileSpec);
+    }
+
+    public function testThrowsExceptionWithMismatchedStructures(): void
+    {
+        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+
+        $files = [
+            'invalid' => [
+                'tmp_name' => [$tempPath],
+                'size' => 'not_array', // Should be array when tmp_name is array
+                'error' => [UPLOAD_ERR_OK],
+            ],
+        ];
+
+        $creator = new UploadedFileCreator(
+            FactoryHelper::createUploadedFileFactory(),
+            FactoryHelper::createStreamFactory(),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::MISSING_OR_INVALID_ARRAY_IN_MULTI_SPEC->getMessage('size', 'validateMultiFileSpec()'),
+        );
+
+        $creator->createFromGlobals($files);
+    }
+}

--- a/tests/creator/UploadedFileCreatorTest.php
+++ b/tests/creator/UploadedFileCreatorTest.php
@@ -16,20 +16,17 @@ use function stream_get_meta_data;
 
 #[Group('http')]
 #[Group('creator')]
-
-/**
- * @phpstan-type FileSpec array{tmp_name: string, size: int, error: int, name?: string|null, type?: string|null}
- */
 final class UploadedFileCreatorTest extends TestCase
 {
     public function testCreateFromArrayWithMinimalFileSpec(): void
     {
-        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tmpFile = $this->createTmpFile();
+        $tmpPath = stream_get_meta_data($tmpFile)['uri'];
 
         $fileSpec = [
-            'tmp_name' => $tempPath,
+            'tmp_name' => $tmpPath,
             'size' => 512,
-            'error' => UPLOAD_ERR_OK,
+            'error' => \UPLOAD_ERR_OK,
         ];
 
         $creator = new UploadedFileCreator(
@@ -53,7 +50,7 @@ final class UploadedFileCreatorTest extends TestCase
             "Should preserve 'file size' from minimal specification.",
         );
         self::assertSame(
-            UPLOAD_ERR_OK,
+            \UPLOAD_ERR_OK,
             $uploadedFile->getError(),
             "Should preserve 'error code' from minimal specification.",
         );
@@ -61,12 +58,13 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testCreateFromArrayWithNullOptionalFields(): void
     {
-        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tmpFile = $this->createTmpFile();
+        $tmpPath = stream_get_meta_data($tmpFile)['uri'];
 
         $fileSpec = [
-            'tmp_name' => $tempPath,
+            'tmp_name' => $tmpPath,
             'size' => 256,
-            'error' => UPLOAD_ERR_OK,
+            'error' => \UPLOAD_ERR_OK,
             'name' => null,
             'type' => null,
         ];
@@ -95,12 +93,13 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testCreateFromArrayWithValidFileSpec(): void
     {
-        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tmpFile = $this->createTmpFile();
+        $tmpPath = stream_get_meta_data($tmpFile)['uri'];
 
         $fileSpec = [
-            'tmp_name' => $tempPath,
+            'tmp_name' => $tmpPath,
             'size' => 1024,
-            'error' => UPLOAD_ERR_OK,
+            'error' => \UPLOAD_ERR_OK,
             'name' => 'test.txt',
             'type' => 'text/plain',
         ];
@@ -128,7 +127,7 @@ final class UploadedFileCreatorTest extends TestCase
             "Should preserve 'file size' from file specification.",
         );
         self::assertSame(
-            UPLOAD_ERR_OK,
+            \UPLOAD_ERR_OK,
             $uploadedFile->getError(),
             "Should preserve 'error code' from file specification.",
         );
@@ -153,7 +152,7 @@ final class UploadedFileCreatorTest extends TestCase
             'existing.txt',
             'text/plain',
             '/tmp/existing',
-            UPLOAD_ERR_OK,
+            \UPLOAD_ERR_OK,
             1024,
         );
 
@@ -182,30 +181,35 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testCreateFromGlobalsWithMixedFileStructures(): void
     {
-        $tempPath1 = stream_get_meta_data($this->getTmpFile1())['uri'];
-        $tempPath2 = stream_get_meta_data($this->getTmpFile2())['uri'];
-        $tempPath3 = stream_get_meta_data($this->getTmpFile3())['uri'];
+        $tmpFile1 = $this->createTmpFile();
+        $tmpPath1 = stream_get_meta_data($tmpFile1)['uri'];
+
+        $tmpFile2 = $this->createTmpFile();
+        $tmpPath2 = stream_get_meta_data($tmpFile2)['uri'];
+
+        $tmpFile3 = $this->createTmpFile();
+        $tmpPath3 = stream_get_meta_data($tmpFile3)['uri'];
 
         $files = [
             'single' => [
-                'tmp_name' => $tempPath1,
+                'tmp_name' => $tmpPath1,
                 'size' => 1024,
-                'error' => UPLOAD_ERR_OK,
+                'error' => \UPLOAD_ERR_OK,
                 'name' => 'single.txt',
                 'type' => 'text/plain',
             ],
             'multiple' => [
                 'tmp_name' => [
-                    $tempPath2,
-                    $tempPath3,
+                    $tmpPath2,
+                    $tmpPath3,
                 ],
                 'size' => [
                     2048,
                     1536,
                 ],
                 'error' => [
-                    UPLOAD_ERR_OK,
-                    UPLOAD_ERR_OK,
+                    \UPLOAD_ERR_OK,
+                    \UPLOAD_ERR_OK,
                 ],
                 'name' => [
                     'multi1.pdf',
@@ -300,22 +304,25 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testCreateFromGlobalsWithMultipleFiles(): void
     {
-        $tempPath1 = stream_get_meta_data($this->getTmpFile1())['uri'];
-        $tempPath2 = stream_get_meta_data($this->getTmpFile2())['uri'];
+        $tmpFile1 = $this->createTmpFile();
+        $tmpPath1 = stream_get_meta_data($tmpFile1)['uri'];
+
+        $tmpFile2 = $this->createTmpFile();
+        $tmpPath2 = stream_get_meta_data($tmpFile2)['uri'];
 
         $files = [
             'documents' => [
                 'tmp_name' => [
-                    $tempPath1,
-                    $tempPath2,
+                    $tmpPath1,
+                    $tmpPath2,
                 ],
                 'size' => [
                     2048,
                     1536,
                 ],
                 'error' => [
-                    UPLOAD_ERR_OK,
-                    UPLOAD_ERR_OK,
+                    \UPLOAD_ERR_OK,
+                    \UPLOAD_ERR_OK,
                 ],
                 'name' => [
                     'doc1.txt',
@@ -407,23 +414,26 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testCreateFromGlobalsWithNestedStructure(): void
     {
-        $tempPath1 = stream_get_meta_data($this->getTmpFile1())['uri'];
-        $tempPath2 = stream_get_meta_data($this->getTmpFile2())['uri'];
+        $tmpFile1 = $this->createTmpFile();
+        $tmpPath1 = stream_get_meta_data($tmpFile1)['uri'];
+
+        $tmpFile2 = $this->createTmpFile();
+        $tmpPath2 = stream_get_meta_data($tmpFile2)['uri'];
 
         $files = [
             'nested' => [
                 'level1' => [
-                    'tmp_name' => $tempPath1,
+                    'tmp_name' => $tmpPath1,
                     'size' => 1024,
-                    'error' => UPLOAD_ERR_OK,
+                    'error' => \UPLOAD_ERR_OK,
                     'name' => 'nested1.txt',
                     'type' => 'text/plain',
                 ],
                 'level2' => [
                     'level3' => [
-                        'tmp_name' => [$tempPath2],
+                        'tmp_name' => [$tmpPath2],
                         'size' => [512],
-                        'error' => [UPLOAD_ERR_OK],
+                        'error' => [\UPLOAD_ERR_OK],
                         'name' => ['nested2.jpg'],
                         'type' => ['image/jpeg'],
                     ],
@@ -534,13 +544,14 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testCreateFromGlobalsWithSingleFile(): void
     {
-        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tmpFile = $this->createTmpFile();
+        $tmpPath = stream_get_meta_data($tmpFile)['uri'];
 
         $files = [
             'upload' => [
-                'tmp_name' => $tempPath,
+                'tmp_name' => $tmpPath,
                 'size' => 1024,
-                'error' => UPLOAD_ERR_OK,
+                'error' => \UPLOAD_ERR_OK,
                 'name' => 'document.pdf',
                 'type' => 'application/pdf',
             ],
@@ -590,9 +601,10 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testSuccessWithMaximumAllowedRecursionDepth(): void
     {
-        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tmpFile = $this->createTmpFile();
+        $tmpPath = stream_get_meta_data($tmpFile)['uri'];
 
-        $maxDepthFiles = $this->createDeeplyNestedFileStructure($tempPath, 10);
+        $maxDepthFiles = $this->createDeeplyNestedFileStructure($tmpPath, 10);
 
         $creator = new UploadedFileCreator(
             FactoryHelper::createUploadedFileFactory(),
@@ -620,13 +632,14 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testThrowExceptionInBuildFileTreeRecursion(): void
     {
-        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tmpFile = $this->createTmpFile();
+        $tmpPath = stream_get_meta_data($tmpFile)['uri'];
 
         $files = [
             'documents' => [
                 'tmp_name' => [
                     'category' => [
-                        'subcategory' => $tempPath,
+                        'subcategory' => $tmpPath,
                     ],
                 ],
                 'size' => [
@@ -634,7 +647,7 @@ final class UploadedFileCreatorTest extends TestCase
                 ],
                 'error' => [
                     'category' => [
-                        'subcategory' => UPLOAD_ERR_OK,
+                        'subcategory' => \UPLOAD_ERR_OK,
                     ],
                 ],
             ],
@@ -655,18 +668,19 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testThrowExceptionInBuildFileTreeWithMismatchedArrayStructureError(): void
     {
-        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tmpFile = $this->createTmpFile();
+        $tmpPath = stream_get_meta_data($tmpFile)['uri'];
 
         $files = [
             'documents' => [
                 'tmp_name' => [
-                    'level1' => [$tempPath],
+                    'level1' => [$tmpPath],
                 ],
                 'size' => [
                     'level1' => [1024],
                 ],
                 'error' => [
-                    'level1' => UPLOAD_ERR_OK,
+                    'level1' => \UPLOAD_ERR_OK,
                 ],
             ],
         ];
@@ -686,18 +700,19 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testThrowExceptionInBuildFileTreeWithMismatchedArrayStructureSize(): void
     {
-        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tmpFile = $this->createTmpFile();
+        $tmpPath = stream_get_meta_data($tmpFile)['uri'];
 
         $files = [
             'documents' => [
                 'tmp_name' => [
-                    'level1' => [$tempPath],
+                    'level1' => [$tmpPath],
                 ],
                 'size' => [
                     'level1' => 1024,
                 ],
                 'error' => [
-                    'level1' => [UPLOAD_ERR_OK],
+                    'level1' => [\UPLOAD_ERR_OK],
                 ],
             ],
         ];
@@ -717,10 +732,11 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testThrowExceptionWhenErrorIsNotInteger(): void
     {
-        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tmpFile = $this->createTmpFile();
+        $tmpPath = stream_get_meta_data($tmpFile)['uri'];
 
         $fileSpec = [
-            'tmp_name' => $tempPath,
+            'tmp_name' => $tmpPath,
             'size' => 1024,
             'error' => 'invalid',
         ];
@@ -739,11 +755,12 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testThrowExceptionWhenMissingSize(): void
     {
-        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tmpFile = $this->createTmpFile();
+        $tmpPath = stream_get_meta_data($tmpFile)['uri'];
 
         $fileSpec = [
-            'tmp_name' => $tempPath,
-            'error' => UPLOAD_ERR_OK,
+            'tmp_name' => $tmpPath,
+            'error' => \UPLOAD_ERR_OK,
         ];
 
         $creator = new UploadedFileCreator(
@@ -764,7 +781,7 @@ final class UploadedFileCreatorTest extends TestCase
     {
         $fileSpec = [
             'size' => 1024,
-            'error' => UPLOAD_ERR_OK,
+            'error' => \UPLOAD_ERR_OK,
         ];
 
         $creator = new UploadedFileCreator(
@@ -783,14 +800,26 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testThrowExceptionWhenNameIsNotArrayOrNullInMultiFileSpec(): void
     {
-        $tempPath1 = stream_get_meta_data($this->getTmpFile1())['uri'];
-        $tempPath2 = stream_get_meta_data($this->getTmpFile2())['uri'];
+        $tempFile1 = $this->createTmpFile();
+        $tmpPath1 = stream_get_meta_data($tempFile1)['uri'];
+
+        $tempFile2 = $this->createTmpFile();
+        $tmpPath2 = stream_get_meta_data($tempFile2)['uri'];
 
         $files = [
             'invalid' => [
-                'tmp_name' => [$tempPath1, $tempPath2],
-                'size' => [2048, 1536],
-                'error' => [UPLOAD_ERR_OK, UPLOAD_ERR_OK],
+                'tmp_name' => [
+                    $tmpPath1,
+                    $tmpPath2,
+                ],
+                'size' => [
+                    2048,
+                    1536,
+                ],
+                'error' => [
+                    \UPLOAD_ERR_OK,
+                    \UPLOAD_ERR_OK,
+                ],
                 'name' => 'not_array', // should be array or 'null' when 'tmp_name' is array
             ],
         ];
@@ -810,12 +839,13 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testThrowExceptionWhenNameIsNotStringOrNull(): void
     {
-        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tmpFile = $this->createTmpFile();
+        $tmpPath = stream_get_meta_data($tmpFile)['uri'];
 
         $fileSpec = [
-            'tmp_name' => $tempPath,
+            'tmp_name' => $tmpPath,
             'size' => 1024,
-            'error' => UPLOAD_ERR_OK,
+            'error' => \UPLOAD_ERR_OK,
             'name' => 123,
         ];
 
@@ -833,9 +863,10 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testThrowExceptionWhenRecursionDepthExceeded(): void
     {
-        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tmpFile = $this->createTmpFile();
+        $tmpPath = stream_get_meta_data($tmpFile)['uri'];
 
-        $deeplyNestedFiles = $this->createDeeplyNestedFileStructure($tempPath, 15);
+        $deeplyNestedFiles = $this->createDeeplyNestedFileStructure($tmpPath, 15);
 
         $creator = new UploadedFileCreator(
             FactoryHelper::createUploadedFileFactory(),
@@ -850,12 +881,13 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testThrowExceptionWhenSizeIsNotInteger(): void
     {
-        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tmpFile = $this->createTmpFile();
+        $tmpPath = stream_get_meta_data($tmpFile)['uri'];
 
         $fileSpec = [
-            'tmp_name' => $tempPath,
+            'tmp_name' => $tmpPath,
             'size' => 'invalid',
-            'error' => UPLOAD_ERR_OK,
+            'error' => \UPLOAD_ERR_OK,
         ];
 
         $creator = new UploadedFileCreator(
@@ -877,7 +909,7 @@ final class UploadedFileCreatorTest extends TestCase
         $fileSpec = [
             'tmp_name' => $nonExistentPath,
             'size' => 1024,
-            'error' => UPLOAD_ERR_OK,
+            'error' => \UPLOAD_ERR_OK,
             'name' => 'test.txt',
             'type' => 'text/plain',
         ];
@@ -898,7 +930,7 @@ final class UploadedFileCreatorTest extends TestCase
         $fileSpec = [
             'tmp_name' => 123,
             'size' => 1024,
-            'error' => UPLOAD_ERR_OK,
+            'error' => \UPLOAD_ERR_OK,
         ];
 
         $creator = new UploadedFileCreator(
@@ -915,10 +947,11 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testThrowExceptionWhenTypeIsNotStringOrNull(): void
     {
-        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tmpFile = $this->createTmpFile();
+        $tmpPath = stream_get_meta_data($tmpFile)['uri'];
 
         $fileSpec = [
-            'tmp_name' => $tempPath,
+            'tmp_name' => $tmpPath,
             'size' => 1024,
             'error' => UPLOAD_ERR_OK,
             'type' => 123,
@@ -938,14 +971,20 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testThrowExceptionWithMismatchedErrorsArray(): void
     {
-        $tempPath1 = stream_get_meta_data($this->getTmpFile1())['uri'];
-        $tempPath2 = stream_get_meta_data($this->getTmpFile2())['uri'];
+        $tmpFile1 = $this->createTmpFile();
+        $tmpPath1 = stream_get_meta_data($tmpFile1)['uri'];
+
+        $tmpFile2 = $this->createTmpFile();
+        $tmpPath2 = stream_get_meta_data($tmpFile2)['uri'];
 
         $files = [
             'invalid' => [
-                'tmp_name' => [$tempPath1, $tempPath2],
-                'size' => [2048, 1536],
-                'error' => [UPLOAD_ERR_OK], // Missing error for second file
+                'tmp_name' => [$tmpPath1, $tmpPath2],
+                'size' => [
+                    2048,
+                    1536,
+                ],
+                'error' => [\UPLOAD_ERR_OK], // missing 'error code' for second file
             ],
         ];
 
@@ -962,14 +1001,23 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testThrowExceptionWithMismatchedSizesArray(): void
     {
-        $tempPath1 = stream_get_meta_data($this->getTmpFile1())['uri'];
-        $tempPath2 = stream_get_meta_data($this->getTmpFile2())['uri'];
+        $tmpFile1 = $this->createTmpFile();
+        $tmpPath1 = stream_get_meta_data($tmpFile1)['uri'];
+
+        $tmpFile2 = $this->createTmpFile();
+        $tmpPath2 = stream_get_meta_data($tmpFile2)['uri'];
 
         $files = [
             'invalid' => [
-                'tmp_name' => [$tempPath1, $tempPath2],
-                'size' => [2048], // Missing size for second file
-                'error' => [UPLOAD_ERR_OK, UPLOAD_ERR_OK],
+                'tmp_name' => [
+                    $tmpPath1,
+                    $tmpPath2,
+                ],
+                'size' => [2048], // missing 'size' for second file
+                'error' => [
+                    \UPLOAD_ERR_OK,
+                    \UPLOAD_ERR_OK,
+                ],
             ],
         ];
 
@@ -986,10 +1034,11 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testThrowsExceptionWhenMissingError(): void
     {
-        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tmpFile = $this->createTmpFile();
+        $tmpPath = stream_get_meta_data($tmpFile)['uri'];
 
         $fileSpec = [
-            'tmp_name' => $tempPath,
+            'tmp_name' => $tmpPath,
             'size' => 1024,
         ];
 
@@ -1009,13 +1058,14 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testThrowsExceptionWithMismatchedStructures(): void
     {
-        $tempPath = stream_get_meta_data($this->getTmpFile1())['uri'];
+        $tmpFile = $this->createTmpFile();
+        $tmpPath = stream_get_meta_data($tmpFile)['uri'];
 
         $files = [
             'invalid' => [
-                'tmp_name' => [$tempPath],
-                'size' => 'not_array', // Should be array when tmp_name is array
-                'error' => [UPLOAD_ERR_OK],
+                'tmp_name' => [$tmpPath],
+                'size' => 'not_array', // should be array when 'tmp_name' is array
+                'error' => [\UPLOAD_ERR_OK],
             ],
         ];
 
@@ -1035,24 +1085,24 @@ final class UploadedFileCreatorTest extends TestCase
     /**
      * Create deeply nested file structures for testing recursion limits.
      *
-     * @param string $tempPath Path to temporary file.
+     * @param string $tmpPath Path to temporary file.
      * @param int $depth Desired nesting depth.
      *
      * @return array Nested file structure.
      *
      * @phpstan-return array<array<mixed>|UploadedFileInterface>
      */
-    private function createDeeplyNestedFileStructure(string $tempPath, int $depth): array
+    private function createDeeplyNestedFileStructure(string $tmpPath, int $depth): array
     {
         return [
-            'deep' => $this->createSingleDeeplyNestedFileSpec($tempPath, $depth),
+            'deep' => $this->createSingleDeeplyNestedFileSpec($tmpPath, $depth),
         ];
     }
 
     /**
      * Create a single deeply nested file specification.
      *
-     * @param string $tempPath Path to temporary file.
+     * @param string $tmpPath Path to temporary file.
      * @param int $depth Desired nesting depth.
      *
      * @return array Nested file specification matching PHP $_FILES structure.
@@ -1062,9 +1112,9 @@ final class UploadedFileCreatorTest extends TestCase
      *   array<string, array<string, array<string, array<string, int|string>|int|string>|string>|int|string>|int|string
      * >
      */
-    private function createSingleDeeplyNestedFileSpec(string $tempPath, int $depth): array
+    private function createSingleDeeplyNestedFileSpec(string $tmpPath, int $depth): array
     {
-        $tmpName = $tempPath;
+        $tmpName = $tmpPath;
         $size = 1024;
         $error = UPLOAD_ERR_OK;
         $name = "deep_file_level_{$depth}.txt";

--- a/tests/creator/UploadedFileCreatorTest.php
+++ b/tests/creator/UploadedFileCreatorTest.php
@@ -726,6 +726,7 @@ final class UploadedFileCreatorTest extends TestCase
         // @phpstan-ignore-next-line
         $creator->createFromArray($fileSpec);
     }
+
     public function testThrowExceptionWhenMissingTmpNameInFileSpec(): void
     {
         $fileSpec = [

--- a/tests/support/FactoryHelper.php
+++ b/tests/support/FactoryHelper.php
@@ -4,13 +4,24 @@ declare(strict_types=1);
 
 namespace yii2\extensions\psrbridge\tests\support;
 
-use HttpSoft\Message\{Response, ResponseFactory, ServerRequest, Stream, StreamFactory, UploadedFile, Uri};
+use HttpSoft\Message\{
+    Response,
+    ResponseFactory,
+    ServerRequest,
+    ServerRequestFactory,
+    Stream,
+    StreamFactory,
+    UploadedFile,
+    UploadedFileFactory,
+    Uri,
+};
 use Psr\Http\Message\{
     ResponseFactoryInterface,
     ResponseInterface,
     ServerRequestInterface,
     StreamFactoryInterface,
     StreamInterface,
+    UploadedFileFactoryInterface,
     UploadedFileInterface,
     UriInterface,
 };
@@ -130,6 +141,21 @@ final class FactoryHelper
     }
 
     /**
+     * Creates a PSR-17 {@see ServerRequestFactory} instance.
+     *
+     * @return ServerRequestFactory PSR-17 server request factory instance.
+     *
+     * Usage example:
+     * ```php
+     * FactoryHelper::createServerRequestFactory();
+     * ```
+     */
+    public static function createServerRequestFactory(): ServerRequestFactory
+    {
+        return new ServerRequestFactory();
+    }
+
+    /**
      * Creates a PSR-7 {@see StreamInterface} instance.
      *
      * @param string $stream Stream content.
@@ -186,6 +212,21 @@ final class FactoryHelper
         int $size = 0,
     ): UploadedFileInterface {
         return new UploadedFile($tmpName, $size, $error, $name, $type);
+    }
+
+    /**
+     * Creates a PSR-17 {@see UploadedFileFactoryInterface} instance.
+     *
+     * @return UploadedFileFactoryInterface PSR-17 uploaded file factory instance.
+     *
+     * Usage example:
+     * ```php
+     * FactoryHelper::createUploadedFileFactory();
+     * ```
+     */
+    public static function createUploadedFileFactory(): UploadedFileFactoryInterface
+    {
+        return new UploadedFileFactory();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | /❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to create HTTP server requests from PHP global variables, supporting both SAPI and worker environments.
  * Introduced support for handling single and multiple file uploads, including nested file structures, with robust validation and error handling.

* **Bug Fixes**
  * Enhanced error messages for file upload and response stream validation to provide clearer feedback on invalid input.

* **Tests**
  * Added comprehensive test coverage for server request and uploaded file creation, including edge cases and error scenarios.
  * Improved test infrastructure with better temporary file management and new factory helpers for easier test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->