### PR TITLE
refactor(tests): Add comprehensive tests for `getServerPort()` method  in `Request` class to ensure correct handling of forwarded ports and server parameters.

### DIFF
--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -646,9 +646,11 @@ final class Request extends \yii\web\Request
     public function getServerPort(): int|null
     {
         if ($this->adapter !== null) {
+            $headers = $this->getHeaders();
+
             foreach ($this->portHeaders as $portHeader) {
-                if ($this->headers->has($portHeader)) {
-                    $port = $this->headers->get($portHeader);
+                if ($headers->has($portHeader)) {
+                    $port = $headers->get($portHeader);
 
                     if (is_numeric($port)) {
                         return (int) $port;

--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -17,6 +17,7 @@ use function count;
 use function explode;
 use function filter_var;
 use function is_array;
+use function is_numeric;
 use function is_string;
 use function mb_check_encoding;
 use function mb_substr;
@@ -622,6 +623,45 @@ final class Request extends \yii\web\Request
 
         // fallback to '$_SERVER' for non-PSR7 environments
         return $_SERVER;
+    }
+
+    /**
+     * Retrieves the server port number for the current request, supporting PSR-7 and Yii2 fallback.
+     *
+     * Returns the port number as determined by the PSR-7 adapter if present, checking configured port headers and
+     * falling back to the 'SERVER_PORT' server parameter if no header is found.
+     *
+     * If no adapter is set, this method falls back to the parent implementation.
+     *
+     * This enables seamless access to the server port in both PSR-7 and Yii2 environments, supporting interoperability
+     * with modern HTTP stacks and legacy workflows.
+     *
+     * @return int|null Server port number, or `null` if unavailable.
+     *
+     * Usage example:
+     * ```php
+     * $port = $request->getServerPort();
+     * ```
+     */
+    public function getServerPort(): int|null
+    {
+        if ($this->adapter !== null) {
+            foreach ($this->portHeaders as $portHeader) {
+                if ($this->headers->has($portHeader)) {
+                    $port = $this->headers->get($portHeader);
+
+                    if (is_numeric($port)) {
+                        return (int) $port;
+                    }
+                }
+            }
+
+            $port = $this->getServerParam('SERVER_PORT');
+
+            return is_numeric($port) ? (int) $port : null;
+        }
+
+        return parent::getServerPort();
     }
 
     /**

--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -650,10 +650,19 @@ final class Request extends \yii\web\Request
 
             foreach ($this->portHeaders as $portHeader) {
                 if ($headers->has($portHeader)) {
-                    $port = $headers->get($portHeader);
+                    $headerPort = $headers->get($portHeader);
 
-                    if (is_numeric($port)) {
-                        return (int) $port;
+                    if (is_string($headerPort)) {
+                        $ports = explode(',', $headerPort);
+                        $firstPort = trim($ports[0]);
+
+                        if (is_numeric($firstPort)) {
+                            $port = (int) $firstPort;
+
+                            if ($port >= 1 && $port <= 65535) {
+                                return $port;
+                            }
+                        }
                     }
                 }
             }

--- a/tests/adapter/ServerParamsPsr7Test.php
+++ b/tests/adapter/ServerParamsPsr7Test.php
@@ -567,6 +567,38 @@ final class ServerParamsPsr7Test extends TestCase
     }
 
     #[Group('server-port')]
+    public function testReturnServerPortFromCommaSeparatedForwardedHeader(): void
+    {
+        $_SERVER = ['REMOTE_ADDR' => '127.0.0.1'];
+
+        $request = new Request(
+            [
+                'portHeaders' => ['X-Forwarded-Port'],
+                'secureHeaders' => ['X-Forwarded-Port'],
+                'trustedHosts' => ['127.0.0.1'],
+            ],
+        );
+
+        $request->setPsr7Request(
+            FactoryHelper::createRequest(
+                'GET',
+                '/test',
+                ['X-Forwarded-Port' => '9443, 7443'],
+                serverParams: [
+                    'REMOTE_ADDR' => '127.0.0.1',
+                    'SERVER_PORT' => '80',
+                ],
+            ),
+        );
+
+        self::assertSame(
+            9443,
+            $request->getServerPort(),
+            "'getServerPort()' should return the first port from a comma-separated 'X-Forwarded-Port' header.",
+        );
+    }
+
+    #[Group('server-port')]
     public function testReturnServerPortFromFirstValidForwardedHeaderWhenMultipleConfigured(): void
     {
         $_SERVER = ['REMOTE_ADDR' => '127.0.0.1'];

--- a/tests/adapter/ServerParamsPsr7Test.php
+++ b/tests/adapter/ServerParamsPsr7Test.php
@@ -49,6 +49,7 @@ final class ServerParamsPsr7Test extends TestCase
             "'getServerPort()' should ignore forwarded port header from untrusted hosts and use 'SERVER_PORT'.",
         );
     }
+
     #[Group('remote-host')]
     public function testIndependentRequestsWithDifferentRemoteHosts(): void
     {

--- a/tests/adapter/ServerParamsPsr7Test.php
+++ b/tests/adapter/ServerParamsPsr7Test.php
@@ -419,23 +419,6 @@ final class ServerParamsPsr7Test extends TestCase
         );
     }
 
-    #[Group('server-port')]
-    public function testReturnServerPortFromPsr7RequestWhenAdapterIsSetAndServerPortPresent(): void
-    {
-        $request = new Request();
-
-        $request->setPsr7Request(
-            FactoryHelper::createRequest('GET', '/test', serverParams: ['SERVER_PORT' => '8080']),
-        );
-
-        self::assertSame(
-            8080,
-            $request->getServerPort(),
-            "'SERVER_PORT' should return '8080' from PSR-7 'serverParams' when adapter is set and 'SERVER_PORT' is " .
-            'present as a string.',
-        );
-    }
-
     #[Group('server-name')]
     public function testServerNameAfterRequestReset(): void
     {

--- a/tests/provider/ServerParamsPsr7Provider.php
+++ b/tests/provider/ServerParamsPsr7Provider.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\psrbridge\tests\provider;
+
+final class ServerParamsPsr7Provider
+{
+    /**
+     * @phpstan-return array<
+     *   string,
+     *   array{
+     *     array<string, mixed>,
+     *     array<string, mixed>,
+     *     array<string, array<int, string>|int|string>,
+     *     array<string, mixed>,
+     *     int|null,
+     *     string,
+     *   }
+     * >
+     */
+    public static function serverPortCases(): array
+    {
+        return [
+            'Forwarded port when request from trusted proxy' => [
+                [
+                    'portHeaders' => ['X-Forwarded-Port'],
+                    'trustedHosts' => ['10.0.0.0/24'], // trust this subnet
+                ],
+                ['REMOTE_ADDR' => '10.0.0.1'],
+                ['X-Forwarded-Port' => '443'],
+                [
+                    'SERVER_PORT' => '8080',
+                    'REMOTE_ADDR' => '10.0.0.1',
+                ],
+                443,
+                "'getServerPort()' should return forwarded port when request comes from trusted proxy.",
+            ],
+            'Ignore forwarded port when request from untrusted host' => [
+                [
+                    'portHeaders' => ['X-Forwarded-Port'],
+                    'secureHeaders' => ['X-Forwarded-Port'],
+                    'trustedHosts' => ['10.0.0.0/24'], // only trust this subnet
+                ],
+                ['REMOTE_ADDR' => '192.168.1.100'],
+                ['X-Forwarded-Port' => '443'],
+                [
+                    'REMOTE_ADDR' => '192.168.1.100',
+                    'SERVER_PORT' => '8080',
+                ],
+                8080,
+                "'getServerPort()' should ignore forwarded port header from untrusted hosts and use 'SERVER_PORT'.",
+            ],
+            'Null when PSR-7 request server port is empty array' => [
+                [],
+                [],
+                [],
+                ['SERVER_PORT' => []],
+                null,
+                "'SERVER_PORT' should return 'null' from PSR-7 'serverParams' when adapter is set but 'SERVER_PORT' " .
+                'is an empty array.',
+            ],
+            'Null when PSR-7 request server port is null' => [
+                [],
+                [],
+                [],
+                ['SERVER_PORT' => null],
+                null,
+                "'SERVER_PORT' should return 'null' from PSR-7 'serverParams' when adapter is set but 'SERVER_PORT' " .
+                "is 'null'.",
+            ],
+            'Null when PSR-7 request server port is not present' => [
+                [],
+                [],
+                [],
+                ['HTTP_HOST' => 'example.com'],
+                null,
+                "'SERVER_PORT' should return 'null' from PSR-7 'serverParams' when adapter is set but 'SERVER_PORT' " .
+                'is not present.',
+            ],
+            'Null when PSR-7 request server port is not string' => [
+                [],
+                [],
+                [],
+                ['SERVER_PORT' => ['invalid' => 'array']],
+                null,
+                "'SERVER_PORT' should return 'null' from PSR-7 'serverParams' when adapter is set but 'SERVER_PORT' " .
+                'is not a string.',
+            ],
+            'Server port as integer when PSR-7 server port is numeric string' => [
+                [],
+                [],
+                [],
+                ['SERVER_PORT' => '443'],
+                443,
+                "'getServerPort()' should return integer value when 'SERVER_PORT' is a numeric string.",
+            ],
+            'Server port from comma separated forwarded header' => [
+                [
+                    'portHeaders' => ['X-Forwarded-Port'],
+                    'secureHeaders' => ['X-Forwarded-Port'],
+                    'trustedHosts' => ['127.0.0.1'],
+                ],
+                ['REMOTE_ADDR' => '127.0.0.1'],
+                ['X-Forwarded-Port' => '9443, 7443'],
+                [
+                    'REMOTE_ADDR' => '127.0.0.1',
+                    'SERVER_PORT' => '80',
+                ],
+                9443,
+                "'getServerPort()' should return the first port from a comma-separated 'X-Forwarded-Port' header.",
+            ],
+            'Server port from first valid forwarded header when multiple configured' => [
+                [
+                    'portHeaders' => [
+                        'X-Custom-Port',
+                        'X-Forwarded-Port',
+                        'X-Real-Port',
+                    ],
+                    'secureHeaders' => [
+                        'X-Custom-Port',
+                        'X-Forwarded-For',
+                        'X-Forwarded-Host',
+                        'X-Forwarded-Port',
+                        'X-Forwarded-Proto',
+                        'X-Real-Port',
+                    ],
+                    'trustedHosts' => ['127.0.0.1'],
+                ],
+                ['REMOTE_ADDR' => '127.0.0.1'],
+                [
+                    'X-Custom-Port' => '',
+                    'X-Forwarded-Port' => '9443',
+                    'X-Real-Port' => '7443',
+                ],
+                [
+                    'REMOTE_ADDR' => '127.0.0.1',
+                    'SERVER_PORT' => '80',
+                ],
+                9443,
+                "'getServerPort()' should return the port from the first valid forwarded header in the configured " .
+                'list.',
+            ],
+            'Server port from forwarded header when adapter is set' => [
+                [
+                    'portHeaders' => ['X-Forwarded-Port'],
+                    'trustedHosts' => ['127.0.0.1'],
+                ],
+                ['REMOTE_ADDR' => '127.0.0.1'],
+                ['X-Forwarded-Port' => '443'],
+                [
+                    'REMOTE_ADDR' => '127.0.0.1',
+                    'SERVER_PORT' => '8080',
+                ],
+                443,
+                "'getServerPort()' should return the port from 'X-Forwarded-Port' header when present, ignoring " .
+                "'SERVER_PORT' from PSR-7 'serverParams'.",
+            ],
+            'Server port from PSR-7 request when adapter is set and server port present' => [
+                [
+                    'portHeaders' => [
+                        'X-Custom-Port',
+                        'X-Forwarded-Port',
+                    ],
+                ],
+                [],
+                ['X-Custom-Port' => ''],
+                ['SERVER_PORT' => '3000'],
+                3000,
+                "'getServerPort()' should fallback to 'SERVER_PORT' when all forwarded headers are 'null' or missing.",
+            ],
+        ];
+    }
+}

--- a/tests/provider/ServerParamsPsr7Provider.php
+++ b/tests/provider/ServerParamsPsr7Provider.php
@@ -87,6 +87,14 @@ final class ServerParamsPsr7Provider
                 "'SERVER_PORT' should return 'null' from PSR-7 'serverParams' when adapter is set but 'SERVER_PORT' " .
                 'is not a string.',
             ],
+            'Server port as integer when PSR-7 server port.' => [
+                [],
+                [],
+                [],
+                ['SERVER_PORT' => '443'],
+                443,
+                "'getServerPort()' should return integer value when 'SERVER_PORT' is a numeric string.",
+            ],
             'Server port as integer when PSR-7 server port is numeric string' => [
                 [],
                 [],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server port detection now works with PSR-7 requests and the existing request system, respects configurable forwarded headers and trusted hosts, and falls back gracefully when headers or adapter data are unavailable.
  * Retrieval of uploaded files from PSR-7 requests with automatic conversion to native upload objects for seamless file handling.

* **Tests**
  * Added data-driven and scenario tests covering trusted/untrusted proxies, multiple forwarded headers, fallbacks, numeric casting, request resets, and independent requests with different ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->