### PR TITLE
test: Add test for returning credentials when valid Basic `Authorization` header is present in `StatelessApplication` class.

### DIFF
--- a/tests/http/StatelessApplicationTest.php
+++ b/tests/http/StatelessApplicationTest.php
@@ -2002,7 +2002,7 @@ final class StatelessApplicationTest extends TestCase
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
-    public function testReturnNullCredentialsWhenBasicAuthorizationHeaderHasInvalidBase64(): void
+    public function testReturnNullCredentialsWhenBasicAuthorizationHeaderHasInvalidBase64DueToMissingSpace(): void
     {
         $criticalBase64 = base64_encode('a:b'); // "YTpi"
 

--- a/tests/http/StatelessApplicationTest.php
+++ b/tests/http/StatelessApplicationTest.php
@@ -1443,6 +1443,46 @@ final class StatelessApplicationTest extends TestCase
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
+    public function testReturnCredentialsWhenValidBasicAuthorizationHeaderIsPresent(): void
+    {
+        $_SERVER = [
+            'HTTP_AUTHORIZATION' => 'Basic ' . base64_encode('testuser:testpass'),
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => 'site/auth',
+        ];
+
+        $request = FactoryHelper::createServerRequestCreator()->createFromGlobals();
+
+        $app = $this->statelessApplication();
+
+        $response = $app->handle($request);
+
+        self::assertSame(
+            200,
+            $response->getStatusCode(),
+            "Response 'status code' should be '200' for 'site/auth' route with valid Basic 'HTTP_AUTHORIZATION' " .
+            "header in 'StatelessApplication'.",
+        );
+        self::assertSame(
+            'application/json; charset=UTF-8',
+            $response->getHeaderLine('Content-Type'),
+            "Response 'Content-Type' should be 'application/json; charset=UTF-8' for 'site/auth' route with 'Basic' " .
+            "'HTTP_AUTHORIZATION' header in 'StatelessApplication'.",
+        );
+        self::assertSame(
+            <<<JSON
+            {"username":"testuser","password":"testpass"}
+            JSON,
+            $response->getBody()->getContents(),
+            "Response 'body' should return extracted credentials 'testuser' and 'testpass' when valid 'Basic' " .
+            "'HTTP_AUTHORIZATION' header is present, confirming correct 'mb_substr' extraction starting at position '6' " .
+            "(after 'Basic ') for 'site/auth' route in 'StatelessApplication'.",
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
     public function testReturnEmptyCookieCollectionWhenValidationEnabledWithInvalidCookies(): void
     {
         $app = $this->statelessApplication(

--- a/tests/http/StatelessApplicationTest.php
+++ b/tests/http/StatelessApplicationTest.php
@@ -2024,7 +2024,7 @@ final class StatelessApplicationTest extends TestCase
         self::assertSame(
             'application/json; charset=UTF-8',
             $response->getHeaderLine('Content-Type'),
-            "Response 'Content-Type' should be 'application/json; charset=UTF-8' for 'site/suth' route in " .
+            "Response 'Content-Type' should be 'application/json; charset=UTF-8' for 'site/auth' route in " .
             "'StatelessApplication'.",
         );
 
@@ -2070,7 +2070,7 @@ final class StatelessApplicationTest extends TestCase
         self::assertSame(
             'application/json; charset=UTF-8',
             $response->getHeaderLine('Content-Type'),
-            "Response 'Content-Type' should be 'application/json; charset=UTF-8' for 'site/suth' route in " .
+            "Response 'Content-Type' should be 'application/json; charset=UTF-8' for 'site/auth' route in " .
             "'StatelessApplication'.",
         );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests validating HTTP Basic Authorization header handling on the auth route for valid and multiple invalid/edge-case formats (bad prefix, missing space, malformed Base64), asserting 200 responses and JSON credential output.
  * Improves confidence in authentication behavior for stateless requests; no user-facing or production behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->