### PR TITLE
ci: Update uopz for runkit7 installation.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,15 +31,15 @@ jobs:
       before-hook: |
         sudo apt-get update
         sudo apt-get install -y autoconf automake libtool m4 make gcc
-        git clone https://github.com/krakjoe/uopz.git /tmp/uopz
-        cd /tmp/uopz && phpize && ./configure && make && sudo make install
+        git clone https://github.com/zonuexe/uopz.git /tmp/uopz
+        cd /tmp/uopz && git checkout support/php84-exit
+        phpize && ./configure && make && sudo make install
         PHP_INI_DIR=$(php-config --ini-dir)
         sudo mkdir -p "$PHP_INI_DIR"
         sudo sh -c "echo 'extension=uopz' > '$PHP_INI_DIR/uopz.ini'"
       concurrency-group: phpunit-uozp${{ github.workflow }}-${{ github.ref }}
       extensions: mbstring, gd
       os: '["ubuntu-latest"]'
-      php-version: '["8.3"]'
+      php-version: '["8.4"]'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,24 +22,6 @@ jobs:
     uses: php-forge/actions/.github/workflows/phpunit.yml@main
     with:
       concurrency-group: phpunit-${{ github.workflow }}-${{ github.ref }}
-      extensions: mbstring, gd
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  phpunit-uozp:
-    uses: php-forge/actions/.github/workflows/phpunit.yml@main
-    with:
-      before-hook: |
-        sudo apt-get update
-        sudo apt-get install -y autoconf automake libtool m4 make gcc
-        git clone https://github.com/zonuexe/uopz.git /tmp/uopz
-        cd /tmp/uopz && git checkout support/php84-exit
-        phpize && ./configure && make && sudo make install
-        PHP_INI_DIR=$(php-config --ini-dir)
-        sudo mkdir -p "$PHP_INI_DIR"
-        sudo sh -c "echo 'extension=uopz' > '$PHP_INI_DIR/uopz.ini'"
-      concurrency-group: phpunit-uozp${{ github.workflow }}-${{ github.ref }}
-      extensions: mbstring, gd
-      os: '["ubuntu-latest"]'
-      php-version: '["8.4"]'
+      extensions: mbstring, gd, runkit7
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -30,7 +30,7 @@ jobs:
         PHP_INI_DIR=$(php-config --ini-dir)
         sudo mkdir -p "$PHP_INI_DIR"
         sudo sh -c "echo 'extension=uopz' > '$PHP_INI_DIR/uopz.ini'"
-      php-version: '["8.3"]'
+      php-version: '["8.4"]'
       phpstan: true
     secrets:
       STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -23,6 +23,7 @@ jobs:
     with:
       command-options: --threads=2 --ignore-msi-with-no-mutations
       extensions: runkit7-4.0.0a6
+      php-version: '["8.2"]'
       phpstan: true
     secrets:
       STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -21,16 +21,7 @@ jobs:
   mutation:
     uses: php-forge/actions/.github/workflows/infection.yml@main
     with:
-      before-hook: |
-        sudo apt-get update
-        sudo apt-get install -y autoconf automake libtool m4 make gcc
-        git clone https://github.com/zonuexe/uopz.git /tmp/uopz
-        cd /tmp/uopz && git checkout support/php84-exit
-        phpize && ./configure && make && sudo make install
-        PHP_INI_DIR=$(php-config --ini-dir)
-        sudo mkdir -p "$PHP_INI_DIR"
-        sudo sh -c "echo 'extension=uopz' > '$PHP_INI_DIR/uopz.ini'"
-      command-options: --threads=2 --ignore-msi-with-no-mutations --initial-tests-php-options="-d error_reporting=E_ALL"
+      command-options: --threads=2 --ignore-msi-with-no-mutations
       php-version: '["8.4"]'
       phpstan: true
     secrets:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -22,7 +22,7 @@ jobs:
     uses: php-forge/actions/.github/workflows/infection.yml@main
     with:
       command-options: --threads=2 --ignore-msi-with-no-mutations
-      extensions: runkit7
+      extensions: runkit7-4.0.0a6
       phpstan: true
     secrets:
       STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -30,6 +30,7 @@ jobs:
         PHP_INI_DIR=$(php-config --ini-dir)
         sudo mkdir -p "$PHP_INI_DIR"
         sudo sh -c "echo 'extension=uopz' > '$PHP_INI_DIR/uopz.ini'"
+      command-options: --threads=2 --ignore-msi-with-no-mutations --initial-tests-php-options="-d error_reporting=E_ALL"
       php-version: '["8.4"]'
       phpstan: true
     secrets:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -30,6 +30,7 @@ jobs:
         PHP_INI_DIR=$(php-config --ini-dir)
         sudo mkdir -p "$PHP_INI_DIR"
         sudo sh -c "echo 'extension=uopz' > '$PHP_INI_DIR/uopz.ini'"
+      php-version: '["8.3"]'
       phpstan: true
     secrets:
       STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -21,6 +21,15 @@ jobs:
   mutation:
     uses: php-forge/actions/.github/workflows/infection.yml@main
     with:
+      before-hook: |
+        sudo apt-get update
+        sudo apt-get install -y autoconf automake libtool m4 make gcc
+        git clone https://github.com/zonuexe/uopz.git /tmp/uopz
+        cd /tmp/uopz && git checkout support/php84-exit
+        phpize && ./configure && make && sudo make install
+        PHP_INI_DIR=$(php-config --ini-dir)
+        sudo mkdir -p "$PHP_INI_DIR"
+        sudo sh -c "echo 'extension=uopz' > '$PHP_INI_DIR/uopz.ini'"
       phpstan: true
     secrets:
       STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -23,7 +23,7 @@ jobs:
     with:
       command-options: --threads=2 --ignore-msi-with-no-mutations
       extensions: runkit7-4.0.0a6
-      php-version: '["8.2"]'
+      php-version: '["8.3"]'
       phpstan: true
     secrets:
       STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -22,7 +22,7 @@ jobs:
     uses: php-forge/actions/.github/workflows/infection.yml@main
     with:
       command-options: --threads=2 --ignore-msi-with-no-mutations
-      php-version: '["8.4"]'
+      extensions: runkit7
       phpstan: true
     secrets:
       STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -1,6 +1,6 @@
 {
     "symbol-whitelist": [
-        "uopz_redefine",
+        "runkit_constant_redefine",
         "YII_DEBUG",
         "YII_ENV_TEST"
     ]

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "yiisoft/yii2": "^2.0.53|^22"
     },
     "require-dev": {
-        "infection/infection": "^0.27|^0.30",
+        "infection/infection": "^0.27|^0.31",
         "httpsoft/http-message": "^1.1",
         "maglnet/composer-require-checker": "^4.1",
         "phpstan/extension-installer": "^1.4",

--- a/src/http/StatelessApplication.php
+++ b/src/http/StatelessApplication.php
@@ -21,9 +21,9 @@ use function is_array;
 use function memory_get_usage;
 use function method_exists;
 use function microtime;
+use function runkit_constant_redefine;
 use function sscanf;
 use function strtoupper;
-use function uopz_redefine;
 
 /**
  * Stateless Yii2 Application with PSR-7 RequestHandler integration for worker and SAPI environments.
@@ -387,8 +387,8 @@ final class StatelessApplication extends Application implements RequestHandlerIn
     protected function reset(ServerRequestInterface $request): void
     {
         // override 'YII_BEGIN_TIME' if possible for yii2-debug and other modules that depend on it
-        if (function_exists('uopz_redefine')) {
-            uopz_redefine('YII_BEGIN_TIME', microtime(true));
+        if (function_exists('runkit_constant_redefine')) {
+            @runkit_constant_redefine('YII_ENV', 'prod');
         }
 
         $this->startEventTracking();

--- a/src/http/StatelessApplication.php
+++ b/src/http/StatelessApplication.php
@@ -20,7 +20,6 @@ use function ini_get;
 use function is_array;
 use function memory_get_usage;
 use function method_exists;
-use function microtime;
 use function runkit_constant_redefine;
 use function sscanf;
 use function strtoupper;

--- a/src/http/StatelessApplication.php
+++ b/src/http/StatelessApplication.php
@@ -20,6 +20,7 @@ use function ini_get;
 use function is_array;
 use function memory_get_usage;
 use function method_exists;
+use function microtime;
 use function runkit_constant_redefine;
 use function sscanf;
 use function strtoupper;
@@ -387,7 +388,7 @@ final class StatelessApplication extends Application implements RequestHandlerIn
     {
         // override 'YII_BEGIN_TIME' if possible for yii2-debug and other modules that depend on it
         if (function_exists('runkit_constant_redefine')) {
-            @runkit_constant_redefine('YII_ENV', 'prod');
+            @runkit_constant_redefine('YII_BEGIN_TIME', microtime(true));
         }
 
         $this->startEventTracking();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workflows to remove the uopz PHP extension installation and add the runkit7 extension.
  * Changed PHP version in mutation testing workflows to 8.3 with parallel execution enhancements.
  * Expanded allowed versions for the infection development dependency.
  * Adjusted configuration to support runkit7-related features in testing and application reset logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->