### PR TITLE
refactor(Request): Enhance `getRemoteIP()` method to validate the remote IP address and improve handling of server parameters. Add tests for retrieving remote IP from PSR-7 server parameters in `ServerParamsPsr7Test` class.

### DIFF
--- a/tests/adapter/ServerParamsPsr7Test.php
+++ b/tests/adapter/ServerParamsPsr7Test.php
@@ -137,6 +137,47 @@ final class ServerParamsPsr7Test extends TestCase
         );
     }
 
+    public function testReturnRemoteIPFromPsr7ServerParams(): void
+    {
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest(
+                'GET',
+                'https://old.example.com/api',
+                serverParams: ['REMOTE_ADDR' => '192.168.1.100'],
+            ),
+        );
+
+        self::assertSame(
+            '192.168.1.100',
+            $request->getRemoteIP(),
+            "'getRemoteIP()' should return the 'REMOTE_ADDR' value from PSR-7 'serverParams'.",
+        );
+    }
+
+    public function testReturnRemoteIPFromPsr7ServerParamsOverridesGlobalServer(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '192.168.1.100';
+
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest(
+                'GET',
+                'https://old.example.com/api',
+                serverParams: ['REMOTE_ADDR' => '10.0.0.1'],
+            ),
+        );
+
+        self::assertSame(
+            '10.0.0.1',
+            $request->getRemoteIP(),
+            "'getRemoteIP()' should return the 'REMOTE_ADDR' value from PSR-7 'serverParams', not from global " .
+            '$_SERVER.',
+        );
+    }
+
     #[DataProviderExternal(RequestProvider::class, 'serverNameCases')]
     #[Group('server-name')]
     public function testReturnServerNameFromServerParamsCases(mixed $serverValue, string|null $expected): void

--- a/tests/adapter/ServerRequestAdapterTest.php
+++ b/tests/adapter/ServerRequestAdapterTest.php
@@ -1179,47 +1179,6 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
-    public function testReturnRemoteIPFromPsr7ServerParams(): void
-    {
-        $request = new Request();
-
-        $request->setPsr7Request(
-            FactoryHelper::createRequest(
-                'GET',
-                'https://old.example.com/api',
-                serverParams: ['REMOTE_ADDR' => '192.168.1.100'],
-            ),
-        );
-
-        self::assertSame(
-            '192.168.1.100',
-            $request->getRemoteIP(),
-            "'getRemoteIP()' should return the 'REMOTE_ADDR' value from PSR-7 'serverParams'.",
-        );
-    }
-
-    public function testReturnRemoteIPFromPsr7ServerParamsOverridesGlobalServer(): void
-    {
-        $_SERVER['REMOTE_ADDR'] = '192.168.1.100';
-
-        $request = new Request();
-
-        $request->setPsr7Request(
-            FactoryHelper::createRequest(
-                'GET',
-                'https://old.example.com/api',
-                serverParams: ['REMOTE_ADDR' => '10.0.0.1'],
-            ),
-        );
-
-        self::assertSame(
-            '10.0.0.1',
-            $request->getRemoteIP(),
-            "'getRemoteIP()' should return the 'REMOTE_ADDR' value from PSR-7 'serverParams', not from global " .
-            '$_SERVER.',
-        );
-    }
-
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
