### PR TITLE
refactor(adapter): Rename variable for clarity in `ResponseAdapter` class constructor and related methods.

### DIFF
--- a/src/http/Response.php
+++ b/src/http/Response.php
@@ -79,7 +79,7 @@ final class Response extends \yii\web\Response
             ResponseAdapter::class,
             config: [
                 '__construct()' => [
-                    'response' => $this,
+                    'psrResponse' => $this,
                     'security' => Yii::$app->getSecurity(),
                 ],
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal response handling to align with PSR-7 terminology (status, headers, cookies, and body/stream access), improving consistency across the adapter.
  * Updated dependency wiring to match the new naming.
  * No user-facing changes or behavior differences; existing integrations continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->