### PR TITLE
refactor(SapiEmitter): Remove unused output buffer functions from imports.

### DIFF
--- a/src/emitter/SapiEmitter.php
+++ b/src/emitter/SapiEmitter.php
@@ -10,8 +10,6 @@ use yii2\extensions\psrbridge\exception\{HeadersAlreadySentException, Message, O
 
 use function array_map;
 use function implode;
-use function ob_get_length;
-use function ob_get_level;
 use function sprintf;
 use function str_replace;
 use function strlen;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused import statements for certain PHP functions. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->