### PR TITLE
refactor(tests): Remove redundant group psr7-request attribute from multiple test classes for improved clarity and organization.

### DIFF
--- a/tests/adapter/CookiesPsr7Test.php
+++ b/tests/adapter/CookiesPsr7Test.php
@@ -13,7 +13,6 @@ use yii2\extensions\psrbridge\tests\support\FactoryHelper;
 use yii2\extensions\psrbridge\tests\TestCase;
 
 #[Group('adapter')]
-#[Group('psr7-request')]
 #[Group('cookies')]
 final class CookiesPsr7Test extends TestCase
 {

--- a/tests/adapter/HeadersPsr7Test.php
+++ b/tests/adapter/HeadersPsr7Test.php
@@ -10,7 +10,6 @@ use yii2\extensions\psrbridge\tests\support\FactoryHelper;
 use yii2\extensions\psrbridge\tests\TestCase;
 
 #[Group('adapter')]
-#[Group('psr7-request')]
 final class HeadersPsr7Test extends TestCase
 {
     #[Group('csrf-token')]

--- a/tests/adapter/ResponseAdapterTest.php
+++ b/tests/adapter/ResponseAdapterTest.php
@@ -29,7 +29,7 @@ use function time;
 use function unlink;
 use function urlencode;
 
-#[Group('http')]
+#[Group('adapter')]
 final class ResponseAdapterTest extends TestCase
 {
     protected function tearDown(): void

--- a/tests/adapter/ServerParamsPsr7Test.php
+++ b/tests/adapter/ServerParamsPsr7Test.php
@@ -15,7 +15,6 @@ use function sprintf;
 use function var_export;
 
 #[Group('adapter')]
-#[Group('psr7-request')]
 final class ServerParamsPsr7Test extends TestCase
 {
     #[Group('remote-host')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test group annotations for improved organization.
  * Removed certain group annotations from multiple test classes.
  * Changed the group annotation for one test class to a different group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->