### PR TITLE
fix(tests): Normalize line endings in error message assertions in `StatelessApplicationTest` class.

### DIFF
--- a/tests/http/StatelessApplicationTest.php
+++ b/tests/http/StatelessApplicationTest.php
@@ -1277,11 +1277,13 @@ final class StatelessApplicationTest extends TestCase
             "action is invalid in 'StatelessApplication'.",
         );
         self::assertStringContainsString(
-            <<<HTML
-            <pre>An Error occurred while handling another error:
-            yii\base\InvalidRouteException: Unable to resolve the request &quot;invalid/nonexistent-action&quot;.
-            HTML,
-            $response->getBody()->getContents(),
+            self::normalizeLineEndings(
+                <<<HTML
+                <pre>An Error occurred while handling another error:
+                yii\base\InvalidRouteException: Unable to resolve the request &quot;invalid/nonexistent-action&quot;.
+                HTML,
+            ),
+            self::normalizeLineEndings($response->getBody()->getContents()),
             "Response 'body' should contain error message about 'An Error occurred while handling another error' and " .
             "the InvalidRouteException when errorHandler action is invalid in 'StatelessApplication'.",
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved cross-platform stability by normalizing line endings in HTML error response assertions, reducing environment-specific test flakiness.
  - No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->