### PR TITLE
refactor(tests): Remove unnecessary `TestSupport` trait usage in `ErrorHandlerTest` and `StatelessApplicationTest` classes.

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace yii2\extensions\psrbridge\tests;
 
 use HttpSoft\Message\{ResponseFactory, StreamFactory};
+use PHPForge\Support\TestSupport;
 use Psr\Http\Message\{ResponseFactoryInterface, StreamFactoryInterface};
 use RuntimeException;
 use Yii;
@@ -21,6 +22,8 @@ use function tmpfile;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
+    use TestSupport;
+
     /**
      * A secret key used for cookie validation in tests.
      */

--- a/tests/http/ErrorHandlerTest.php
+++ b/tests/http/ErrorHandlerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace yii2\extensions\psrbridge\tests\http;
 
-use PHPForge\Support\TestSupport;
 use PHPUnit\Framework\Attributes\{Group, RequiresPhpExtension};
 use RuntimeException;
 use Throwable;
@@ -20,8 +19,6 @@ use function str_repeat;
 #[Group('http')]
 final class ErrorHandlerTest extends TestCase
 {
-    use TestSupport;
-
     #[RequiresPhpExtension('runkit7')]
     public function testClearOutputCleansAllBuffersInNonTestEnvironment(): void
     {

--- a/tests/http/StatelessApplicationTest.php
+++ b/tests/http/StatelessApplicationTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace yii2\extensions\psrbridge\tests\http;
 
 use HttpSoft\Message\{ServerRequestFactory, StreamFactory, UploadedFileFactory};
-use PHPForge\Support\TestSupport;
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group, RequiresPhpExtension};
 use Psr\Http\Message\{ServerRequestFactoryInterface, StreamFactoryInterface, UploadedFileFactoryInterface};
 use stdClass;
@@ -49,8 +48,6 @@ use const PHP_INT_MAX;
 #[Group('http')]
 final class StatelessApplicationTest extends TestCase
 {
-    use TestSupport;
-
     protected function tearDown(): void
     {
         $this->closeApplication();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
