### PR TITLE
test: Add test for filtering sensitive server variables in fallback exception message in `StatelessApplicationTest` class.

### DIFF
--- a/tests/http/StatelessApplicationTest.php
+++ b/tests/http/StatelessApplicationTest.php
@@ -472,14 +472,14 @@ final class StatelessApplicationTest extends TestCase
     public function testFiltersSensitiveServerVariablesInFallbackExceptionMessage(): void
     {
         $_SERVER = [
-            'API_KEY' => 'secret-api-key-12345',
-            'AUTH_TOKEN' => 'bearer-token-67890',
-            'DB_PASSWORD' => 'database-password-secret',
+            'API_KEY' => 'not-a-secret-api-key',
+            'AUTH_TOKEN' => 'dummy-bearer-token',
+            'DB_PASSWORD' => 'not-a-real-password',
             'HTTP_HOST' => 'example.com',
             'REQUEST_METHOD' => 'GET',
             'REQUEST_URI' => 'site/nonexistent-action',
             'SAFE_VARIABLE' => 'this-should-appear',
-            'SECRET_KEY' => 'application-secret-key',
+            'SECRET_KEY' => 'not-a-real-secret-key',
         ];
 
         $request = FactoryHelper::createServerRequestCreator()->createFromGlobals();
@@ -520,19 +520,19 @@ final class StatelessApplicationTest extends TestCase
                 "'StatelessApplication'.",
             );
             self::assertStringNotContainsString(
-                'secret-api-key-12345',
+                'not-a-secret-api-key',
                 $responseBody,
                 "Response 'body' should NOT contain 'API_KEY' value in debug output for fallback exception in " .
                 "'StatelessApplication'.",
             );
             self::assertStringNotContainsString(
-                'bearer-token-67890',
+                'dummy-bearer-token',
                 $responseBody,
                 "Response 'body' should NOT contain 'AUTH_TOKEN' value in debug output for fallback exception in " .
                 "'StatelessApplication'.",
             );
             self::assertStringNotContainsString(
-                'database-password-secret',
+                'not-a-real-password',
                 $responseBody,
                 "Response 'body' should NOT contain 'DB_PASSWORD' value in debug output for fallback exception in " .
                 "'StatelessApplication'.",
@@ -544,7 +544,7 @@ final class StatelessApplicationTest extends TestCase
                 "'StatelessApplication'.",
             );
             self::assertStringNotContainsString(
-                'application-secret-key',
+                'not-a-real-secret-key',
                 $responseBody,
                 "Response 'body' should NOT contain 'SECRET_KEY' value in debug output for fallback exception in " .
                 "'StatelessApplication'.",

--- a/tests/http/StatelessApplicationTest.php
+++ b/tests/http/StatelessApplicationTest.php
@@ -514,10 +514,10 @@ final class StatelessApplicationTest extends TestCase
 
         if (YII_DEBUG) {
             self::assertStringContainsString(
-                '$_SERVER =',
+                "\n\$_SERVER = [",
                 $responseBody,
-                "Response 'body' should contain '\$_SERVER =' debug output for fallback exception in " .
-                "'StatelessApplication'.",
+                "Response 'body' should contain '\$_SERVER = [' in correct order (label before array) for fallback " .
+                "exception debug output in 'StatelessApplication'.",
             );
             self::assertStringNotContainsString(
                 'not-a-secret-api-key',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that, in debug mode, fallback error pages mask sensitive server/environment values (API keys, auth tokens, DB passwords, secret keys) while still displaying safe context like host information.
  * Enhanced validation of 500 error responses to confirm correct status and fallback messaging, increasing confidence in error handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->