### PR TITLE
fix: Align query parameters behavior between PSR-7 and Yii2 Request.

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -149,6 +149,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
                             'enableStrictParsing' => false,
                             'enablePrettyUrl' => true,
                             'rules' => [
+                                'site/query/<test:\w+>' => 'site/query',
                                 'site/update/<id:\d+>' => 'site/update',
                             ],
                         ],

--- a/tests/http/StatelessApplicationTest.php
+++ b/tests/http/StatelessApplicationTest.php
@@ -1238,6 +1238,39 @@ final class StatelessApplicationTest extends TestCase
         );
     }
 
+    public function testReturnJsonResponseWithQueryParamsForSiteQueryRoute(): void
+    {
+        $_GET = ['q' => '1'];
+        $_SERVER = [
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => 'site/query/foo?q=1',
+        ];
+
+        $request = FactoryHelper::createServerRequestCreator()->createFromGlobals();
+
+        $app = $this->statelessApplication();
+
+        $response = $app->handle($request);
+
+        self::assertSame(
+            200,
+            $response->getStatusCode(),
+            "Response 'status code' should be '200' for 'site/query/foo?q=1' route in 'StatelessApplication'.",
+        );
+        self::assertSame(
+            'application/json; charset=UTF-8',
+            $response->getHeaders()['content-type'][0] ?? '',
+            "Response 'content-type' should be 'application/json; charset=UTF-8' for 'site/query/foo?q=1' route in " .
+            "'StatelessApplication'.",
+        );
+        self::assertSame(
+            '{"test":"foo","q":"1","queryParams":{"test":"foo","q":"1"}}',
+            $response->getBody()->getContents(),
+            "Response 'body' should contain valid JSON with route and query parameters for 'site/query/foo?q=1' in " .
+            "'StatelessApplication'.",
+        );
+    }
+
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */

--- a/tests/support/stub/SiteController.php
+++ b/tests/support/stub/SiteController.php
@@ -232,6 +232,20 @@ final class SiteController extends Controller
     }
 
     /**
+     * @phpstan-return array<array-key, mixed>
+     */
+    public function actionQuery(string $test): array
+    {
+        $this->response->format = Response::FORMAT_JSON;
+
+        return [
+            'test' => $test,
+            'q' => $this->request->get('q'),
+            'queryParams' => $this->request->getQueryParams(),
+        ];
+    }
+
+    /**
      * @throws InvalidRouteException
      */
     public function actionRedirect(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for handling and returning combined route and query parameters in JSON responses for specific routes.
  * Introduced a new endpoint that returns both route and query parameters in its JSON output.

* **Tests**
  * Added tests to verify correct handling and response of combined route and query parameters for the new endpoint.

* **Chores**
  * Updated URL routing rules to support new endpoint patterns with dynamic parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->