### PR TITLE
test: Add test for handling invalid `Authorization` header in `StatelessApplication` to return `null` credentials.

### DIFF
--- a/tests/http/StatelessApplicationTest.php
+++ b/tests/http/StatelessApplicationTest.php
@@ -1920,7 +1920,7 @@ final class StatelessApplicationTest extends TestCase
     public function testReturnNullCredentialsWhenAuthorizationHeaderHasInvalidBasicPrefix(): void
     {
         $_SERVER = [
-            'HTTP_AUTHORIZATION' => 'basi',
+            'HTTP_AUTHORIZATION' => 'basix ' . base64_encode('user:pass'),
             'REQUEST_METHOD' => 'GET',
             'REQUEST_URI' => 'site/auth',
         ];
@@ -1934,22 +1934,23 @@ final class StatelessApplicationTest extends TestCase
         self::assertSame(
             200,
             $response->getStatusCode(),
-            "Response 'status code' should be '200' for 'site/auth' route with invalid 'basi' Authorization header " .
+            "Response 'status code' should be '200' for 'site/auth' route with 'basix' 'HTTP_AUTHORIZATION' header " .
             "in 'StatelessApplication'.",
         );
         self::assertSame(
             'application/json; charset=UTF-8',
             $response->getHeaderLine('Content-Type'),
-            "Response 'Content-Type' should be 'application/json; charset=UTF-8' for 'site/auth' route with invalid " .
-            "'basi' Authorization header in 'StatelessApplication'.",
+            "Response 'Content-Type' should be 'application/json; charset=UTF-8' for 'site/auth' route with 'basix' " .
+            "'HTTP_AUTHORIZATION' header in 'StatelessApplication'.",
         );
         self::assertSame(
             <<<JSON
             {"username":null,"password":null}
             JSON,
             $response->getBody()->getContents(),
-            "Response 'body' should return 'null' credentials when 'Authorization' header is only 'basi' instead of " .
-            "'basic', confirming that exactly '5' characters must match for 'site/auth' route in 'StatelessApplication'.",
+            "Response 'body' should return 'null' credentials when 'HTTP_AUTHORIZATION' header is 'basix' instead of " .
+            "'basic', confirming that exactly '5' characters must match (not just '4') for 'site/auth' route in " .
+            "'StatelessApplication'.",
         );
     }
 

--- a/tests/http/StatelessApplicationTest.php
+++ b/tests/http/StatelessApplicationTest.php
@@ -1948,9 +1948,8 @@ final class StatelessApplicationTest extends TestCase
             {"username":null,"password":null}
             JSON,
             $response->getBody()->getContents(),
-            "Response 'body' should return 'null' credentials when 'HTTP_AUTHORIZATION' header is 'basix' instead of " .
-            "'basic', confirming that exactly '5' characters must match (not just '4') for 'site/auth' route in " .
-            "'StatelessApplication'.",
+            "Response 'body' should return 'null' credentials when the 'HTTP_AUTHORIZATION' header does not start " .
+            "with 'Basic ' (case-insensitive) for 'site/auth' route in 'StatelessApplication'.",
         );
     }
 

--- a/tests/http/StatelessApplicationTest.php
+++ b/tests/http/StatelessApplicationTest.php
@@ -1917,6 +1917,45 @@ final class StatelessApplicationTest extends TestCase
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
+    public function testReturnNullCredentialsWhenAuthorizationHeaderHasInvalidBasicPrefix(): void
+    {
+        $_SERVER = [
+            'HTTP_AUTHORIZATION' => 'basi',
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => 'site/auth',
+        ];
+
+        $request = FactoryHelper::createServerRequestCreator()->createFromGlobals();
+
+        $app = $this->statelessApplication();
+
+        $response = $app->handle($request);
+
+        self::assertSame(
+            200,
+            $response->getStatusCode(),
+            "Response 'status code' should be '200' for 'site/auth' route with invalid 'basi' Authorization header " .
+            "in 'StatelessApplication'.",
+        );
+        self::assertSame(
+            'application/json; charset=UTF-8',
+            $response->getHeaderLine('Content-Type'),
+            "Response 'Content-Type' should be 'application/json; charset=UTF-8' for 'site/auth' route with invalid " .
+            "'basi' Authorization header in 'StatelessApplication'.",
+        );
+        self::assertSame(
+            <<<JSON
+            {"username":null,"password":null}
+            JSON,
+            $response->getBody()->getContents(),
+            "Response 'body' should return 'null' credentials when 'Authorization' header is only 'basi' instead of " .
+            "'basic', confirming that exactly '5' characters must match for 'site/auth' route in 'StatelessApplication'.",
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
     public function testReturnPartialCredentialsWhenOnlyUsernameIsPresent(): void
     {
         $_SERVER = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a unit test verifying handling of an invalid Basic Authorization header prefix.
  * Confirms the app responds with HTTP 200, Content-Type application/json; charset=UTF-8, and JSON body with username and password as null.
  * Extends malformed-header coverage to ensure invalid auth prefixes are safely ignored.
  * No production code or user-facing behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->