### PR TITLE
refactor(adapter): Optimize `ResponseAdapter` class instantiation for better performance.

### DIFF
--- a/src/http/Response.php
+++ b/src/http/Response.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace yii2\extensions\psrbridge\http;
 
-use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\{ResponseFactoryInterface, ResponseInterface, StreamFactoryInterface};
 use Yii;
 use yii\base\InvalidConfigException;
 use yii\di\NotInstantiableException;
@@ -77,14 +77,11 @@ final class Response extends \yii\web\Response
      */
     public function getPsr7Response(): ResponseInterface
     {
-        $adapter = Yii::$container->get(
-            ResponseAdapter::class,
-            config: [
-                '__construct()' => [
-                    'psrResponse' => $this,
-                    'security' => Yii::$app->getSecurity(),
-                ],
-            ],
+        $adapter = new ResponseAdapter(
+            $this,
+            Yii::$container->get(ResponseFactoryInterface::class),
+            Yii::$container->get(StreamFactoryInterface::class),
+            Yii::$app->getSecurity(),
         );
 
         $this->trigger(self::EVENT_BEFORE_SEND);

--- a/src/http/Response.php
+++ b/src/http/Response.php
@@ -106,7 +106,7 @@ final class Response extends \yii\web\Response
             $session->close();
         }
 
-        return $this->getAdapter()->toPsr7();
+        return $this->createAdapter()->toPsr7();
     }
 
     /**
@@ -140,17 +140,13 @@ final class Response extends \yii\web\Response
      *
      * @return ResponseAdapter PSR-7 ResponseAdapter instance for the current Response.
      */
-    private function getAdapter(): ResponseAdapter
+    private function createAdapter(): ResponseAdapter
     {
-        if ($this->adapter === null) {
-            $this->adapter = new ResponseAdapter(
-                $this,
-                Yii::$container->get(ResponseFactoryInterface::class),
-                Yii::$container->get(StreamFactoryInterface::class),
-                Yii::$app->getSecurity(),
-            );
-        }
-
-        return $this->adapter;
+        return $this->adapter ??= new ResponseAdapter(
+            $this,
+            Yii::$container->get(ResponseFactoryInterface::class),
+            Yii::$container->get(StreamFactoryInterface::class),
+            Yii::$app->getSecurity(),
+        );
     }
 }

--- a/src/http/Response.php
+++ b/src/http/Response.php
@@ -40,14 +40,6 @@ use function filter_var;
 final class Response extends \yii\web\Response
 {
     /**
-     * PSR-7 ResponseAdapter for bridging PSR-7 ResponseInterface with Yii2 Response component.
-     *
-     * Adapter allows the Response class to access PSR-7 ResponseInterface data while maintaining compatibility with
-     * Yii2 Response component.
-     */
-    private ResponseAdapter|null $adapter = null;
-
-    /**
      * @var string A secret key used for cookie validation. This property must be set if {@see enableCookieValidation}
      * is 'true'.
      */
@@ -58,6 +50,13 @@ final class Response extends \yii\web\Response
      * {@see cookieValidationKey}. This is recommended for security, especially when handling session cookies.
      */
     public bool $enableCookieValidation = false;
+    /**
+     * PSR-7 ResponseAdapter for bridging PSR-7 ResponseInterface with Yii2 Response component.
+     *
+     * Adapter allows the Response class to access PSR-7 ResponseInterface data while maintaining compatibility with
+     * Yii2 Response component.
+     */
+    private ResponseAdapter|null $adapter = null;
 
     /**
      * Converts the Yii2 Response component to a PSR-7 ResponseInterface instance.

--- a/src/http/Response.php
+++ b/src/http/Response.php
@@ -11,8 +11,6 @@ use yii\di\NotInstantiableException;
 use yii\web\Cookie;
 use yii2\extensions\psrbridge\adapter\ResponseAdapter;
 
-use function filter_var;
-
 /**
  * HTTP Response extension with PSR-7 bridge support.
  *
@@ -50,6 +48,7 @@ final class Response extends \yii\web\Response
      * {@see cookieValidationKey}. This is recommended for security, especially when handling session cookies.
      */
     public bool $enableCookieValidation = false;
+
     /**
      * PSR-7 ResponseAdapter for bridging PSR-7 ResponseInterface with Yii2 Response component.
      *
@@ -88,7 +87,6 @@ final class Response extends \yii\web\Response
         $this->prepare();
         $this->trigger(self::EVENT_AFTER_PREPARE);
 
-
         if (Yii::$app->has('session') && ($session = Yii::$app->getSession())->getIsActive()) {
             $cookieParams = $session->getCookieParams();
 
@@ -97,8 +95,8 @@ final class Response extends \yii\web\Response
                 'value' => $session->getId(),
                 'path' => $cookieParams['path'] ?? '/',
                 'domain' => $cookieParams['domain'] ?? '',
-                'secure' => filter_var($cookieParams['secure'] ?? false, FILTER_VALIDATE_BOOLEAN),
-                'httpOnly' => filter_var($cookieParams['httponly'] ?? true, FILTER_VALIDATE_BOOLEAN),
+                'secure' => $cookieParams['secure'] ?? false,
+                'httpOnly' => $cookieParams['httponly'] ?? true,
                 'sameSite' => $cookieParams['samesite'] ?? Cookie::SAME_SITE_LAX,
             ];
 

--- a/src/http/StatelessApplication.php
+++ b/src/http/StatelessApplication.php
@@ -417,7 +417,7 @@ final class StatelessApplication extends Application implements RequestHandlerIn
         $this->response->cookieValidationKey = $this->request->cookieValidationKey;
         $this->response->enableCookieValidation = $this->request->enableCookieValidation;
 
-        // reset the response to clear any previous state
+        // reset the PSR-7 adapter cache for the response
         $this->response->reset();
 
         $this->session->close();

--- a/src/http/StatelessApplication.php
+++ b/src/http/StatelessApplication.php
@@ -417,6 +417,9 @@ final class StatelessApplication extends Application implements RequestHandlerIn
         $this->response->cookieValidationKey = $this->request->cookieValidationKey;
         $this->response->enableCookieValidation = $this->request->enableCookieValidation;
 
+        // reset the response to clear any previous state
+        $this->response->reset();
+
         $this->session->close();
         $sessionId = $this->request->getCookies()->get($this->session->getName())->value ?? '';
         $this->session->setId($sessionId);

--- a/tests/http/StatelessApplicationTest.php
+++ b/tests/http/StatelessApplicationTest.php
@@ -1009,7 +1009,7 @@ final class StatelessApplicationTest extends TestCase
         // verify response headers are preserved correctly across adapter operations
         $cookieHeaders = array_filter(
             $response3->getHeader('Set-Cookie'),
-            static fn (string $header): bool => str_starts_with($header, $app->session->getName()) === false,
+            static fn(string $header): bool => str_starts_with($header, $app->session->getName()) === false,
         );
 
         $hasCookieHeader = false;

--- a/tests/http/StatelessApplicationTest.php
+++ b/tests/http/StatelessApplicationTest.php
@@ -920,11 +920,11 @@ final class StatelessApplicationTest extends TestCase
         $bridgeResponse1 = $app->response;
 
         // get PSR-7 response twice to test caching
+        $bridgeResponse1->getPsr7Response();
         $adapter1 = Assert::inaccessibleProperty($bridgeResponse1, 'adapter');
-        $bridgeResponse1->getPsr7Response();
 
-        $adapter2 = Assert::inaccessibleProperty($bridgeResponse1, 'adapter');
         $bridgeResponse1->getPsr7Response();
+        $adapter2 = Assert::inaccessibleProperty($bridgeResponse1, 'adapter');
 
         // verify adapter is cached (same instance across multiple calls)
         self::assertSame(
@@ -961,13 +961,13 @@ final class StatelessApplicationTest extends TestCase
         );
 
         // test 'reset()' functionality
-        $adapter3 = Assert::inaccessibleProperty($bridgeResponse2, 'adapter');
         $bridgeResponse2->getPsr7Response();
+        $adapter3 = Assert::inaccessibleProperty($bridgeResponse2, 'adapter');
 
         $bridgeResponse2->reset();
 
-        $adapter4 = Assert::inaccessibleProperty($bridgeResponse2, 'adapter');
         $bridgeResponse2->getPsr7Response();
+        $adapter4 = Assert::inaccessibleProperty($bridgeResponse2, 'adapter');
 
         self::assertNotSame(
             $adapter3,
@@ -995,8 +995,8 @@ final class StatelessApplicationTest extends TestCase
 
         $bridgeResponse3 = $app->response;
 
-        $adapter5 = Assert::inaccessibleProperty($bridgeResponse3, 'adapter');
         $bridgeResponse3->getPsr7Response();
+        $adapter5 = Assert::inaccessibleProperty($bridgeResponse3, 'adapter');
 
         // verify each request gets its own adapter instance
         self::assertNotSame(

--- a/tests/http/StatelessApplicationTest.php
+++ b/tests/http/StatelessApplicationTest.php
@@ -1060,9 +1060,22 @@ final class StatelessApplicationTest extends TestCase
                         'test2=test2',
                     ],
                     sprintf(
-                        "Cookie header should contain either 'test=test' or 'test2=test2', got '%s' for 'site/cookie' " .
-                        'route.',
+                        "Cookie header should contain either 'test=test' or 'test2=test2', got '%s' for " .
+                        "'site/cookie' route.",
                         $params[0],
+                    ),
+                );
+                self::assertNotContains(
+                    $params[0],
+                    [
+                        'Secure',
+                        'HttpOnly',
+                    ],
+                    sprintf(
+                        "Cookie header should not contain 'Secure' or 'HttpOnly' flags for '%s', got '%s' for " .
+                        "'site/cookie' route.",
+                        $params[0],
+                        $cookie,
                     ),
                 );
             }

--- a/tests/http/StatelessApplicationTest.php
+++ b/tests/http/StatelessApplicationTest.php
@@ -954,9 +954,9 @@ final class StatelessApplicationTest extends TestCase
         $bridgeResponse2 = $app->response;
 
         self::assertNotSame(
-            $response1,
-            $response2,
-            'PSR-7 Response should be a different instance for each request, confirming stateless behavior in ' .
+            $bridgeResponse1,
+            $bridgeResponse2,
+            'Response component should be a different instance for each request, confirming stateless behavior in ' .
             "'StatelessApplication'.",
         );
 
@@ -965,6 +965,12 @@ final class StatelessApplicationTest extends TestCase
         $adapter3 = Assert::inaccessibleProperty($bridgeResponse2, 'adapter');
 
         $bridgeResponse2->reset();
+
+        // after reset, adapter cache should be cleared
+        self::assertNull(
+            Assert::inaccessibleProperty($bridgeResponse2, 'adapter'),
+            "'reset()' should nullify the cached adapter before the next 'getPsr7Response()' call.",
+        );
 
         $bridgeResponse2->getPsr7Response();
         $adapter4 = Assert::inaccessibleProperty($bridgeResponse2, 'adapter');
@@ -1024,7 +1030,7 @@ final class StatelessApplicationTest extends TestCase
 
         self::assertTrue(
             $hasCookieHeader,
-            "PSR-7 response should contain proper 'Set-Cookie' headers from Response component, confirming correct " .
+            "PSR-7 response should contain 'test=test' or 'test2=test2' in 'Set-Cookie' headers, confirming correct " .
             "adapter behavior in 'StatelessApplication'.",
         );
     }

--- a/tests/http/StatelessApplicationTest.php
+++ b/tests/http/StatelessApplicationTest.php
@@ -1065,15 +1065,34 @@ final class StatelessApplicationTest extends TestCase
                         $params[0],
                     ),
                 );
-                self::assertNotContains(
-                    $params[0],
-                    [
-                        'Secure',
-                        'HttpOnly',
-                    ],
+                self::assertStringContainsString(
+                    'Path=/',
+                    $cookie,
+                    "Cookie header should contain 'Path=/' for 'site/cookie' route.",
+                );
+                self::assertStringNotContainsString(
+                    'Secure',
+                    $cookie,
                     sprintf(
-                        "Cookie header should not contain 'Secure' or 'HttpOnly' flags for '%s', got '%s' for " .
-                        "'site/cookie' route.",
+                        "Cookie header should not contain 'Secure' flag for '%s', got '%s' for 'site/cookie' route.",
+                        $params[0],
+                        $cookie,
+                    ),
+                );
+                self::assertStringNotContainsString(
+                    'HttpOnly',
+                    $cookie,
+                    sprintf(
+                        "Cookie header should not contain 'HttpOnly' flag for '%s', got '%s' for 'site/cookie' route.",
+                        $params[0],
+                        $cookie,
+                    ),
+                );
+                self::assertStringContainsString(
+                    'SameSite=Lax',
+                    $cookie,
+                    sprintf(
+                        "Cookie header should contain 'SameSite=Lax' for '%s', got '%s' for 'site/cookie' route.",
                         $params[0],
                         $cookie,
                     ),

--- a/tests/http/StatelessApplicationTest.php
+++ b/tests/http/StatelessApplicationTest.php
@@ -956,7 +956,7 @@ final class StatelessApplicationTest extends TestCase
         self::assertNotSame(
             $response1,
             $response2,
-            'Response component should be a different instance for each request, confirming stateless behavior in ' .
+            'PSR-7 Response should be a different instance for each request, confirming stateless behavior in ' .
             "'StatelessApplication'.",
         );
 
@@ -1007,7 +1007,10 @@ final class StatelessApplicationTest extends TestCase
         );
 
         // verify response headers are preserved correctly across adapter operations
-        $cookieHeaders = $response3->getHeader('Set-Cookie');
+        $cookieHeaders = array_filter(
+            $response3->getHeader('Set-Cookie'),
+            static fn (string $header): bool => str_starts_with($header, $app->session->getName()) === false,
+        );
 
         $hasCookieHeader = false;
 

--- a/tests/support/stub/SiteController.php
+++ b/tests/support/stub/SiteController.php
@@ -55,6 +55,7 @@ final class SiteController extends Controller
                 [
                     'name' => 'test',
                     'value' => 'test',
+                    'secure' => false,
                     'httpOnly' => false,
                 ],
             ),
@@ -65,6 +66,8 @@ final class SiteController extends Controller
                 [
                     'name' => 'test2',
                     'value' => 'test2',
+                    'secure' => false,
+                    'httpOnly' => false,
                 ],
             ),
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Response now lazily caches its PSR-7 adapter for efficiency and exposes a public reset(); the application reset clears that cache to preserve per-request isolation.

- Bug Fixes
  - Cookie attribute handling and Set-Cookie header formatting standardized (secure and HttpOnly defaults adjusted) for consistent behavior across requests.

- Tests
  - Added and extended tests to validate adapter caching, reset behavior, per-request isolation, and cookie/header correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->