### PR TITLE
feat: Add `flushLogger` property to `StatelessApplication` class and corresponding test for exception logging.

### DIFF
--- a/src/http/StatelessApplication.php
+++ b/src/http/StatelessApplication.php
@@ -7,7 +7,6 @@ namespace yii2\extensions\psrbridge\http;
 use Psr\Http\Message\{ResponseInterface, ServerRequestInterface};
 use Psr\Http\Server\RequestHandlerInterface;
 use Throwable;
-use Yii;
 use yii\base\{Event, InvalidConfigException};
 use yii\di\{Container, NotInstantiableException};
 use yii\web\{Application, UploadedFile};
@@ -49,6 +48,21 @@ use function strtoupper;
  */
 final class StatelessApplication extends Application implements RequestHandlerInterface
 {
+    /**
+     * Whether to flush the logger during application termination.
+     *
+     * When enabled (default), the logger will be flushed during the {@see terminate()} method, ensuring that all log
+     * messages are persisted immediately after request processing.
+     *
+     * This is the recommended behavior for production environments and worker-based applications.
+     *
+     * When disabled, log messages will remain in memory and may accumulate across multiple requests.
+     *
+     * **Warning**: Disabling logger flushing in production or worker environments may lead to memory leaks and log
+     * message loss in case of application crashes. Use with caution and ensure proper memory management.
+     */
+    public bool $flushLogger = true;
+
     /**
      * Version of the StatelessApplication.
      */
@@ -446,7 +460,9 @@ final class StatelessApplication extends Application implements RequestHandlerIn
 
         UploadedFile::reset();
 
-        Yii::getLogger()->flush(true);
+        if ($this->flushLogger) {
+            $this->getLog()->getLogger()->flush(true);
+        }
 
         return $response->getPsr7Response();
     }

--- a/tests/http/StatelessApplicationTest.php
+++ b/tests/http/StatelessApplicationTest.php
@@ -13,7 +13,7 @@ use yii\base\{Exception, InvalidConfigException, Security};
 use yii\di\NotInstantiableException;
 use yii\helpers\Json;
 use yii\i18n\{Formatter, I18N};
-use yii\log\{Dispatcher, FileTarget};
+use yii\log\{Dispatcher, FileTarget, Logger};
 use yii\web\{AssetManager, NotFoundHttpException, Session, UrlManager, User, View};
 use yii2\extensions\psrbridge\exception\Message;
 use yii2\extensions\psrbridge\http\{ErrorHandler, Request, Response};
@@ -615,7 +615,6 @@ final class StatelessApplicationTest extends TestCase
         );
 
         $response = $app->handle($request);
-
         $logMessages = $app->getLog()->getLogger()->messages;
 
         self::assertSame(
@@ -634,12 +633,14 @@ final class StatelessApplicationTest extends TestCase
         foreach ($logMessages as $logMessage) {
             if (
                 is_array($logMessage) &&
-                isset($logMessage[0], $logMessage[2]) &&
+                isset($logMessage[0], $logMessage[1], $logMessage[2]) &&
+                $logMessage[1] === Logger::LEVEL_ERROR &&
                 $logMessage[0] instanceof Exception &&
                 $logMessage[2] === $expectedCategory &&
                 str_contains($logMessage[0]->getMessage(), 'Exception error message.')
             ) {
                 $exceptionLogFound = true;
+
                 break;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to enable or disable automatic log flushing when the application terminates (enabled by default).
  * Logger flushing now occurs conditionally based on this setting, using the application’s logger.

* **Tests**
  * Added tests verifying that exceptions are logged during error handling and that log messages can be inspected without forcing a flush.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->