### PR TITLE
refactor(tests): Update PHPStan parameter types for headers in `FactoryHelper` class for improved type safety.

### DIFF
--- a/tests/support/FactoryHelper.php
+++ b/tests/support/FactoryHelper.php
@@ -61,7 +61,7 @@ final class FactoryHelper
      * FactoryHelper::createRequest($method, $uri, $headers, $parsedBody, $serverParams);
      * ```
      *
-     * @phpstan-param array<string, int|string> $headers
+     * @phpstan-param array<string, array<int, string>|int|string> $headers
      * @phpstan-param array<string, mixed> $serverParams
      * @phpstan-param array<string, mixed>|object|null $parsedBody
      */

--- a/tests/support/FactoryHelper.php
+++ b/tests/support/FactoryHelper.php
@@ -61,7 +61,7 @@ final class FactoryHelper
      * FactoryHelper::createRequest($method, $uri, $headers, $parsedBody, $serverParams);
      * ```
      *
-     * @phpstan-param array<string, string> $headers
+     * @phpstan-param array<string, int|string> $headers
      * @phpstan-param array<string, mixed> $serverParams
      * @phpstan-param array<string, mixed>|object|null $parsedBody
      */
@@ -104,7 +104,7 @@ final class FactoryHelper
      * FactoryHelper::createResponse($statusCode, $headers, $body, $protocol, $reasonPhrase);
      * ```
      *
-     * @phpstan-param array<string, array<int, string>|string> $headers
+     * @phpstan-param array<string, array<int, string>|int|string> $headers
      */
     public static function createResponse(
         int $statusCode = 200,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test helper methods to accept a wider range of header value types for requests and responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->