### PR TITLE
refactor(tests): Move server parameter tests to new `ServerParamsPsr7Test` class for better organization and clarity.

### DIFF
--- a/tests/adapter/ServerParamsPsr7Test.php
+++ b/tests/adapter/ServerParamsPsr7Test.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\psrbridge\tests\adapter;
+
+use PHPUnit\Framework\Attributes\Group;
+use yii2\extensions\psrbridge\http\Request;
+use yii2\extensions\psrbridge\tests\support\FactoryHelper;
+use yii2\extensions\psrbridge\tests\TestCase;
+
+#[Group('http')]
+#[Group('psr7-request')]
+#[Group('server-params')]
+final class ServerParamsPsr7Test extends TestCase
+{
+    public function testReturnEmptyServerParamsWhenAdapterIsSet(): void
+    {
+        $_SERVER = [
+            'REMOTE_ADDR' => '192.168.1.100',
+            'REQUEST_TIME' => '1234567890',
+            'SERVER_NAME' => 'old.example.com',
+        ];
+
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', 'https://old.example.com/api'),
+        );
+
+        self::assertEmpty(
+            $request->getServerParams(),
+            'Server parameters should be an empty array when using a PSR-7 request, ignoring global $_SERVER.',
+        );
+    }
+
+    public function testReturnServerParamsFromPsr7RequestOverridesGlobalServer(): void
+    {
+        $_SERVER = [
+            'REMOTE_ADDR' => '192.168.1.100',
+            'REQUEST_TIME' => '1234567890',
+            'SERVER_NAME' => 'old.example.com',
+        ];
+
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest(
+                'GET',
+                'https://old.example.com/api',
+                serverParams: [
+                    'HTTP_X_FORWARDED_FOR' => '203.0.113.1',
+                    'REMOTE_ADDR' => '10.0.0.50',
+                    'REQUEST_TIME' => null,
+                    'SERVER_NAME' => 'new.example.com',
+                ],
+            ),
+        );
+
+        $serverParams = $request->getServerParams();
+
+        self::assertSame(
+            '10.0.0.50',
+            $serverParams['REMOTE_ADDR'] ?? null,
+            "Server parameter 'REMOTE_ADDR' should be taken from PSR-7 'serverParams', not from global \$_SERVER.",
+        );
+        self::assertNull(
+            $serverParams['REQUEST_TIME'] ?? null,
+            "Server parameter 'REQUEST_TIME' should be 'null' when not set in PSR-7 'serverParams', even if present " .
+            'in global $_SERVER.',
+        );
+    }
+
+    public function testReturnServerParamsFromPsr7RequestWhenAdapterIsSet(): void
+    {
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest(
+                'GET',
+                'https://old.example.com/api',
+                serverParams: [
+                    'HTTP_X_FORWARDED_FOR' => '203.0.113.1',
+                    'REQUEST_TIME' => '1234567890',
+                ],
+            ),
+        );
+
+        $serverParams = $request->getServerParams();
+
+        self::assertSame(
+            '203.0.113.1',
+            $serverParams['HTTP_X_FORWARDED_FOR'] ?? null,
+            "'HTTP_X_FORWARDED_FOR' should match the value from PSR-7 'serverParams'.",
+        );
+        self::assertSame(
+            '1234567890',
+            $serverParams['REQUEST_TIME'] ?? null,
+            "'REQUEST_TIME' should match the value from PSR-7 'serverParams'.",
+        );
+        self::assertNull(
+            $serverParams['REMOTE_ADDR'] ?? null,
+            "'REMOTE_ADDR' should not be set when not present in PSR-7 'serverParams'.",
+        );
+    }
+}

--- a/tests/adapter/ServerParamsPsr7Test.php
+++ b/tests/adapter/ServerParamsPsr7Test.php
@@ -59,6 +59,16 @@ final class ServerParamsPsr7Test extends TestCase
 
         $serverParams = $request->getServerParams();
 
+        self::assertCount(
+            4,
+            $serverParams,
+            "Only parameters present in PSR-7 'serverParams' should be returned.",
+        );
+        self::assertSame(
+            '203.0.113.1',
+            $serverParams['HTTP_X_FORWARDED_FOR'] ?? null,
+            "'HTTP_X_FORWARDED_FOR' should be taken from PSR-7 'serverParams'.",
+        );
         self::assertSame(
             '10.0.0.50',
             $serverParams['REMOTE_ADDR'] ?? null,
@@ -66,8 +76,13 @@ final class ServerParamsPsr7Test extends TestCase
         );
         self::assertNull(
             $serverParams['REQUEST_TIME'] ?? null,
-            "Server parameter 'REQUEST_TIME' should be 'null' when not set in PSR-7 'serverParams', even if present " .
-            'in global $_SERVER.',
+            "Server parameter 'REQUEST_TIME' should be 'null' when explicitly set to 'null' in PSR-7 'serverParams', " .
+            'even if present in global $_SERVER.',
+        );
+        self::assertSame(
+            'new.example.com',
+            $serverParams['SERVER_NAME'] ?? null,
+            "'SERVER_NAME' should be taken from PSR-7 'serverParams'.",
         );
     }
 
@@ -88,6 +103,11 @@ final class ServerParamsPsr7Test extends TestCase
 
         $serverParams = $request->getServerParams();
 
+        self::assertCount(
+            2,
+            $serverParams,
+            "Only parameters present in PSR-7 'serverParams' should be returned.",
+        );
         self::assertSame(
             '203.0.113.1',
             $serverParams['HTTP_X_FORWARDED_FOR'] ?? null,

--- a/tests/adapter/ServerRequestAdapterTest.php
+++ b/tests/adapter/ServerRequestAdapterTest.php
@@ -587,26 +587,6 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
-    public function testReturnEmptyServerParamsWhenAdapterIsSet(): void
-    {
-        $_SERVER = [
-            'REMOTE_ADDR' => '192.168.1.100',
-            'REQUEST_TIME' => '1234567890',
-            'SERVER_NAME' => 'old.example.com',
-        ];
-
-        $request = new Request();
-
-        $request->setPsr7Request(
-            FactoryHelper::createRequest('GET', 'https://old.example.com/api'),
-        );
-
-        self::assertEmpty(
-            $request->getServerParams(),
-            'Server parameters should be an empty array when using a PSR-7 request, ignoring global $_SERVER.',
-        );
-    }
-
     public function testReturnEmptyStringFromHeaderWhenCsrfHeaderPresentButEmpty(): void
     {
         $request = new Request();
@@ -1547,76 +1527,6 @@ final class ServerRequestAdapterTest extends TestCase
             'test_value',
             $request->getServerParam('TEST_PARAM'),
             "'getServerParam()' should return the value from PSR-7 'serverParams'.",
-        );
-    }
-
-    public function testReturnServerParamsFromPsr7RequestOverridesGlobalServer(): void
-    {
-        $_SERVER = [
-            'REMOTE_ADDR' => '192.168.1.100',
-            'REQUEST_TIME' => '1234567890',
-            'SERVER_NAME' => 'old.example.com',
-        ];
-
-        $request = new Request();
-
-        $request->setPsr7Request(
-            FactoryHelper::createRequest(
-                'GET',
-                'https://old.example.com/api',
-                serverParams: [
-                    'HTTP_X_FORWARDED_FOR' => '203.0.113.1',
-                    'REMOTE_ADDR' => '10.0.0.50',
-                    'REQUEST_TIME' => null,
-                    'SERVER_NAME' => 'new.example.com',
-                ],
-            ),
-        );
-
-        $serverParams = $request->getServerParams();
-
-        self::assertSame(
-            '10.0.0.50',
-            $serverParams['REMOTE_ADDR'] ?? null,
-            "Server parameter 'REMOTE_ADDR' should be taken from PSR-7 'serverParams', not from global \$_SERVER.",
-        );
-        self::assertNull(
-            $serverParams['REQUEST_TIME'] ?? null,
-            "Server parameter 'REQUEST_TIME' should be 'null' when not set in PSR-7 'serverParams', even if present " .
-            'in global $_SERVER.',
-        );
-    }
-
-    public function testReturnServerParamsFromPsr7RequestWhenAdapterIsSet(): void
-    {
-        $request = new Request();
-
-        $request->setPsr7Request(
-            FactoryHelper::createRequest(
-                'GET',
-                'https://old.example.com/api',
-                serverParams: [
-                    'HTTP_X_FORWARDED_FOR' => '203.0.113.1',
-                    'REQUEST_TIME' => '1234567890',
-                ],
-            ),
-        );
-
-        $serverParams = $request->getServerParams();
-
-        self::assertSame(
-            '203.0.113.1',
-            $serverParams['HTTP_X_FORWARDED_FOR'] ?? null,
-            "'HTTP_X_FORWARDED_FOR' should match the value from PSR-7 'serverParams'.",
-        );
-        self::assertSame(
-            '1234567890',
-            $serverParams['REQUEST_TIME'] ?? null,
-            "'REQUEST_TIME' should match the value from PSR-7 'serverParams'.",
-        );
-        self::assertNull(
-            $serverParams['REMOTE_ADDR'] ?? null,
-            "'REMOTE_ADDR' should not be set when not present in PSR-7 'serverParams'.",
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new tests to verify server parameter handling when using PSR-7 requests.
  * Relocated related test cases to a dedicated test class for improved organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->