### PR TITLE
refactor(Request): Add methods to `getRemoteIP()`, `getServerParams()` and `getServerParam()` with PSR-7 support. (#69)

### DIFF
--- a/src/adapter/ServerRequestAdapter.php
+++ b/src/adapter/ServerRequestAdapter.php
@@ -303,7 +303,7 @@ final class ServerRequestAdapter
      */
     public function getScriptUrl(bool $workerMode): string
     {
-        $serverParams = $this->psrRequest->getServerParams();
+        $serverParams = $this->getServerParams();
 
         // for traditional PSR-7 apps where 'SCRIPT_NAME' is available
         if ($workerMode === false && isset($serverParams['SCRIPT_NAME']) && is_string($serverParams['SCRIPT_NAME'])) {
@@ -313,6 +313,28 @@ final class ServerRequestAdapter
         // for PSR-7 workers (RoadRunner, FrankenPHP, etc.) where no script file exists
         // return empty to prevent URL duplication as routing is handled internally
         return '';
+    }
+
+    /**
+     * Retrieves server parameters from the PSR-7 ServerRequestInterface.
+     *
+     * Returns the server parameters as provided by the underlying PSR-7 ServerRequestInterface instance.
+     *
+     * This method exposes the raw server parameters array, enabling direct access to all server environment values in
+     * a format compatible with PSR-7 expectations.
+     *
+     * @return array Server parameters from the PSR-7 ServerRequestInterface.
+     *
+     * @phpstan-return array<array-key, mixed>
+     *
+     * Usage example:
+     * ```php
+     * $params = $adapter->getServerParams();
+     * ```
+     */
+    public function getServerParams(): array
+    {
+        return $this->psrRequest->getServerParams();
     }
 
     /**

--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -499,6 +499,27 @@ final class Request extends \yii\web\Request
     }
 
     /**
+     * Retrieves a server parameter value as a string or `null`.
+     *
+     * Returns the value of the specified server parameter from the current request server parameters array.
+     *
+     * If the parameter is not set or is not a string, `null` is returned.
+     *
+     * This method provides type-safe access to individual server parameters ensuring compatibility with both PSR-7 and
+     * Yii2 environments.
+     *
+     * @param string $name Name of the server parameter to retrieve.
+     *
+     * @return string|null Value of the server parameter as a string, or `null` if not set or not a string.
+     */
+    public function getServerParam(string $name): string|null
+    {
+        $serverParam = $this->getServerParams()[$name] ?? null;
+
+        return is_string($serverParam) ? $serverParam : null;
+    }
+
+    /**
      * Retrieves server parameters from the current request, supporting PSR-7 and Yii2 fallback.
      *
      * Returns the server parameters from the PSR-7 adapter if present, otherwise returns `$_SERVER` for backward
@@ -724,26 +745,5 @@ final class Request extends \yii\web\Request
                 'type' => $psrFile->getClientMediaType() ?? '',
             ],
         );
-    }
-
-    /**
-     * Retrieves a server parameter value as a string or `null`.
-     *
-     * Returns the value of the specified server parameter from the current request server parameters array.
-     *
-     * If the parameter is not set or is not a string, `null` is returned.
-     *
-     * This method provides type-safe access to individual server parameters ensuring compatibility with both PSR-7 and
-     * Yii2 environments.
-     *
-     * @param string $name Name of the server parameter to retrieve.
-     *
-     * @return string|null Value of the server parameter as a string, or `null` if not set or not a string.
-     */
-    private function getServerParam(string $name): string|null
-    {
-        $serverParam = $this->getServerParams()[$name] ?? null;
-
-        return is_string($serverParam) ? $serverParam : null;
     }
 }

--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -501,14 +501,13 @@ final class Request extends \yii\web\Request
     /**
      * Retrieves server parameters from the current request, supporting PSR-7 and Yii2 fallback.
      *
-     * Returns the server parameters as provided by the PSR-7 ServerRequestAdapter if the adapter is set.
-     *
-     * If no adapter is present, an empty array is returned.
+     * Returns the server parameters from the PSR-7 adapter if present, otherwise returns `$_SERVER` for backward
+     * compatibility with traditional SAPI environments.
      *
      * This method enables seamless access to server parameters in both PSR-7 and Yii2 environments, supporting
      * interoperability with modern HTTP stacks and legacy workflows.
      *
-     * @return array Array of server parameters for the current request.
+     * @return array Server parameters for the current request.
      *
      * @phpstan-return array<array-key, mixed>
      *
@@ -523,7 +522,8 @@ final class Request extends \yii\web\Request
             return $this->adapter->getServerParams();
         }
 
-        return [];
+        // fallback to `$_SERVER` for non-PSR7 environments
+        return $_SERVER;
     }
 
     /**

--- a/tests/adapter/ServerRequestAdapterTest.php
+++ b/tests/adapter/ServerRequestAdapterTest.php
@@ -32,11 +32,7 @@ final class ServerRequestAdapterTest extends TestCase
         $request->csrfHeader = $csrfHeaderName;
 
         $request->setPsr7Request(
-            FactoryHelper::createRequest(
-                'POST',
-                '/test',
-                [$csrfHeaderName => $expectedToken],
-            ),
+            FactoryHelper::createRequest('POST', '/test', [$csrfHeaderName => $expectedToken]),
         );
         $result = $request->getCsrfTokenFromHeader();
 
@@ -270,7 +266,9 @@ final class ServerRequestAdapterTest extends TestCase
         $request->enableCookieValidation = false;
         $request->cookieValidationKey = 'test-validation-key-32-characters';
 
-        $request->setPsr7Request(FactoryHelper::createRequest('GET', '/test'));
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/test'),
+        );
         $cookies = $request->getCookies();
 
         self::assertCount(
@@ -386,11 +384,7 @@ final class ServerRequestAdapterTest extends TestCase
         $request = new Request();
 
         $request->setPsr7Request(
-            FactoryHelper::createRequest(
-                'POST',
-                '/test',
-                ['X-CSRF-Token' => $csrfToken],
-            ),
+            FactoryHelper::createRequest('POST', '/test', ['X-CSRF-Token' => $csrfToken]),
         );
         $result = $request->getCsrfTokenFromHeader();
 
@@ -411,11 +405,7 @@ final class ServerRequestAdapterTest extends TestCase
         $request->csrfHeader = $customHeaderName;
 
         $request->setPsr7Request(
-            FactoryHelper::createRequest(
-                'PUT',
-                '/api/resource',
-                [$customHeaderName => $csrfToken],
-            ),
+            FactoryHelper::createRequest('PUT', '/api/resource', [$customHeaderName => $csrfToken]),
         );
         $result = $request->getCsrfTokenFromHeader();
 
@@ -477,7 +467,9 @@ final class ServerRequestAdapterTest extends TestCase
     {
         $request = new Request();
 
-        $request->setPsr7Request(FactoryHelper::createRequest('GET', '/products'));
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/products'),
+        );
         $queryParams = $request->getQueryParams();
 
         self::assertEmpty(
@@ -490,7 +482,9 @@ final class ServerRequestAdapterTest extends TestCase
     {
         $request = new Request();
 
-        $request->setPsr7Request(FactoryHelper::createRequest('GET', '/test'));
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/test'),
+        );
         $result = $request->getQueryString();
 
         self::assertEmpty($result, 'Query string should be empty when no query parameters are present.');
@@ -503,7 +497,9 @@ final class ServerRequestAdapterTest extends TestCase
     {
         $request = new Request(['workerMode' => false]);
 
-        $request->setPsr7Request(FactoryHelper::createRequest('GET', '/test'));
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/test'),
+        );
         $scriptUrl = $request->getScriptUrl();
 
         self::assertEmpty(
@@ -519,7 +515,9 @@ final class ServerRequestAdapterTest extends TestCase
     {
         $request = new Request();
 
-        $request->setPsr7Request(FactoryHelper::createRequest('GET', '/test'));
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/test'),
+        );
         $scriptUrl = $request->getScriptUrl();
 
         self::assertSame(
@@ -529,11 +527,33 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
+    public function testReturnEmptyServerParamsWhenAdapterIsSet(): void
+    {
+        $_SERVER = [
+            'REMOTE_ADDR' => '192.168.1.100',
+            'REQUEST_TIME' => '1234567890',
+            'SERVER_NAME' => 'old.example.com',
+        ];
+
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', 'https://old.example.com/api'),
+        );
+
+        self::assertEmpty(
+            $request->getServerParams(),
+            'Server parameter should be empty array when using a PSR-7 request, ignoring global \'$_SERVER\'.',
+        );
+    }
+
     public function testReturnHttpMethodFromAdapterWhenAdapterIsSet(): void
     {
         $request = new Request();
 
-        $request->setPsr7Request(FactoryHelper::createRequest('POST', '/test'));
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('POST', '/test'),
+        );
         $method = $request->getMethod();
 
         self::assertSame(
@@ -622,11 +642,7 @@ final class ServerRequestAdapterTest extends TestCase
         $request = new Request();
 
         $request->setPsr7Request(
-            FactoryHelper::createRequest(
-                'POST',
-                '/test',
-                ['X-Http-Method-Override' => 'DELETE'],
-            ),
+            FactoryHelper::createRequest('POST', '/test', ['X-Http-Method-Override' => 'DELETE']),
         );
         $method = $request->getMethod();
 
@@ -641,7 +657,9 @@ final class ServerRequestAdapterTest extends TestCase
     {
         $request = new Request();
 
-        $request->setPsr7Request(FactoryHelper::createRequest('GET', '/test'));
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/test'),
+        );
         $method = $request->getMethod();
 
         self::assertSame(
@@ -717,7 +735,9 @@ final class ServerRequestAdapterTest extends TestCase
 
         $request = new Request();
 
-        $request->setPsr7Request(FactoryHelper::createRequest('POST', '/upload')->withUploadedFiles($uploadedFiles));
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('POST', '/upload')->withUploadedFiles($uploadedFiles),
+        );
         $convertedFiles = $request->getUploadedFiles();
 
         self::assertCount(
@@ -877,11 +897,7 @@ final class ServerRequestAdapterTest extends TestCase
         $request = new Request();
 
         $request->setPsr7Request(
-            FactoryHelper::createRequest(
-                'PATCH',
-                '/api/update',
-                ['X-CSRF-Token' => ''],
-            ),
+            FactoryHelper::createRequest('PATCH', '/api/update', ['X-CSRF-Token' => '']),
         );
         $result = $request->getCsrfTokenFromHeader();
 
@@ -897,12 +913,28 @@ final class ServerRequestAdapterTest extends TestCase
     {
         $request = new Request();
 
-        $request->setPsr7Request(FactoryHelper::createRequest('DELETE', '/api/resource'));
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('DELETE', '/api/resource'),
+        );
         $result = $request->getCsrfTokenFromHeader();
 
         self::assertNull(
             $result,
             "'CSRF' token from header should return 'null' when no 'CSRF' header is present in the 'PSR-7' request.",
+        );
+    }
+
+    public function testReturnNullWhenServerParamNotPresentInPsr7Request(): void
+    {
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/test'),
+        );
+
+        self::assertNull(
+            $request->getServerParam('TEST_PARAM'),
+            "'getServerParam()' should return 'null' when the parameter is not present in PSR-7 'serverParams'.",
         );
     }
 
@@ -943,7 +975,7 @@ final class ServerRequestAdapterTest extends TestCase
     {
         $request = new Request();
 
-        // ensure adapter is 'null' (default state)
+        // ensure adapter is `null` (default state)
         $request->reset();
 
         $_SERVER['SCRIPT_NAME'] = '/test.php';
@@ -963,7 +995,7 @@ final class ServerRequestAdapterTest extends TestCase
     {
         $request = new Request();
 
-        // ensure adapter is 'null' (default state)
+        // ensure adapter is `null` (default state)
         $request->reset();
         $method = $request->getMethod();
 
@@ -974,7 +1006,7 @@ final class ServerRequestAdapterTest extends TestCase
     {
         $request = new Request();
 
-        // ensure adapter is 'null' (default state)
+        // ensure adapter is `null` (default state)
         $request->reset();
         $queryParams = $request->getQueryParams();
 
@@ -1082,10 +1114,7 @@ final class ServerRequestAdapterTest extends TestCase
         $request = new Request();
 
         $request->setPsr7Request(
-            FactoryHelper::createRequest(
-                'GET',
-                '/api/users',
-            ),
+            FactoryHelper::createRequest('GET', '/api/users'),
         );
         $result = $request->getParsedBody();
 
@@ -1139,7 +1168,9 @@ final class ServerRequestAdapterTest extends TestCase
     {
         $request = new Request();
 
-        $request->setPsr7Request(FactoryHelper::createRequest('GET', '/test'));
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/test'),
+        );
 
         self::assertInstanceOf(
             ServerRequestInterface::class,
@@ -1198,7 +1229,9 @@ final class ServerRequestAdapterTest extends TestCase
     {
         $request = new Request();
 
-        $request->setPsr7Request(FactoryHelper::createRequest('GET', "/test?{$queryString}"));
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', "/test?{$queryString}"),
+        );
         $result = $request->getQueryString();
 
         self::assertSame(
@@ -1218,7 +1251,9 @@ final class ServerRequestAdapterTest extends TestCase
 
         $request = new Request();
 
-        $request->setPsr7Request(FactoryHelper::createRequest('POST', '/api/contact')->withBody($stream));
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('POST', '/api/contact')->withBody($stream),
+        );
         $result = $request->getRawBody();
 
         self::assertSame(
@@ -1232,7 +1267,9 @@ final class ServerRequestAdapterTest extends TestCase
     {
         $request = new Request();
 
-        $request->setPsr7Request(FactoryHelper::createRequest('GET', '/test'));
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/test'),
+        );
         $result = $request->getRawBody();
 
         self::assertEmpty(
@@ -1278,11 +1315,28 @@ final class ServerRequestAdapterTest extends TestCase
 
     public function testReturnRemoteIPFromPsr7ServerParams(): void
     {
-        $_SERVER = [
-            'REMOTE_ADDR' => '192.168.1.100',
-            'REQUEST_TIME' => '1234567890',
-            'SERVER_NAME' => 'old.example.com',
-        ];
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest(
+                'GET',
+                'https://old.example.com/api',
+                serverParams: ['REMOTE_ADDR' => '192.168.1.100'],
+            ),
+        );
+
+        $remoteIP = $request->getRemoteIP();
+
+        self::assertSame(
+            '192.168.1.100',
+            $remoteIP,
+            "'getRemoteIP()' should return the 'REMOTE_ADDR' value from PSR-7 'serverParams'.",
+        );
+    }
+
+    public function testReturnRemoteIPFromPsr7ServerParamsOverridesGlobalServer(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '192.168.1.100';
 
         $request = new Request();
 
@@ -1290,19 +1344,17 @@ final class ServerRequestAdapterTest extends TestCase
             FactoryHelper::createRequest(
                 'GET',
                 'https://old.example.com/api',
-                serverParams: [
-                    'HTTP_X_FORWARDED_FOR' => '203.0.113.1',
-                    'REMOTE_ADDR' => '10.0.0.50',
-                    'REQUEST_TIME' => '1234567999',
-                    'SERVER_NAME' => 'new.example.com',
-                ],
+                serverParams: ['REMOTE_ADDR' => '10.0.0.1'],
             ),
         );
 
+        $remoteIP = $request->getRemoteIP();
+
         self::assertSame(
-            '10.0.0.50',
-            $request->getRemoteIP(),
-            "'getRemoteIP()' should return the 'REMOTE_ADDR' from PSR-7 'serverParams', not from global " . '$_SERVER',
+            '10.0.0.1',
+            $remoteIP,
+            "'getRemoteIP()' should return the 'REMOTE_ADDR' value from PSR-7 'serverParams', not from global " .
+            '\'$_SERVER\'.',
         );
     }
 
@@ -1330,6 +1382,92 @@ final class ServerRequestAdapterTest extends TestCase
             $expectedScriptName,
             $scriptUrl,
             "Script URL should return 'SCRIPT_NAME' when adapter is set in traditional mode.",
+        );
+    }
+
+    public function testReturnServerParamFromPsr7RequestWhenAdapterIsSet(): void
+    {
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/test', serverParams: ['TEST_PARAM' => 'test_value']),
+        );
+
+        self::assertSame(
+            'test_value',
+            $request->getServerParam('TEST_PARAM'),
+            "'getServerParam()' should return the value from PSR-7 'serverParams'.",
+        );
+    }
+
+    public function testReturnServerParamsFromPsr7RequestOverridesGlobalServer(): void
+    {
+        $_SERVER = [
+            'REMOTE_ADDR' => '192.168.1.100',
+            'REQUEST_TIME' => '1234567890',
+            'SERVER_NAME' => 'old.example.com',
+        ];
+
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest(
+                'GET',
+                'https://old.example.com/api',
+                serverParams: [
+                    'HTTP_X_FORWARDED_FOR' => '203.0.113.1',
+                    'REMOTE_ADDR' => '10.0.0.50',
+                    'REQUEST_TIME' => null,
+                    'SERVER_NAME' => 'new.example.com',
+                ],
+            ),
+        );
+
+        $serverParams = $request->getServerParams();
+
+        self::assertSame(
+            '10.0.0.50',
+            $serverParams['REMOTE_ADDR'] ?? null,
+            "Server parameter 'REMOTE_ADDR' should be taken from PSR-7 'serverParams', not from global " .
+            '\'$_SERVER\'.',
+        );
+        self::assertNull(
+            $serverParams['REQUEST_TIME'] ?? null,
+            "Server parameter 'REQUEST_TIME' should be 'null' when not set in PSR-7 'serverParams', even if present " .
+            'in global \'$_SERVER\'.',
+        );
+    }
+
+    public function testReturnServerParamsFromPsr7RequestWhenAdapterIsSet(): void
+    {
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest(
+                'GET',
+                'https://old.example.com/api',
+                serverParams: [
+                    'HTTP_X_FORWARDED_FOR' => '203.0.113.1',
+                    'REQUEST_TIME' => '1234567890',
+                ],
+            ),
+        );
+
+        $serverParams = $request->getServerParams();
+
+        self::assertSame(
+            '203.0.113.1',
+            $serverParams['HTTP_X_FORWARDED_FOR'] ?? null,
+            "'HTTP_X_FORWARDED_FOR' should match the value from PSR-7 'serverParams'.",
+        );
+        self::assertSame(
+            '1234567890',
+            $serverParams['REQUEST_TIME'] ?? null,
+            "'REQUEST_TIME' should match the value from PSR-7 'serverParams'.",
+        );
+        self::assertNull(
+            $serverParams['REMOTE_ADDR'] ?? null,
+            "'REMOTE_ADDR' should not be set when not present in PSR-7 'serverParams'.",
         );
     }
 
@@ -1603,7 +1741,9 @@ final class ServerRequestAdapterTest extends TestCase
     {
         $request = new Request();
 
-        $request->setPsr7Request(FactoryHelper::createRequest('GET', $url));
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', $url),
+        );
         $url = $request->getUrl();
 
         self::assertSame(

--- a/tests/adapter/ServerRequestAdapterTest.php
+++ b/tests/adapter/ServerRequestAdapterTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use Yii;
 use yii\base\{InvalidCallException, InvalidConfigException};
 use yii\helpers\Json;
-use yii\web\{Cookie, CookieCollection, UploadedFile};
+use yii\web\{Cookie, UploadedFile};
 use yii2\extensions\psrbridge\exception\Message;
 use yii2\extensions\psrbridge\http\Request;
 use yii2\extensions\psrbridge\tests\provider\RequestProvider;

--- a/tests/adapter/ServerRequestAdapterTest.php
+++ b/tests/adapter/ServerRequestAdapterTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace yii2\extensions\psrbridge\tests\adapter;
 
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
-use Psr\Http\Message\ServerRequestInterface;
 use Yii;
 use yii\base\{InvalidCallException, InvalidConfigException};
 use yii\helpers\Json;
@@ -22,11 +21,6 @@ use function filesize;
 #[Group('http')]
 final class ServerRequestAdapterTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
     public function testGetCsrfTokenFromHeaderUsesAdapterWhenAdapterIsNotNull(): void
     {
         $expectedToken = 'adapter-csrf-token-123';
@@ -52,6 +46,9 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function testResetCookieCollectionAfterReset(): void
     {
         $psr7Request = FactoryHelper::createRequest('GET', '/test');
@@ -90,6 +87,9 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function testReturnBodyParamsWhenPsr7RequestHasFormData(): void
     {
         $request = new Request();
@@ -133,6 +133,9 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function testReturnBodyParamsWithMethodParamRemoved(): void
     {
         $request = new Request();
@@ -204,6 +207,9 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function testReturnCookieCollectionWhenCookiesPresent(): void
     {
         $psr7Request = FactoryHelper::createRequest('GET', '/test');
@@ -224,11 +230,6 @@ final class ServerRequestAdapterTest extends TestCase
         $request->setPsr7Request($psr7Request);
         $cookies = $request->getCookies();
 
-        self::assertInstanceOf(
-            CookieCollection::class,
-            $cookies,
-            "Cookies should return a 'CookieCollection' instance when cookies are present.",
-        );
         self::assertCount(
             2,
             $cookies,
@@ -258,6 +259,9 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function testReturnCookieCollectionWhenNoCookiesPresent(): void
     {
         $request = new Request();
@@ -268,11 +272,6 @@ final class ServerRequestAdapterTest extends TestCase
         $request->setPsr7Request(FactoryHelper::createRequest('GET', '/test'));
         $cookies = $request->getCookies();
 
-        self::assertInstanceOf(
-            CookieCollection::class,
-            $cookies,
-            "Cookies should return a 'CookieCollection' instance when no cookies are present.",
-        );
         self::assertCount(
             0,
             $cookies,
@@ -280,6 +279,9 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function testReturnCookieCollectionWithValidationDisabled(): void
     {
         $psr7Request = FactoryHelper::createRequest('GET', '/test');
@@ -299,11 +301,6 @@ final class ServerRequestAdapterTest extends TestCase
         $request->setPsr7Request($psr7Request);
         $cookies = $request->getCookies();
 
-        self::assertInstanceOf(
-            CookieCollection::class,
-            $cookies,
-            "Cookies should return a 'CookieCollection' instance when validation is disabled.",
-        );
         self::assertCount(
             2,
             $cookies,
@@ -329,6 +326,9 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function testReturnCookieWithCorrectNamePropertyWhenAdapterIsSet(): void
     {
         $cookieName = 'session_id';
@@ -443,6 +443,9 @@ final class ServerRequestAdapterTest extends TestCase
         $request->getCookies();
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function testReturnEmptyCookieCollectionWhenValidationEnabledWithInvalidCookies(): void
     {
         $psr7Request = FactoryHelper::createRequest('GET', '/test');
@@ -462,11 +465,6 @@ final class ServerRequestAdapterTest extends TestCase
         $request->setPsr7Request($psr7Request);
         $cookies = $request->getCookies();
 
-        self::assertInstanceOf(
-            CookieCollection::class,
-            $cookies,
-            "Cookies should return a 'CookieCollection' instance when validation is enabled with invalid cookies.",
-        );
         self::assertCount(
             0,
             $cookies,
@@ -497,11 +495,14 @@ final class ServerRequestAdapterTest extends TestCase
         self::assertEmpty($result, 'Query string should be empty when no query parameters are present.');
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function testReturnEmptyScriptUrlWhenAdapterIsSetInTraditionalModeWithoutScriptName(): void
     {
         $request = new Request(['workerMode' => false]);
 
-        $request->setPsr7Request(FactoryHelper::createRequest('GET', '/test', [], null, []));
+        $request->setPsr7Request(FactoryHelper::createRequest('GET', '/test'));
         $scriptUrl = $request->getScriptUrl();
 
         self::assertEmpty(
@@ -510,6 +511,9 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function testReturnEmptyScriptUrlWhenAdapterIsSetInWorkerMode(): void
     {
         $request = new Request();
@@ -770,6 +774,9 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function testReturnMultipleValidatedCookiesWhenValidationEnabledWithMultipleValidCookies(): void
     {
         $validationKey = 'test-validation-key-32-characters';
@@ -839,6 +846,9 @@ final class ServerRequestAdapterTest extends TestCase
         }
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function testReturnNewCookieCollectionInstanceOnEachCall(): void
     {
         $psr7Request = FactoryHelper::createRequest('GET', '/test');
@@ -909,11 +919,14 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function testReturnParentGetParsedBodyWhenAdapterIsNull(): void
     {
         $request = new Request();
 
-        // ensure adapter is 'null' (default state)
+        // ensure adapter is `null` (default state)
         $request->reset();
 
         self::assertEmpty(
@@ -922,6 +935,9 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function testReturnParentGetScriptUrlWhenAdapterIsNull(): void
     {
         $request = new Request();
@@ -934,7 +950,7 @@ final class ServerRequestAdapterTest extends TestCase
 
         $scriptUrl = $request->getScriptUrl();
 
-        // kust verify the method executes without throwing exception when adapter is 'null'
+        // verify the method executes without throwing exception when adapter is `null`
         self::assertSame(
             '/test.php',
             $scriptUrl,
@@ -990,6 +1006,9 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function testReturnParentUrlWhenAdapterIsNull(): void
     {
         $_SERVER['REQUEST_URI'] = '/legacy/path?param=value';
@@ -1010,6 +1029,9 @@ final class ServerRequestAdapterTest extends TestCase
         unset($_SERVER['REQUEST_URI']);
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function testReturnParsedBodyArrayWhenAdapterIsSet(): void
     {
         $parsedBodyData = [
@@ -1051,6 +1073,9 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function testReturnParsedBodyNullWhenAdapterIsSetWithNullBody(): void
     {
         $request = new Request();
@@ -1059,8 +1084,6 @@ final class ServerRequestAdapterTest extends TestCase
             FactoryHelper::createRequest(
                 'GET',
                 '/api/users',
-                [],
-                null,
             ),
         );
         $result = $request->getParsedBody();
@@ -1068,6 +1091,9 @@ final class ServerRequestAdapterTest extends TestCase
         self::assertNull($result, "Parsed body should return 'null' when 'PSR-7' request has no parsed body.");
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function testReturnParsedBodyObjectWhenAdapterIsSet(): void
     {
         $parsedBodyObject = (object) [
@@ -1105,20 +1131,6 @@ final class ServerRequestAdapterTest extends TestCase
             'Article content',
             $result->content,
             "Object 'content' property should match the expected value.",
-        );
-    }
-
-    public function testReturnPsr7RequestInstanceWhenAdapterIsSet(): void
-    {
-        $request = new Request();
-
-        $request->setPsr7Request(FactoryHelper::createRequest('GET', '/test'));
-
-        self::assertInstanceOf(
-            ServerRequestInterface::class,
-            $request->getPsr7Request(),
-            "'getPsr7Request()' should return a '" . ServerRequestInterface::class . "' instance when the 'PSR-7' " .
-            'adapter is set.',
         );
     }
 
@@ -1185,7 +1197,7 @@ final class ServerRequestAdapterTest extends TestCase
     {
         $bodyContent = '{"name":"John","email":"john@example.com","message":"Hello World"}';
 
-        $stream = FactoryHelper::createStream('php://temp', 'wb+');
+        $stream = FactoryHelper::createStream();
 
         $stream->write($bodyContent);
 
@@ -1214,6 +1226,9 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function testReturnReadOnlyCookieCollectionWhenAdapterIsSet(): void
     {
         $psr7Request = FactoryHelper::createRequest('GET', '/test');
@@ -1233,12 +1248,6 @@ final class ServerRequestAdapterTest extends TestCase
         $request->setPsr7Request($psr7Request);
         $cookies = $request->getCookies();
 
-        self::assertInstanceOf(
-            CookieCollection::class,
-            $cookies,
-            "Cookies should return a 'CookieCollection' instance when adapter is set.",
-        );
-
         $this->expectException(InvalidCallException::class);
         $this->expectExceptionMessage('The cookie collection is read only.');
 
@@ -1252,6 +1261,39 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
+    public function testReturnRemoteIPFromPsr7ServerParams(): void
+    {
+        $_SERVER = [
+            'REMOTE_ADDR' => '192.168.1.100',
+            'REQUEST_TIME' => '1234567890',
+            'SERVER_NAME' => 'old.example.com',
+        ];
+
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest(
+                'GET',
+                'https://old.example.com/api',
+                serverParams: [
+                    'HTTP_X_FORWARDED_FOR' => '203.0.113.1',
+                    'REMOTE_ADDR' => '10.0.0.50',
+                    'REQUEST_TIME' => '1234567999',
+                    'SERVER_NAME' => 'new.example.com',
+                ],
+            ),
+        );
+
+        self::assertSame(
+            '10.0.0.50',
+            $request->getRemoteIP(),
+            "'getRemoteIP()' should return the 'REMOTE_ADDR' from PSR-7 'serverParams', not from global " . '$_SERVER',
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
     public function testReturnScriptNameWhenAdapterIsSetInTraditionalMode(): void
     {
         $expectedScriptName = '/app/public/index.php';
@@ -1538,6 +1580,9 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     #[DataProviderExternal(RequestProvider::class, 'getUrl')]
     public function testReturnUrlFromAdapterWhenAdapterIsSet(string $url, string $expectedUrl): void
     {
@@ -1553,6 +1598,9 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function testReturnValidatedCookiesWhenValidationEnabledWithValidCookies(): void
     {
         $validationKey = 'test-validation-key-32-characters';
@@ -1580,11 +1628,6 @@ final class ServerRequestAdapterTest extends TestCase
         $request->setPsr7Request($psr7Request);
         $cookies = $request->getCookies();
 
-        self::assertInstanceOf(
-            CookieCollection::class,
-            $cookies,
-            "Cookies should return a 'CookieCollection' instance when validation is enabled with valid cookies.",
-        );
         self::assertCount(
             1,
             $cookies,
@@ -1605,6 +1648,9 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function testReturnValidatedCookieWithCorrectNamePropertyWhenValidationEnabled(): void
     {
         $validationKey = 'test-validation-key-32-characters';

--- a/tests/adapter/ServerRequestAdapterTest.php
+++ b/tests/adapter/ServerRequestAdapterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace yii2\extensions\psrbridge\tests\adapter;
 
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use Psr\Http\Message\ServerRequestInterface;
 use Yii;
 use yii\base\{InvalidCallException, InvalidConfigException};
 use yii\helpers\Json;
@@ -47,7 +48,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testResetCookieCollectionAfterReset(): void
     {
@@ -88,7 +89,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testReturnBodyParamsWhenPsr7RequestHasFormData(): void
     {
@@ -134,7 +135,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testReturnBodyParamsWithMethodParamRemoved(): void
     {
@@ -208,7 +209,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testReturnCookieCollectionWhenCookiesPresent(): void
     {
@@ -260,7 +261,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testReturnCookieCollectionWhenNoCookiesPresent(): void
     {
@@ -280,7 +281,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testReturnCookieCollectionWithValidationDisabled(): void
     {
@@ -327,7 +328,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testReturnCookieWithCorrectNamePropertyWhenAdapterIsSet(): void
     {
@@ -444,7 +445,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testReturnEmptyCookieCollectionWhenValidationEnabledWithInvalidCookies(): void
     {
@@ -496,7 +497,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testReturnEmptyScriptUrlWhenAdapterIsSetInTraditionalModeWithoutScriptName(): void
     {
@@ -512,7 +513,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testReturnEmptyScriptUrlWhenAdapterIsSetInWorkerMode(): void
     {
@@ -775,7 +776,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testReturnMultipleValidatedCookiesWhenValidationEnabledWithMultipleValidCookies(): void
     {
@@ -847,7 +848,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testReturnNewCookieCollectionInstanceOnEachCall(): void
     {
@@ -920,7 +921,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testReturnParentGetParsedBodyWhenAdapterIsNull(): void
     {
@@ -936,7 +937,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testReturnParentGetScriptUrlWhenAdapterIsNull(): void
     {
@@ -1007,7 +1008,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testReturnParentUrlWhenAdapterIsNull(): void
     {
@@ -1030,7 +1031,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testReturnParsedBodyArrayWhenAdapterIsSet(): void
     {
@@ -1074,7 +1075,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testReturnParsedBodyNullWhenAdapterIsSetWithNullBody(): void
     {
@@ -1092,7 +1093,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testReturnParsedBodyObjectWhenAdapterIsSet(): void
     {
@@ -1131,6 +1132,20 @@ final class ServerRequestAdapterTest extends TestCase
             'Article content',
             $result->content,
             "Object 'content' property should match the expected value.",
+        );
+    }
+
+    public function testReturnPsr7RequestInstanceWhenAdapterIsSet(): void
+    {
+        $request = new Request();
+
+        $request->setPsr7Request(FactoryHelper::createRequest('GET', '/test'));
+
+        self::assertInstanceOf(
+            ServerRequestInterface::class,
+            $request->getPsr7Request(),
+            "'getPsr7Request()' should return a '" . ServerRequestInterface::class . "' instance when the 'PSR-7' " .
+            'adapter is set.',
         );
     }
 
@@ -1227,7 +1242,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testReturnReadOnlyCookieCollectionWhenAdapterIsSet(): void
     {
@@ -1292,7 +1307,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testReturnScriptNameWhenAdapterIsSetInTraditionalMode(): void
     {
@@ -1581,7 +1596,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     #[DataProviderExternal(RequestProvider::class, 'getUrl')]
     public function testReturnUrlFromAdapterWhenAdapterIsSet(string $url, string $expectedUrl): void
@@ -1599,7 +1614,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testReturnValidatedCookiesWhenValidationEnabledWithValidCookies(): void
     {
@@ -1649,7 +1664,7 @@ final class ServerRequestAdapterTest extends TestCase
     }
 
     /**
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     public function testReturnValidatedCookieWithCorrectNamePropertyWhenValidationEnabled(): void
     {

--- a/tests/http/RequestTest.php
+++ b/tests/http/RequestTest.php
@@ -959,6 +959,33 @@ final class RequestTest extends TestCase
         );
     }
 
+    public function testGetServerParamsReturnsExpectedServerArray(): void
+    {
+        $_SERVER = [
+            'HTTP_HOST' => 'example.com',
+            'QUERY_STRING' => 'param=value',
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/test',
+            'SERVER_NAME' => 'example.com',
+            'SERVER_PORT' => '80',
+        ];
+
+        $request = new Request();
+
+        self::assertSame(
+            [
+                'HTTP_HOST' => 'example.com',
+                'QUERY_STRING' => 'param=value',
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/test',
+                'SERVER_NAME' => 'example.com',
+                'SERVER_PORT' => '80',
+            ],
+            $request->getServerParams(),
+            "'getServerParams()' should return the expected server parameters array.",
+        );
+    }
+
     public function testGetServerPort(): void
     {
         $request = new Request();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to access all server parameters and retrieve the remote IP address from requests, improving interoperability and information access.

* **Bug Fixes**
  * Enhanced consistency and reliability when retrieving server parameters and remote IP, especially when using PSR-7 adapters.

* **Tests**
  * Added tests to verify remote IP retrieval from server parameters.
  * Added tests to confirm correct server parameters exposure.
  * Removed redundant type assertions and improved test documentation.
  * Performed minor test code cleanup for clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->