### PR TITLE
refactor(tests): Consolidate `PHPUnit` attribute imports and add test for output buffer clearing in non-test environment.

### DIFF
--- a/tests/http/ErrorHandlerTest.php
+++ b/tests/http/ErrorHandlerTest.php
@@ -13,6 +13,8 @@ use yii2\extensions\psrbridge\http\{ErrorHandler, Response};
 use yii2\extensions\psrbridge\tests\support\stub\HTTPFunctions;
 use yii2\extensions\psrbridge\tests\TestCase;
 
+use function ob_get_level;
+use function ob_start;
 use function str_repeat;
 
 #[Group('http')]
@@ -34,13 +36,13 @@ final class ErrorHandlerTest extends TestCase
             @runkit_constant_redefine('YII_ENV_TEST', false);
 
             $errorHandler = new ErrorHandler();
-            $errorHandler->discardExistingOutput = false;
 
             ob_start();
             ob_start();
             ob_start();
 
             $levelBeforeClear = ob_get_level();
+
             self::assertGreaterThan(
                 $initialLevel,
                 $levelBeforeClear,
@@ -50,6 +52,7 @@ final class ErrorHandlerTest extends TestCase
             $errorHandler->clearOutput();
 
             $levelAfterClear = ob_get_level();
+
             self::assertSame(
                 0,
                 $levelAfterClear,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added a test ensuring output buffers are fully cleared in non-test environments, validating error-handling behavior.
  - Verifies the initial output buffering state is restored after clearing, improving stability across environments.
  - Increases coverage and guards against regressions related to output buffering without affecting UI or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->