### PR TITLE
refactor(response): Enhance cookie validation handling and improve response initialization in `Response` and `ResponseAdapter`.

### DIFF
--- a/src/adapter/ResponseAdapter.php
+++ b/src/adapter/ResponseAdapter.php
@@ -7,7 +7,6 @@ namespace yii2\extensions\psrbridge\adapter;
 use DateTimeInterface;
 use Psr\Http\Message\{ResponseFactoryInterface, ResponseInterface, StreamFactoryInterface, StreamInterface};
 use yii\base\{InvalidConfigException, Security};
-use yii\helpers\Json;
 use yii\web\Cookie;
 use yii2\extensions\psrbridge\exception\Message;
 use yii2\extensions\psrbridge\http\{Request, Response};
@@ -22,6 +21,7 @@ use function is_numeric;
 use function is_resource;
 use function is_string;
 use function max;
+use function serialize;
 use function strtotime;
 use function time;
 use function urlencode;
@@ -280,7 +280,7 @@ final class ResponseAdapter
             ($expire === 0 || $expire >= time())
         ) {
             $value = $this->security->hashData(
-                Json::encode([$cookie->name, $cookie->value]),
+                serialize([$cookie->name, $cookie->value]),
                 $this->response->cookieValidationKey,
             );
         }

--- a/src/adapter/ResponseAdapter.php
+++ b/src/adapter/ResponseAdapter.php
@@ -59,13 +59,13 @@ final class ResponseAdapter
      * @param Response $response Yii2 Response instance to adapt.
      * @param ResponseFactoryInterface $responseFactory PSR-7 ResponseFactoryInterface instance for response creation.
      * @param StreamFactoryInterface $streamFactory PSR-7 StreamFactoryInterface instance for body stream creation.
-     * @param Security $security Optional Security component for cookie validation. Defaults to a new instance.
+     * @param Security $security Optional Security component for cookie validation.
      */
     public function __construct(
         private readonly Response $response,
         private readonly ResponseFactoryInterface $responseFactory,
         private readonly StreamFactoryInterface $streamFactory,
-        private readonly Security $security = new Security(),
+        private readonly Security $security,
     ) {}
 
     /**

--- a/src/adapter/ResponseAdapter.php
+++ b/src/adapter/ResponseAdapter.php
@@ -6,16 +6,18 @@ namespace yii2\extensions\psrbridge\adapter;
 
 use DateTimeInterface;
 use Psr\Http\Message\{ResponseFactoryInterface, ResponseInterface, StreamFactoryInterface, StreamInterface};
-use Yii;
-use yii\base\InvalidConfigException;
+use yii\base\{InvalidConfigException, Security};
 use yii\helpers\Json;
-use yii\web\{Cookie, Response};
+use yii\web\Cookie;
 use yii2\extensions\psrbridge\exception\Message;
-use yii2\extensions\psrbridge\http\Request;
+use yii2\extensions\psrbridge\http\{Request, Response};
 
+use function count;
 use function fclose;
 use function fseek;
 use function gmdate;
+use function is_array;
+use function is_int;
 use function is_numeric;
 use function is_resource;
 use function is_string;
@@ -57,11 +59,13 @@ final class ResponseAdapter
      * @param Response $response Yii2 Response instance to adapt.
      * @param ResponseFactoryInterface $responseFactory PSR-7 ResponseFactoryInterface instance for response creation.
      * @param StreamFactoryInterface $streamFactory PSR-7 StreamFactoryInterface instance for body stream creation.
+     * @param Security $security Optional Security component for cookie validation. Defaults to a new instance.
      */
     public function __construct(
         private readonly Response $response,
         private readonly ResponseFactoryInterface $responseFactory,
         private readonly StreamFactoryInterface $streamFactory,
+        private readonly Security $security = new Security(),
     ) {}
 
     /**
@@ -131,24 +135,16 @@ final class ResponseAdapter
     private function buildCookieHeaders(): array
     {
         $headers = [];
-        $request = Yii::$app->getRequest();
 
-        $enableValidation = $request->enableCookieValidation;
-        $validationKey = null;
-
-        if ($enableValidation) {
-            $validationKey = $request->cookieValidationKey;
-
-            if ($validationKey === '') {
-                throw new InvalidConfigException(
-                    Message::COOKIE_VALIDATION_KEY_NOT_CONFIGURED->getMessage(Request::class),
-                );
-            }
+        if ($this->response->enableCookieValidation && $this->response->cookieValidationKey === '') {
+            throw new InvalidConfigException(
+                Message::COOKIE_VALIDATION_KEY_NOT_CONFIGURED->getMessage(Request::class),
+            );
         }
 
         foreach ($this->response->getCookies() as $cookie) {
             if ($cookie->value !== null && $cookie->value !== '') {
-                $headers[] = $this->formatCookieHeader($cookie, $enableValidation, $validationKey);
+                $headers[] = $this->formatCookieHeader($cookie);
             }
         }
 
@@ -256,14 +252,12 @@ final class ResponseAdapter
      * compatibility with both Yii2 and PSR-7 HTTP stacks.
      *
      * @param Cookie $cookie Cookie instance to format.
-     * @param bool $enableValidation Whether to apply Yii2 Cookie validation.
-     * @param string|null $validationKey Validation key for hashing the cookie value if validation is enabled.
      *
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      *
      * @return string Formatted 'Set-Cookie' header string.
      */
-    private function formatCookieHeader(Cookie $cookie, bool $enableValidation, string|null $validationKey): string
+    private function formatCookieHeader(Cookie $cookie): string
     {
         $value = $cookie->value;
         $expire = $cookie->expire;
@@ -280,8 +274,15 @@ final class ResponseAdapter
             $expire = $expire->getTimestamp();
         }
 
-        if ($enableValidation && $validationKey !== null && ($expire === 0 || $expire >= time())) {
-            $value = Yii::$app->getSecurity()->hashData(Json::encode([$cookie->name, $cookie->value]), $validationKey);
+        if (
+            $this->response->enableCookieValidation &&
+            $this->response->cookieValidationKey !== '' &&
+            ($expire === 0 || $expire >= time())
+        ) {
+            $value = $this->security->hashData(
+                Json::encode([$cookie->name, $cookie->value]),
+                $this->response->cookieValidationKey,
+            );
         }
 
         $header = urlencode($cookie->name) . '=' . urlencode($value);

--- a/src/adapter/ServerRequestAdapter.php
+++ b/src/adapter/ServerRequestAdapter.php
@@ -7,7 +7,6 @@ namespace yii2\extensions\psrbridge\adapter;
 use Psr\Http\Message\ServerRequestInterface;
 use Yii;
 use yii\base\InvalidConfigException;
-use yii\helpers\Json;
 use yii\web\{Cookie, HeaderCollection};
 use yii2\extensions\psrbridge\exception\Message;
 
@@ -16,6 +15,7 @@ use function in_array;
 use function is_array;
 use function is_string;
 use function strtoupper;
+use function unserialize;
 
 /**
  * Adapter for PSR-7 ServerRequestInterface to Yii2 Request component.
@@ -421,7 +421,7 @@ final class ServerRequestAdapter
                 $data = Yii::$app->getSecurity()->validateData($value, $validationKey);
 
                 if (is_string($data)) {
-                    $data = unserialize($data);
+                    $data = @unserialize($data);
                 }
 
                 if (is_array($data) && isset($data[0], $data[1]) && $data[0] === $name) {

--- a/src/adapter/ServerRequestAdapter.php
+++ b/src/adapter/ServerRequestAdapter.php
@@ -421,7 +421,7 @@ final class ServerRequestAdapter
                 $data = Yii::$app->getSecurity()->validateData($value, $validationKey);
 
                 if (is_string($data)) {
-                    $data = Json::decode($data);
+                    $data = unserialize($data);
                 }
 
                 if (is_array($data) && isset($data[0], $data[1]) && $data[0] === $name) {

--- a/src/adapter/ServerRequestAdapter.php
+++ b/src/adapter/ServerRequestAdapter.php
@@ -421,7 +421,7 @@ final class ServerRequestAdapter
                 $data = Yii::$app->getSecurity()->validateData($value, $validationKey);
 
                 if (is_string($data)) {
-                    $data = @unserialize($data);
+                    $data = @unserialize($data, ['allowed_classes' => false]);
                 }
 
                 if (is_array($data) && isset($data[0], $data[1]) && $data[0] === $name) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,6 +8,7 @@ use HttpSoft\Message\{ResponseFactory, StreamFactory};
 use Psr\Http\Message\{ResponseFactoryInterface, StreamFactoryInterface};
 use RuntimeException;
 use Yii;
+use yii\base\Security;
 use yii\caching\FileCache;
 use yii\helpers\ArrayHelper;
 use yii\log\FileTarget;
@@ -103,6 +104,13 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $this->tmpFiles[] = $tmpFile;
 
         return $tmpFile;
+    }
+
+    protected function signCookie(string $name, string $value): string
+    {
+        $security = new Security();
+
+        return $security->hashData(serialize([$name, $value]), self::COOKIE_VALIDATION_KEY);
     }
 
     /**

--- a/tests/adapter/ResponseAdapterTest.php
+++ b/tests/adapter/ResponseAdapterTest.php
@@ -7,7 +7,7 @@ namespace yii2\extensions\psrbridge\tests\adapter;
 use DateTimeImmutable;
 use PHPUnit\Framework\Attributes\Group;
 use RuntimeException;
-use yii\base\InvalidConfigException;
+use yii\base\{InvalidConfigException, Security};
 use yii\web\Cookie;
 use yii2\extensions\psrbridge\adapter\ResponseAdapter;
 use yii2\extensions\psrbridge\exception\Message;
@@ -54,6 +54,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -90,6 +91,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -139,6 +141,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -186,6 +189,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -238,6 +242,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -295,6 +300,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -339,6 +345,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -390,6 +397,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -477,6 +485,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -547,6 +556,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -604,6 +614,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -660,6 +671,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -737,6 +749,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -814,6 +827,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -865,6 +879,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -917,6 +932,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -965,6 +981,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -1016,6 +1033,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -1092,6 +1110,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -1154,6 +1173,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -1208,6 +1228,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -1260,6 +1281,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -1309,6 +1331,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -1364,6 +1387,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -1417,6 +1441,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -1478,6 +1503,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -1565,6 +1591,7 @@ final class ResponseAdapterTest extends TestCase
             $response1,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response1 = $adapter1->toPsr7();
@@ -1576,6 +1603,7 @@ final class ResponseAdapterTest extends TestCase
             $response2,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response2 = $adapter2->toPsr7();
@@ -1637,6 +1665,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -1714,6 +1743,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $psr7Response = $adapter->toPsr7();
@@ -1754,6 +1784,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $this->expectException(InvalidConfigException::class);
@@ -1781,6 +1812,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         HTTPFunctions::set_stream_get_contents_should_fail();
@@ -1803,6 +1835,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $this->expectException(InvalidConfigException::class);
@@ -1834,6 +1867,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $this->expectException(InvalidConfigException::class);
@@ -1859,6 +1893,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $this->expectException(InvalidConfigException::class);
@@ -1892,6 +1927,7 @@ final class ResponseAdapterTest extends TestCase
             $response,
             FactoryHelper::createResponseFactory(),
             FactoryHelper::createStreamFactory(),
+            new Security(),
         );
 
         $this->expectException(InvalidConfigException::class);

--- a/tests/http/ResponseTest.php
+++ b/tests/http/ResponseTest.php
@@ -9,13 +9,13 @@ use Psr\Http\Message\{ResponseFactoryInterface, StreamFactoryInterface};
 use Yii;
 use yii\base\InvalidConfigException;
 use yii\di\NotInstantiableException;
+use yii\helpers\Json;
 use yii\web\{Cookie, Session};
 use yii2\extensions\psrbridge\http\Response;
 use yii2\extensions\psrbridge\tests\support\FactoryHelper;
 use yii2\extensions\psrbridge\tests\TestCase;
 
 use function count;
-use function json_decode;
 use function str_contains;
 use function time;
 use function urlencode;
@@ -50,7 +50,12 @@ final class ResponseTest extends TestCase
         $eventsBefore = [];
         $eventsAfter = [];
 
-        $response = new Response();
+        $response = new Response(
+            [
+                'cookieValidationKey' => self::COOKIE_VALIDATION_KEY,
+                'enableCookieValidation' => true,
+            ],
+        );
 
         $response->content = 'Test content with session';
 
@@ -378,7 +383,12 @@ final class ResponseTest extends TestCase
             ],
         );
 
-        $response = new Response();
+        $response = new Response(
+            [
+                'cookieValidationKey' => self::COOKIE_VALIDATION_KEY,
+                'enableCookieValidation' => true,
+            ],
+        );
 
         $response->content = 'Test with default session params';
 
@@ -459,7 +469,7 @@ final class ResponseTest extends TestCase
 
         $psr7Response = $response->getPsr7Response();
         $body = (string) $psr7Response->getBody();
-        $decodedData = json_decode($body, true);
+        $decodedData = Json::decode($body);
 
         self::assertIsArray(
             $decodedData,

--- a/tests/http/StatelessApplicationTest.php
+++ b/tests/http/StatelessApplicationTest.php
@@ -39,6 +39,7 @@ use function memory_get_usage;
 use function ob_get_level;
 use function ob_start;
 use function preg_quote;
+use function serialize;
 use function session_name;
 use function sprintf;
 use function str_starts_with;
@@ -1373,7 +1374,7 @@ final class StatelessApplicationTest extends TestCase
 
         foreach ($cookies as $name => $value) {
             $data = [$name, $value];
-            $signedCookies[$name] = $security->hashData(Json::encode($data), self::COOKIE_VALIDATION_KEY);
+            $signedCookies[$name] = $security->hashData(serialize($data), self::COOKIE_VALIDATION_KEY);
         }
 
         $app = $this->statelessApplication(
@@ -1690,7 +1691,7 @@ final class StatelessApplicationTest extends TestCase
         $security = new Security();
 
         $signedCookieValue = $security->hashData(
-            Json::encode(['valid_session', 'abc123session']),
+            serialize(['valid_session', 'abc123session']),
             self::COOKIE_VALIDATION_KEY,
         );
 
@@ -1738,7 +1739,7 @@ final class StatelessApplicationTest extends TestCase
         $security = new Security();
 
         $signedCookieValue = $security->hashData(
-            Json::encode(['validated_session', 'secure_session_value']),
+            serialize(['validated_session', 'secure_session_value']),
             self::COOKIE_VALIDATION_KEY,
         );
 

--- a/tests/http/StatelessApplicationTest.php
+++ b/tests/http/StatelessApplicationTest.php
@@ -39,7 +39,6 @@ use function memory_get_usage;
 use function ob_get_level;
 use function ob_start;
 use function preg_quote;
-use function serialize;
 use function session_name;
 use function sprintf;
 use function str_starts_with;
@@ -1742,7 +1741,7 @@ final class StatelessApplicationTest extends TestCase
                 ->withCookieParams(
                     [
                         'validated_session' => $this->signCookie('validated_session', 'secure_session_value')],
-                    ),
+                ),
         );
 
         self::assertSame(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Configurable cookie validation on responses; when enabled with a validation key, cookie values are signed before being sent.

- **Refactor**
  - Response exposes cookie-validation settings and these are synchronized between request and response during app reset.
  - PSR-7 response adapter is resolved via DI and uses the app security component for signing.

- **Chores**
  - Cookie signing now incorporates cookie name with the value (format changed).

- **Tests**
  - Updated to instantiate responses with validation enabled and to expect signed cookie values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->