### PR TITLE
refactor(Request): Implement `getRemoteHost()` method with PSR-7 support and fallback to Yii2, including comprehensive tests.

### DIFF
--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -445,6 +445,32 @@ final class Request extends \yii\web\Request
     }
 
     /**
+     * Retrieves the remote host name for the current request, supporting PSR-7 and Yii2 fallback.
+     *
+     * Returns the remote host as determined by the PSR-7 adapter if present, using the 'REMOTE_HOST' server parameter.
+     *
+     * If no adapter is set, falls back to the parent implementation.
+     *
+     * This method enables seamless access to the remote host in both PSR-7 and Yii2 environments, supporting
+     * interoperability with modern HTTP stacks and legacy workflows.
+     *
+     * @return string|null Remote host name for the current request, or null if not available.
+     *
+     * Usage example:
+     * ```php
+     * $host = $request->getRemoteHost();
+     * ```
+     */
+    public function getRemoteHost(): string|null
+    {
+        if ($this->adapter !== null) {
+            return $this->getServerParam('REMOTE_HOST');
+        }
+
+        return parent::getRemoteHost();
+    }
+
+    /**
      * Retrieves the remote IP address for the current request, supporting PSR-7 and Yii2 fallback.
      *
      * Returns the remote IP address as provided by the PSR-7 ServerRequestAdapter if the adapter is set.

--- a/tests/adapter/ServerRequestAdapterTest.php
+++ b/tests/adapter/ServerRequestAdapterTest.php
@@ -58,6 +58,7 @@ final class ServerRequestAdapterTest extends TestCase
             'Different request instances should maintain separate remote host values.',
         );
     }
+
     public function testGetCsrfTokenFromHeaderUsesAdapterWhenAdapterIsNotNull(): void
     {
         $expectedToken = 'adapter-csrf-token-123';

--- a/tests/adapter/ServerRequestAdapterTest.php
+++ b/tests/adapter/ServerRequestAdapterTest.php
@@ -748,8 +748,6 @@ final class ServerRequestAdapterTest extends TestCase
 
     public function testReturnIPv4AddressFromPsr7RequestWhenRemoteHostIsIP(): void
     {
-        $this->webApplication();
-
         $request = new Request();
 
         $request->setPsr7Request(
@@ -1059,8 +1057,6 @@ final class ServerRequestAdapterTest extends TestCase
 
     public function testReturnNullWhenRemoteHostIsEmptyStringInPsr7Request(): void
     {
-        $this->webApplication();
-
         $request = new Request();
 
         $request->setPsr7Request(
@@ -1091,8 +1087,6 @@ final class ServerRequestAdapterTest extends TestCase
 
     public function testReturnNullWhenRemoteHostNotPresentInPsr7Request(): void
     {
-        $this->webApplication();
-
         $request = new Request();
 
         $request->setPsr7Request(

--- a/tests/adapter/ServerRequestAdapterTest.php
+++ b/tests/adapter/ServerRequestAdapterTest.php
@@ -769,11 +769,7 @@ final class ServerRequestAdapterTest extends TestCase
         $request = new Request();
 
         $request->setPsr7Request(
-            FactoryHelper::createRequest(
-                'DELETE',
-                '/resource/123',
-                serverParams: ['REMOTE_HOST' => $expectedHost],
-            ),
+            FactoryHelper::createRequest('DELETE', '/resource/123', serverParams: ['REMOTE_HOST' => $expectedHost]),
         );
 
         self::assertSame(

--- a/tests/adapter/ServerRequestAdapterTest.php
+++ b/tests/adapter/ServerRequestAdapterTest.php
@@ -22,6 +22,42 @@ use function filesize;
 #[Group('http')]
 final class ServerRequestAdapterTest extends TestCase
 {
+    public function testConcurrentRequestsWithDifferentRemoteHosts(): void
+    {
+        $host1 = 'client1.example.com';
+        $host2 = 'client2.example.org';
+
+        $request1 = new Request();
+
+        $request1->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/api/v1/users', serverParams: ['REMOTE_HOST' => $host1]),
+        );
+
+        $request2 = new Request();
+
+        $request2->setPsr7Request(
+            FactoryHelper::createRequest('POST', '/api/v1/posts', serverParams: ['REMOTE_HOST' => $host2]),
+        );
+
+        $result1 = $request1->getRemoteHost();
+        $result2 = $request2->getRemoteHost();
+
+        self::assertSame(
+            $host1,
+            $result1,
+            'First request instance should return its own remote host value.',
+        );
+        self::assertSame(
+            $host2,
+            $result2,
+            'Second request instance should return its own remote host value.',
+        );
+        self::assertNotSame(
+            $result1,
+            $result2,
+            'Different request instances should maintain separate remote host values.',
+        );
+    }
     public function testGetCsrfTokenFromHeaderUsesAdapterWhenAdapterIsNotNull(): void
     {
         $expectedToken = 'adapter-csrf-token-123';
@@ -81,6 +117,46 @@ final class ServerRequestAdapterTest extends TestCase
             'new_value',
             $cookies2->getValue('new_cookie'),
             "New cookie 'new_cookie' should have the expected value after reset.",
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testResetRemoteHostAfterRequestReset(): void
+    {
+        $initialHost = 'initial.host.com';
+        $newHost = 'new.host.com';
+
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/first', serverParams: ['REMOTE_HOST' => $initialHost]),
+        );
+
+        $result1 = $request->getRemoteHost();
+
+        self::assertSame(
+            $initialHost,
+            $result1,
+            'Remote host should return the initial host value from the first PSR-7 request.',
+        );
+
+        $request->reset();
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('POST', '/second', serverParams: ['REMOTE_HOST' => $newHost]),
+        );
+        $result2 = $request->getRemoteHost();
+
+        self::assertSame(
+            $newHost,
+            $result2,
+            'Remote host should return the new host value after reset and setting a new PSR-7 request.',
+        );
+        self::assertNotSame(
+            $result1,
+            $result2,
+            'Remote host values should be different after reset with new PSR-7 request data.',
         );
     }
 
@@ -200,7 +276,7 @@ final class ServerRequestAdapterTest extends TestCase
             'multipart/form-data; boundary=----WebKitFormBoundary',
             $request->getContentType(),
             "'getContentType()' should return the 'Content-Type' header from the PSR-7 request when present, " .
-            'overriding "text/plain" from $_SERVER[\'CONTENT_TYPE\'].',
+            "overriding 'text/plain' from \$_SERVER[CONTENT_TYPE].",
         );
     }
 
@@ -543,7 +619,7 @@ final class ServerRequestAdapterTest extends TestCase
 
         self::assertEmpty(
             $request->getServerParams(),
-            'Server parameter should be empty array when using a PSR-7 request, ignoring global \'$_SERVER\'.',
+            'Server parameter should be empty array when using a PSR-7 request, ignoring global $_SERVER.',
         );
     }
 
@@ -666,6 +742,62 @@ final class ServerRequestAdapterTest extends TestCase
             'GET',
             $method,
             'HTTP method should return original method when no override is present and adapter is set.',
+        );
+    }
+
+    public function testReturnIPv4AddressFromPsr7RequestWhenRemoteHostIsIP(): void
+    {
+        $this->webApplication();
+
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('PUT', '/data', serverParams: ['REMOTE_HOST' => '192.168.1.100']),
+        );
+
+        self::assertSame(
+            '192.168.1.100',
+            $request->getRemoteHost(),
+            "Remote host should correctly return IPv4 address from PSR-7 'serverParams' when 'REMOTE_HOST' contains " .
+            'an IPv4 address.',
+        );
+    }
+
+    public function testReturnIPv6AddressFromPsr7RequestWhenRemoteHostIsIPv6(): void
+    {
+        $expectedHost = '2001:0db8:85a3:0000:0000:8a2e:0370:7334';
+
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest(
+                'DELETE',
+                '/resource/123',
+                serverParams: ['REMOTE_HOST' => $expectedHost],
+            ),
+        );
+
+        self::assertSame(
+            $expectedHost,
+            $request->getRemoteHost(),
+            "Remote host should correctly return IPv6 address from PSR-7 'serverParams' when 'REMOTE_HOST' contains " .
+            'an IPv6 address.',
+        );
+    }
+
+    public function testReturnLocalhostFromPsr7RequestWhenRemoteHostIsLocalhost(): void
+    {
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/health-check', serverParams: ['REMOTE_HOST' => 'localhost']),
+        );
+
+        self::assertSame(
+            'localhost',
+            $request->getRemoteHost(),
+            "Remote host should correctly return 'localhost' from PSR-7 'serverParams' when 'REMOTE_HOST' is " .
+            "'localhost'.",
         );
     }
 
@@ -921,6 +1053,54 @@ final class ServerRequestAdapterTest extends TestCase
         self::assertNull(
             $result,
             "'CSRF' token from header should return 'null' when no 'CSRF' header is present in the 'PSR-7' request.",
+        );
+    }
+
+    public function testReturnNullWhenRemoteHostIsEmptyStringInPsr7Request(): void
+    {
+        $this->webApplication();
+
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/test', serverParams: ['REMOTE_HOST' => '']),
+        );
+
+        self::assertSame(
+            '',
+            $request->getRemoteHost(),
+            "Remote host should return an empty string when 'REMOTE_HOST' parameter is an empty string in " .
+            "PSR-7 'serverParams'.",
+        );
+    }
+
+    public function testReturnNullWhenRemoteHostIsNotStringInPsr7Request(): void
+    {
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/test', serverParams: ['REMOTE_HOST' => 123]),
+        );
+
+        self::assertNull(
+            $request->getRemoteHost(),
+            "Remote host should return 'null' when 'REMOTE_HOST' parameter is not a string in PSR-7 'serverParams'.",
+        );
+    }
+
+    public function testReturnNullWhenRemoteHostNotPresentInPsr7Request(): void
+    {
+        $this->webApplication();
+
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/test', serverParams: ['SERVER_NAME' => 'example.com']),
+        );
+
+        self::assertNull(
+            $request->getRemoteHost(),
+            "Remote host should return 'null' when 'REMOTE_HOST' parameter is not present in PSR-7 'serverParams'.",
         );
     }
 
@@ -1313,6 +1493,21 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
+    public function testReturnRemoteHostFromPsr7RequestWhenRemoteHostIsPresent(): void
+    {
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/test', serverParams: ['REMOTE_HOST' => 'example.host.com']),
+        );
+
+        self::assertSame(
+            'example.host.com',
+            $request->getRemoteHost(),
+            "Remote host should match the value from PSR-7 'serverParams' when 'REMOTE_HOST' is present.",
+        );
+    }
+
     public function testReturnRemoteIPFromPsr7ServerParams(): void
     {
         $request = new Request();
@@ -1354,7 +1549,7 @@ final class ServerRequestAdapterTest extends TestCase
             '10.0.0.1',
             $remoteIP,
             "'getRemoteIP()' should return the 'REMOTE_ADDR' value from PSR-7 'serverParams', not from global " .
-            '\'$_SERVER\'.',
+            '$_SERVER.',
         );
     }
 
@@ -1429,12 +1624,12 @@ final class ServerRequestAdapterTest extends TestCase
             '10.0.0.50',
             $serverParams['REMOTE_ADDR'] ?? null,
             "Server parameter 'REMOTE_ADDR' should be taken from PSR-7 'serverParams', not from global " .
-            '\'$_SERVER\'.',
+            '$_SERVER.',
         );
         self::assertNull(
             $serverParams['REQUEST_TIME'] ?? null,
             "Server parameter 'REQUEST_TIME' should be 'null' when not set in PSR-7 'serverParams', even if present " .
-            'in global \'$_SERVER\'.',
+            'in global $_SERVER.',
         );
     }
 
@@ -1858,6 +2053,30 @@ final class ServerRequestAdapterTest extends TestCase
         self::assertNull(
             $cookie->expire,
             "Validated cookie 'expire' property should be 'null' as set in the constructor",
+        );
+    }
+
+    public function testReturnValidHostnameFromPsr7RequestWithDomainName(): void
+    {
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest(
+                'POST',
+                '/api/users',
+                ['Content-Type' => 'application/json'],
+                serverParams: [
+                    'REMOTE_HOST' => 'api.example-service.com',
+                    'SERVER_NAME' => 'localhost',
+                ],
+            ),
+        );
+
+        self::assertSame(
+            'api.example-service.com',
+            $request->getRemoteHost(),
+            "Remote host should correctly return domain name from PSR-7 'serverParams' when 'REMOTE_HOST' contains " .
+            'a valid hostname.',
         );
     }
 

--- a/tests/adapter/ServerRequestAdapterTest.php
+++ b/tests/adapter/ServerRequestAdapterTest.php
@@ -42,6 +42,7 @@ final class ServerRequestAdapterTest extends TestCase
             "Should return CSRF token from adapter headers when adapter is not 'null'",
         );
     }
+
     public function testIndependentRequestsWithDifferentRemoteHosts(): void
     {
         $host1 = 'client1.example.com';

--- a/tests/http/RequestTest.php
+++ b/tests/http/RequestTest.php
@@ -1705,9 +1705,7 @@ final class RequestTest extends TestCase
         $request = new Request();
 
         $this->expectException(TypeError::class);
-        $this->expectExceptionMessage(
-            Request::class . '::getRemoteHost(): Return value must be of type ?string, int returned',
-        );
+        $this->expectExceptionMessageMatches('/getRemoteHost\(\): Return value must be of type \?string/');
 
         $request->getRemoteHost();
     }

--- a/tests/http/RequestTest.php
+++ b/tests/http/RequestTest.php
@@ -6,6 +6,7 @@ namespace yii2\extensions\psrbridge\tests\http;
 
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group, TestWith};
 use stdClass;
+use TypeError;
 use Yii;
 use yii\base\InvalidConfigException;
 use yii\web\{JsonParser, NotFoundHttpException};
@@ -701,7 +702,7 @@ final class RequestTest extends TestCase
         self::assertEquals(
             $expected,
             $request->getIsAjax(),
-            '\'getIsAjax()\' should return the expected value based on the simulated \'$_SERVER\' input.',
+            "'getIsAjax()' should return the expected value based on the simulated \$_SERVER input.",
         );
 
         $_SERVER = $original;
@@ -721,7 +722,7 @@ final class RequestTest extends TestCase
         self::assertEquals(
             $expected,
             $request->getIsPjax(),
-            '\'getIsPjax()\' should return the expected value based on the simulated \'$_SERVER\' input.',
+            "'getIsPjax()' should return the expected value based on the simulated \$_SERVER input.",
         );
 
         $_SERVER = $original;
@@ -842,7 +843,7 @@ final class RequestTest extends TestCase
         self::assertEquals(
             $expected,
             $request->getMethod(),
-            '\'getMethod()\' should return the expected value based on the simulated \'$_SERVER\' input.',
+            "'getMethod()' should return the expected value based on the simulated \$_SERVER input.",
         );
 
         $_SERVER = $original;
@@ -1615,6 +1616,37 @@ final class RequestTest extends TestCase
         );
     }
 
+    public function testReturnNullFromParentWhenRemoteHostNotSetInServerGlobals(): void
+    {
+        unset($_SERVER['REMOTE_HOST']);
+
+        $request = new Request();
+
+        $result = $request->getRemoteHost();
+
+        self::assertNull(
+            $result,
+            "Remote host should return 'null' from parent implementation when PSR-7 adapter is not set and " .
+            "'REMOTE_HOST' is not present in \$_SERVER.",
+        );
+    }
+
+    public function testReturnParentRemoteHostWhenAdapterIsNull(): void
+    {
+        $_SERVER['REMOTE_HOST'] = 'parent.host.com';
+
+        $request = new Request();
+
+        $result = $request->getRemoteHost();
+
+        self::assertSame(
+            'parent.host.com',
+            $result,
+            'Remote host should return the value from parent implementation when PSR-7 adapter is not set and ' .
+            "'REMOTE_HOST' is present in \$_SERVER.",
+        );
+    }
+
     public function testSetHostInfo(): void
     {
         $request = new Request();
@@ -1664,6 +1696,20 @@ final class RequestTest extends TestCase
         $this->expectExceptionMessage('Unable to determine the request URI.');
 
         $request->getUrl();
+    }
+
+    public function testThrowTypeErrorWhenRemoteHostIsNotStringOrNull(): void
+    {
+        $_SERVER['REMOTE_HOST'] = 456;
+
+        $request = new Request();
+
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage(
+            Request::class . '::getRemoteHost(): Return value must be of type ?string, int returned',
+        );
+
+        $request->getRemoteHost();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a method to retrieve the remote host name for the current request, supporting both PSR-7 and Yii2 environments.

* **Tests**
  * Expanded test coverage for remote host retrieval, including various scenarios such as IPv4, IPv6, domain names, and handling of missing or invalid values.
  * Added tests to ensure correct behavior when the PSR-7 adapter is not set and strict type enforcement for return values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->