### PR TITLE
refactor(Request): Remove `getScriptUrl()` method for `ServerRequestAdapter` class and related tests; introduce `getScriptName()` for improved script URL handling in PSR-7 and Yii2 environments.

### DIFF
--- a/src/adapter/ServerRequestAdapter.php
+++ b/src/adapter/ServerRequestAdapter.php
@@ -282,40 +282,6 @@ final class ServerRequestAdapter
     }
 
     /**
-     * Retrieves the script URL from server parameters, supporting both SAPI and worker environments.
-     *
-     * Returns the value of 'SCRIPT_NAME' from server parameters for traditional SAPI-based PSR-7 Application.
-     *
-     * For worker-based environments (such as RoadRunner, FrankenPHP), returns an empty string to prevent URL
-     * duplication, as routing is handled internally and no script file exists.
-     *
-     * This method ensures compatibility with both classic and modern PHP runtimes, providing the correct script URL
-     * context for Yii2 Routing and Request processing.
-     *
-     * @param bool $workerMode Whether the application is running in worker mode (RoadRunner, FrankenPHP, etc.).
-     *
-     * @return string Script URL of SAPI environments, or empty string for worker mode.
-     *
-     * Usage example:
-     * ```php
-     * $scriptUrl = $adapter->getScriptUrl(false);
-     * ```
-     */
-    public function getScriptUrl(bool $workerMode): string
-    {
-        $serverParams = $this->getServerParams();
-
-        // for traditional PSR-7 apps where 'SCRIPT_NAME' is available
-        if ($workerMode === false && isset($serverParams['SCRIPT_NAME']) && is_string($serverParams['SCRIPT_NAME'])) {
-            return $serverParams['SCRIPT_NAME'];
-        }
-
-        // for PSR-7 workers (RoadRunner, FrankenPHP, etc.) where no script file exists
-        // return empty to prevent URL duplication as routing is handled internally
-        return '';
-    }
-
-    /**
      * Retrieves server parameters from the PSR-7 ServerRequestInterface.
      *
      * Returns the server parameters as provided by the underlying PSR-7 ServerRequestInterface instance.

--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -777,7 +777,7 @@ final class Request extends \yii\web\Request
      *
      * @phpstan-param array<array-key, mixed> $uploadedFiles Array of uploaded files or nested arrays to convert.
      *
-     * @phpstan-return array<array<UploadedFile>, mixed>
+     * @phpstan-return array<UploadedFile[], mixed>
      */
     private function convertPsr7ToUploadedFiles(array $uploadedFiles): array
     {

--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -514,14 +514,15 @@ final class Request extends \yii\web\Request
     /**
      * Retrieves the script URL for the current request, supporting PSR-7 and Yii2 fallback.
      *
-     * Returns the script URL as an empty string for PSR-7 worker environments (such as RoadRunner, FrankenPHP, etc.)
-     * where no script file exists, preventing URL duplication as routing is handled internally. If not in worker mode,
-     * return the script name. Falls back to the parent implementation if no PSR-7 adapter is set.
+     * In worker environments (RoadRunner, FrankenPHP, etc.) with a PSR-7 adapter set, returns an empty string, since no
+     * script file exists and routing is handled by the worker.
+     *
+     * In traditional mode, returns 'SCRIPT_NAME'. Falls back to the parent implementation if no PSR-7 adapter is set.
      *
      * This method enables seamless interoperability with both PSR-7 and Yii2 environments, ensuring the correct script
      * URL resolution for modern HTTP stacks and legacy workflows.
      *
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     * @throws InvalidConfigException if unable to determine the entry script URL.
      *
      * @return string Script URL for the current request, or an empty string in worker mode.
      *
@@ -532,10 +533,11 @@ final class Request extends \yii\web\Request
      */
     public function getScriptUrl(): string
     {
-        return match ($this->adapter !== null) {
-            true => $this->workerMode === true ? '' : $this->getScriptName(),
-            default => parent::getScriptUrl(),
-        };
+        if ($this->adapter !== null) {
+            return $this->workerMode ? '' : $this->getScriptName();
+        }
+
+        return parent::getScriptUrl();
     }
 
     /**
@@ -589,7 +591,9 @@ final class Request extends \yii\web\Request
      */
     public function getServerParam(string $name, mixed $default = null): mixed
     {
-        return array_key_exists($name, $this->getServerParams()) ? $this->getServerParams()[$name] : $default;
+        $params = $this->getServerParams();
+
+        return array_key_exists($name, $params) ? $params[$name] : $default;
     }
 
     /**

--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -632,7 +632,7 @@ final class Request extends \yii\web\Request
      *
      * @return array Array of uploaded files for the current request.
      *
-     * @phpstan-return array<UploadedFile[], mixed>
+     * @phpstan-return array<array<array-key, UploadedFile>, mixed>
      *
      * Usage example:
      * ```php
@@ -777,7 +777,7 @@ final class Request extends \yii\web\Request
      *
      * @phpstan-param array<array-key, mixed> $uploadedFiles Array of uploaded files or nested arrays to convert.
      *
-     * @phpstan-return array<UploadedFile[], mixed>
+     * @phpstan-return array<array<array-key, UploadedFile>, mixed>
      */
     private function convertPsr7ToUploadedFiles(array $uploadedFiles): array
     {

--- a/tests/adapter/ServerParamsPsr7Test.php
+++ b/tests/adapter/ServerParamsPsr7Test.php
@@ -93,6 +93,40 @@ final class ServerParamsPsr7Test extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnEmptyScriptUrlWhenAdapterIsSetInTraditionalModeWithoutScriptName(): void
+    {
+        $request = new Request(['workerMode' => false]);
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/test'),
+        );
+
+        self::assertEmpty(
+            $request->getScriptUrl(),
+            "Script URL should be empty when adapter is set in traditional mode without 'SCRIPT_NAME'.",
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnEmptyScriptUrlWhenAdapterIsSetInWorkerMode(): void
+    {
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/test'),
+        );
+
+        self::assertEmpty(
+            $request->getScriptUrl(),
+            "Script URL should be empty when adapter is set in 'worker' mode (default).",
+        );
+    }
+
     #[Group('server-params')]
     public function testReturnEmptyServerParamsWhenAdapterIsSet(): void
     {
@@ -182,6 +216,26 @@ final class ServerParamsPsr7Test extends TestCase
                 var_export($serverValue, true),
                 var_export($actual, true),
             ),
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnScriptNameWhenAdapterIsSetInTraditionalMode(): void
+    {
+        $expectedScriptName = '/app/public/index.php';
+
+        $request = new Request(['workerMode' => false]);
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/test', serverParams: ['SCRIPT_NAME' => $expectedScriptName]),
+        );
+
+        self::assertSame(
+            $expectedScriptName,
+            $request->getScriptUrl(),
+            "Script URL should return 'SCRIPT_NAME' when adapter is set in traditional mode.",
         );
     }
 
@@ -440,60 +494,6 @@ final class ServerParamsPsr7Test extends TestCase
             $result1,
             $result2,
             'Independent request instances should return different server names when configured with different values.',
-        );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testReturnEmptyScriptUrlWhenAdapterIsSetInTraditionalModeWithoutScriptName(): void
-    {
-        $request = new Request(['workerMode' => false]);
-
-        $request->setPsr7Request(
-            FactoryHelper::createRequest('GET', '/test'),
-        );
-
-        self::assertEmpty(
-            $request->getScriptUrl(),
-            "Script URL should be empty when adapter is set in traditional mode without 'SCRIPT_NAME'.",
-        );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testReturnEmptyScriptUrlWhenAdapterIsSetInWorkerMode(): void
-    {
-        $request = new Request();
-
-        $request->setPsr7Request(
-            FactoryHelper::createRequest('GET', '/test'),
-        );
-
-        self::assertEmpty(
-            $request->getScriptUrl(),
-            "Script URL should be empty when adapter is set in 'worker' mode (default).",
-        );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testReturnScriptNameWhenAdapterIsSetInTraditionalMode(): void
-    {
-        $expectedScriptName = '/app/public/index.php';
-
-        $request = new Request(['workerMode' => false]);
-
-        $request->setPsr7Request(
-            FactoryHelper::createRequest('GET', '/test', serverParams: ['SCRIPT_NAME' => $expectedScriptName]),
-        );
-
-        self::assertSame(
-            $expectedScriptName,
-            $request->getScriptUrl(),
-            "Script URL should return 'SCRIPT_NAME' when adapter is set in traditional mode.",
         );
     }
 }

--- a/tests/adapter/ServerParamsPsr7Test.php
+++ b/tests/adapter/ServerParamsPsr7Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace yii2\extensions\psrbridge\tests\adapter;
 
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use yii\base\InvalidConfigException;
 use yii2\extensions\psrbridge\http\Request;
 use yii2\extensions\psrbridge\tests\provider\RequestProvider;
 use yii2\extensions\psrbridge\tests\support\FactoryHelper;
@@ -439,6 +440,60 @@ final class ServerParamsPsr7Test extends TestCase
             $result1,
             $result2,
             'Independent request instances should return different server names when configured with different values.',
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnEmptyScriptUrlWhenAdapterIsSetInTraditionalModeWithoutScriptName(): void
+    {
+        $request = new Request(['workerMode' => false]);
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/test'),
+        );
+
+        self::assertEmpty(
+            $request->getScriptUrl(),
+            "Script URL should be empty when adapter is set in traditional mode without 'SCRIPT_NAME'.",
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnEmptyScriptUrlWhenAdapterIsSetInWorkerMode(): void
+    {
+        $request = new Request();
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/test'),
+        );
+
+        self::assertEmpty(
+            $request->getScriptUrl(),
+            "Script URL should be empty when adapter is set in 'worker' mode (default).",
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnScriptNameWhenAdapterIsSetInTraditionalMode(): void
+    {
+        $expectedScriptName = '/app/public/index.php';
+
+        $request = new Request(['workerMode' => false]);
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest('GET', '/test', serverParams: ['SCRIPT_NAME' => $expectedScriptName]),
+        );
+
+        self::assertSame(
+            $expectedScriptName,
+            $request->getScriptUrl(),
+            "Script URL should return 'SCRIPT_NAME' when adapter is set in traditional mode.",
         );
     }
 }

--- a/tests/adapter/ServerRequestAdapterTest.php
+++ b/tests/adapter/ServerRequestAdapterTest.php
@@ -477,40 +477,6 @@ final class ServerRequestAdapterTest extends TestCase
         );
     }
 
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testReturnEmptyScriptUrlWhenAdapterIsSetInTraditionalModeWithoutScriptName(): void
-    {
-        $request = new Request(['workerMode' => false]);
-
-        $request->setPsr7Request(
-            FactoryHelper::createRequest('GET', '/test'),
-        );
-
-        self::assertEmpty(
-            $request->getScriptUrl(),
-            "Script URL should be empty when adapter is set in traditional mode without 'SCRIPT_NAME'.",
-        );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testReturnEmptyScriptUrlWhenAdapterIsSetInWorkerMode(): void
-    {
-        $request = new Request();
-
-        $request->setPsr7Request(
-            FactoryHelper::createRequest('GET', '/test'),
-        );
-
-        self::assertEmpty(
-            $request->getScriptUrl(),
-            "Script URL should be empty when adapter is set in 'worker' mode (default).",
-        );
-    }
-
     public function testReturnEmptyStringFromHeaderWhenCsrfHeaderPresentButEmpty(): void
     {
         $request = new Request();
@@ -1176,26 +1142,6 @@ final class ServerRequestAdapterTest extends TestCase
         self::assertEmpty(
             $request->getRawBody(),
             'Raw body should return empty string when PSR-7 request has no body content.',
-        );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testReturnScriptNameWhenAdapterIsSetInTraditionalMode(): void
-    {
-        $expectedScriptName = '/app/public/index.php';
-
-        $request = new Request(['workerMode' => false]);
-
-        $request->setPsr7Request(
-            FactoryHelper::createRequest('GET', '/test', serverParams: ['SCRIPT_NAME' => $expectedScriptName]),
-        );
-
-        self::assertSame(
-            $expectedScriptName,
-            $request->getScriptUrl(),
-            "Script URL should return 'SCRIPT_NAME' when adapter is set in traditional mode.",
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved and clarified documentation for request methods, including enhanced type annotations and usage examples.

* **Bug Fixes**
  * Refined script URL handling in worker and traditional modes to better support PSR-7 and Yii2 environments, ensuring correct behavior when certain server parameters are missing.

* **Tests**
  * Added new tests to verify script URL behavior under various adapter modes and server parameter scenarios.
  * Removed outdated tests related to script URL retrieval from the adapter test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->