### PR TITLE
refactor(adapter): Update cookie header generation to set 'Secure' attribute correctly in `ResponseAdapter` class.

### DIFF
--- a/src/adapter/ResponseAdapter.php
+++ b/src/adapter/ResponseAdapter.php
@@ -303,6 +303,11 @@ final class ResponseAdapter
             'SameSite' => $cookie->sameSite,
         ];
 
+        // if 'SameSite=None', ensure Secure is present (browser requirement)
+        if ($attributes['SameSite'] === Cookie::SAME_SITE_NONE && $attributes['Secure'] === null) {
+            $attributes['Secure'] = '';
+        }
+
         foreach ($attributes as $key => $val) {
             if ($val !== null) {
                 $header .= "; {$key}" . ($val !== '' ? "={$val}" : '');

--- a/src/adapter/ResponseAdapter.php
+++ b/src/adapter/ResponseAdapter.php
@@ -298,7 +298,7 @@ final class ResponseAdapter
         $attributes = [
             'Path' => $cookie->path !== '' ? $cookie->path : null,
             'Domain' => $cookie->domain !== '' ? $cookie->domain : null,
-            'Secure' => $cookie->secure ? 'Secure' : null,
+            'Secure' => $cookie->secure ? '' : null,
             'HttpOnly' => $cookie->httpOnly ? '' : null,
             'SameSite' => $cookie->sameSite,
         ];

--- a/src/http/Response.php
+++ b/src/http/Response.php
@@ -98,6 +98,7 @@ final class Response extends \yii\web\Response
                 'value' => $session->getId(),
                 'path' => $cookieParams['path'] ?? '/',
                 'domain' => $cookieParams['domain'] ?? '',
+                'secure' => $cookieParams['secure'] ?? false,
                 'sameSite' => $cookieParams['samesite'] ?? Cookie::SAME_SITE_LAX,
             ];
 

--- a/src/http/Response.php
+++ b/src/http/Response.php
@@ -11,6 +11,8 @@ use yii\di\NotInstantiableException;
 use yii\web\Cookie;
 use yii2\extensions\psrbridge\adapter\ResponseAdapter;
 
+use function filter_var;
+
 /**
  * HTTP Response extension with PSR-7 bridge support.
  *
@@ -98,17 +100,10 @@ final class Response extends \yii\web\Response
                 'value' => $session->getId(),
                 'path' => $cookieParams['path'] ?? '/',
                 'domain' => $cookieParams['domain'] ?? '',
-                'secure' => $cookieParams['secure'] ?? false,
+                'secure' => filter_var($cookieParams['secure'] ?? false, FILTER_VALIDATE_BOOLEAN),
+                'httpOnly' => filter_var($cookieParams['httponly'] ?? true, FILTER_VALIDATE_BOOLEAN),
                 'sameSite' => $cookieParams['samesite'] ?? Cookie::SAME_SITE_LAX,
             ];
-
-            if (isset($cookieParams['secure'])) {
-                $cookieConfig['secure'] = $cookieParams['secure'];
-            }
-
-            if (isset($cookieParams['httponly'])) {
-                $cookieConfig['httpOnly'] = $cookieParams['httponly'];
-            }
 
             $this->cookies->add(new Cookie($cookieConfig));
             $session->close();

--- a/tests/adapter/ResponseAdapterTest.php
+++ b/tests/adapter/ResponseAdapterTest.php
@@ -554,10 +554,20 @@ final class ResponseAdapterTest extends TestCase
             $cookieHeader,
             "'Set-Cookie' header should contain the 'Secure' flag when set to 'true'.",
         );
+        self::assertStringNotContainsString(
+            '; Secure=',
+            $cookieHeader,
+            "'Set-Cookie' header should contain 'Secure' flag without a value (not 'Secure=').",
+        );
         self::assertStringContainsString(
             '; HttpOnly',
             $cookieHeader,
             "'Set-Cookie' header should contain the 'HttpOnly' flag when set to 'true'.",
+        );
+        self::assertStringNotContainsString(
+            '; HttpOnly=',
+            $cookieHeader,
+            "'Set-Cookie' header should contain 'HttpOnly' flag without a value (not 'HttpOnly=').",
         );
         self::assertStringContainsString(
             '; SameSite=Strict',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Set-Cookie header now emits Secure and HttpOnly as flag attributes (e.g., "; Secure") and automatically includes the Secure flag when SameSite=None, improving standards compliance and interoperability.
  * Cookie secure/httpOnly presence is consistently applied with sensible defaults.

* **Tests**
  * Added tests to verify Secure/HttpOnly are rendered as flags and that SameSite=None triggers Secure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->