### PR TITLE
refactor(tests): Clean up `ErrorHandler` and `StatelessApplicationTest` by removing unused code and improving error handling logic.

### DIFF
--- a/src/http/ErrorHandler.php
+++ b/src/http/ErrorHandler.php
@@ -6,15 +6,12 @@ namespace yii2\extensions\psrbridge\http;
 
 use Throwable;
 use Yii;
-use yii\base\{InvalidRouteException, UserException};
-use yii\console\Exception;
+use yii\base\{Exception, InvalidRouteException, UserException};
 use yii\helpers\VarDumper;
-use yii\web\HttpException;
 
 use function array_diff_key;
 use function array_flip;
 use function htmlspecialchars;
-use function http_response_code;
 use function ini_set;
 
 /**
@@ -119,16 +116,6 @@ final class ErrorHandler extends \yii\web\ErrorHandler
 
         $this->unregister();
 
-        if (php_sapi_name() !== 'cli') {
-            $statusCode = 500;
-
-            if ($exception instanceof HttpException) {
-                $statusCode = $exception->statusCode;
-            }
-
-            http_response_code($statusCode);
-        }
-
         try {
             $this->logException($exception);
 
@@ -175,7 +162,7 @@ final class ErrorHandler extends \yii\web\ErrorHandler
      */
     protected function handleFallbackExceptionMessage($exception, $previousException): Response
     {
-        $response = $this->createErrorResponse();
+        $response = $this->createErrorResponse()->setStatusCode(500);
 
         $msg = "An Error occurred while handling another error:\n";
         $msg .= $exception;

--- a/tests/http/ErrorHandlerTest.php
+++ b/tests/http/ErrorHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace yii2\extensions\psrbridge\tests\http;
 
-use PHPUnit\Framework\Attributes\{Group, RequiresPhpExtension, TestWith};
+use PHPUnit\Framework\Attributes\{Group, RequiresPhpExtension};
 use RuntimeException;
 use Throwable;
 use yii\base\{Exception, UserException};
@@ -145,36 +145,6 @@ final class ErrorHandlerTest extends TestCase
         self::assertNotEmpty(
             $response->data,
             'Should set response data with exception information.',
-        );
-    }
-
-    #[TestWith(['apache2handler'])]
-    #[TestWith(['cli'])]
-    public function testHandleExceptionWithHttpException(string $sapi): void
-    {
-        HTTPFunctions::set_sapi($sapi);
-
-        $errorHandler = new ErrorHandler();
-
-        $errorHandler->discardExistingOutput = false;
-
-        $exception = new HttpException(404, 'Page not found');
-
-        $response = $errorHandler->handleException($exception);
-
-        self::assertSame(
-            404,
-            $response->getStatusCode(),
-            "Should preserve HTTP status code from 'HttpException'.",
-        );
-        self::assertNotEmpty(
-            $response->data,
-            'Should set response data for HTTP exception.',
-        );
-        self::assertSame(
-            $sapi,
-            HTTPFunctions::php_sapi_name(),
-            "Should return correct SAPI name '{$sapi}' for 'HttpException'.",
         );
     }
 

--- a/tests/http/StatelessApplicationTest.php
+++ b/tests/http/StatelessApplicationTest.php
@@ -10,7 +10,8 @@ use PHPUnit\Framework\Attributes\{DataProviderExternal, Group, RequiresPhpExtens
 use Psr\Http\Message\{ServerRequestFactoryInterface, StreamFactoryInterface, UploadedFileFactoryInterface};
 use stdClass;
 use Yii;
-use yii\base\{Exception, InvalidConfigException, Security};
+use yii\base\Exception;
+use yii\base\{InvalidConfigException, Security};
 use yii\di\NotInstantiableException;
 use yii\helpers\Json;
 use yii\i18n\{Formatter, I18N};
@@ -741,8 +742,6 @@ final class StatelessApplicationTest extends TestCase
 
         $initialBufferLevel = ob_get_level();
 
-        HTTPFunctions::set_sapi('apache2handler');
-
         $_SERVER = [
             'REQUEST_METHOD' => 'GET',
             'REQUEST_URI' => 'site/trigger-exception',
@@ -795,8 +794,6 @@ final class StatelessApplicationTest extends TestCase
     {
         @runkit_constant_redefine('YII_DEBUG', false);
 
-        HTTPFunctions::set_sapi('apache2handler');
-
         $_SERVER = [
             'REQUEST_METHOD' => 'GET',
             'REQUEST_URI' => 'site/trigger-exception',
@@ -844,8 +841,6 @@ final class StatelessApplicationTest extends TestCase
      */
     public function testRenderExceptionWithRawFormat(): void
     {
-        HTTPFunctions::set_sapi('apache2handler');
-
         $_SERVER = [
             'REQUEST_METHOD' => 'GET',
             'REQUEST_URI' => 'site/trigger-exception',
@@ -1086,9 +1081,9 @@ final class StatelessApplicationTest extends TestCase
         $response = $app->handle($request);
 
         self::assertSame(
-            200,
+            500,
             $response->getStatusCode(),
-            "Response 'status code' should be '200' when 'ErrorHandler' is misconfigured and a nonexistent action is " .
+            "Response 'status code' should be '500' when 'ErrorHandler' is misconfigured and a nonexistent action is " .
             "requested in 'StatelessApplication'.",
         );
         self::assertSame(

--- a/tests/support/MockerExtension.php
+++ b/tests/support/MockerExtension.php
@@ -75,8 +75,10 @@ final class MockerExtension implements Extension
             ],
             [
                 'namespace' => 'yii2\extensions\psrbridge\http',
-                'name' => 'php_sapi_name',
-                'function' => static fn(): string => HTTPFunctions::php_sapi_name(),
+                'name' => 'http_response_code',
+                'function' => static fn(int|null $response_code = null): int => HTTPFunctions::http_response_code(
+                    $response_code,
+                ),
             ],
             [
                 'namespace' => 'yii2\extensions\psrbridge\adapter',

--- a/tests/support/stub/HTTPFunctions.php
+++ b/tests/support/stub/HTTPFunctions.php
@@ -69,11 +69,6 @@ final class HTTPFunctions
     private static int $responseCode = 200;
 
     /**
-     * Tracks the current SAPI name for simulation.
-     */
-    private static string $sapi = 'cli';
-
-    /**
      * Controls whether stream_get_contents should fail.
      */
     private static bool $streamGetContentsShouldFail = false;
@@ -160,11 +155,6 @@ final class HTTPFunctions
         return self::$responseCode;
     }
 
-    public static function php_sapi_name(): string
-    {
-        return self::$sapi;
-    }
-
     public static function reset(): void
     {
         self::$flushedTimes = 0;
@@ -173,7 +163,6 @@ final class HTTPFunctions
         self::$headersSentFile = '';
         self::$headersSentLine = 0;
         self::$responseCode = 200;
-        self::$sapi = 'cli';
         self::$streamGetContentsShouldFail = false;
     }
 
@@ -182,11 +171,6 @@ final class HTTPFunctions
         self::$headersSent = $value;
         self::$headersSentFile = $file;
         self::$headersSentLine = $line;
-    }
-
-    public static function set_sapi(string $sapi): void
-    {
-        self::$sapi = $sapi;
     }
 
     public static function set_stream_get_contents_should_fail(bool $shouldFail = true): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
