### PR TITLE
refactor(Request): Update `getServerParam()` method to return mixed type and improve handling of server parameters. Add tests for `null` and existing parameters in `ServerParamsPsr7Test` class.

### DIFF
--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -566,13 +566,11 @@ final class Request extends \yii\web\Request
      *
      * @param string $name Name of the server parameter to retrieve.
      *
-     * @return string|null Value of the server parameter as a string, or `null` if not set or not a string.
+     * @return mixed Value of the server parameter as a string, or `null` if not set or not a string.
      */
-    public function getServerParam(string $name): string|null
+    public function getServerParam(string $name): mixed
     {
-        $serverParam = $this->getServerParams()[$name] ?? null;
-
-        return is_string($serverParam) ? $serverParam : null;
+        return $this->getServerParams()[$name] ?? null;
     }
 
     /**

--- a/tests/adapter/ServerParamsPsr7Test.php
+++ b/tests/adapter/ServerParamsPsr7Test.php
@@ -113,6 +113,21 @@ final class ServerParamsPsr7Test extends TestCase
         );
     }
 
+    #[Group('server-param')]
+    public function testReturnNullWhenServerParamNotPresentInPsr7Request(): void
+    {
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/test'),
+        );
+
+        self::assertNull(
+            $request->getServerParam('TEST_PARAM'),
+            "'getServerParam()' should return 'null' when the parameter is not present in PSR-7 'serverParams'.",
+        );
+    }
+
     #[DataProviderExternal(RequestProvider::class, 'remoteHostCases')]
     #[Group('remote-host')]
     public function testReturnRemoteHostFromServerParamsCases(mixed $serverValue, string|null $expected): void
@@ -158,6 +173,22 @@ final class ServerParamsPsr7Test extends TestCase
                 var_export($serverValue, true),
                 var_export($actual, true),
             ),
+        );
+    }
+
+    #[Group('server-param')]
+    public function testReturnServerParamFromPsr7RequestWhenAdapterIsSet(): void
+    {
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/test', serverParams: ['TEST_PARAM' => 'test_value']),
+        );
+
+        self::assertSame(
+            'test_value',
+            $request->getServerParam('TEST_PARAM'),
+            "'getServerParam()' should return the value from PSR-7 'serverParams'.",
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
