### PR TITLE
test(http): Extract memory tests from `ApplicationTest` to `ApplicationMemoryTest` class.

### DIFF
--- a/tests/http/stateless/ApplicationMemoryTest.php
+++ b/tests/http/stateless/ApplicationMemoryTest.php
@@ -313,7 +313,7 @@ final class ApplicationMemoryTest extends TestCase
      */
     public function testSetMemoryLimitWithLargePositiveValueMaintainsValue(): void
     {
-        $largeLimit = 2_147_483_647; // near 'PHP_INT_MAX'
+        $largeLimit = 2_147_483_647; // near '32-bit' 'INT_MAX'; well below '64-bit' 'PHP_INT_MAX'
 
         $app = $this->statelessApplication();
 

--- a/tests/http/stateless/ApplicationMemoryTest.php
+++ b/tests/http/stateless/ApplicationMemoryTest.php
@@ -1,0 +1,430 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\psrbridge\tests\http\stateless;
+
+use stdClass;
+use yii\base\InvalidConfigException;
+use yii2\extensions\psrbridge\tests\support\FactoryHelper;
+use yii2\extensions\psrbridge\tests\TestCase;
+
+use function array_fill;
+use function end;
+use function gc_disable;
+use function gc_enable;
+use function gc_status;
+use function ini_get;
+use function ini_set;
+use function memory_get_usage;
+use function ob_get_level;
+use function ob_start;
+
+use const PHP_INT_MAX;
+
+final class ApplicationMemoryTest extends TestCase
+{
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testCleanCalculatesCorrectMemoryThresholdWith90Percent(): void
+    {
+        $originalLimit = ini_get('memory_limit');
+
+        ini_set('memory_limit', '100M');
+
+        $app = $this->statelessApplication();
+
+        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
+        $memoryLimit = $app->getMemoryLimit();
+
+        self::assertFalse(
+            $app->clean(),
+            "'clean()' should return 'false' when memory usage is below the '90%' threshold of the configured memory " .
+            "limit ('100M'), confirming that no cleanup is needed in 'StatelessApplication'.",
+        );
+        self::assertSame(
+            104_857_600,
+            $memoryLimit,
+            "Memory limit should be exactly '104_857_600' bytes ('100M') for threshold calculation test in" .
+            "'StatelessApplication'.",
+        );
+        self::assertSame(
+            94_371_840.0,
+            $memoryLimit * 0.9,
+            "'90%' of '100M' should be exactly '94_371_840' bytes, not a division result like '116_508_444' bytes " .
+            "('100M' / '0.9') in 'StatelessApplication'.",
+        );
+
+        ini_set('memory_limit', $originalLimit);
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testCleanReturnsTrueWhenMemoryUsageExactlyEqualsThreshold(): void
+    {
+        $originalLimit = ini_get('memory_limit');
+
+        ini_set('memory_limit', '2G');
+
+        $app = $this->statelessApplication();
+
+        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
+
+        $currentUsage = memory_get_usage(true);
+
+        $artificialLimit = (int) ($currentUsage / 0.9);
+
+        $app->setMemoryLimit($artificialLimit);
+        $memoryLimit = $app->getMemoryLimit();
+
+        self::assertTrue(
+            $app->clean(),
+            "'clean()' should return 'true' when memory usage is exactly at or above '90%' threshold ('>=' operator)" .
+            ", not only when strictly greater than ('>' operator) in 'StatelessApplication'.",
+        );
+        self::assertSame(
+            $artificialLimit,
+            $memoryLimit,
+            "Memory limit should be set to the artificial limit '{$artificialLimit}' for threshold calculation test " .
+            "in 'StatelessApplication'.",
+        );
+
+        ini_set('memory_limit', $originalLimit);
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testCleanTriggersGarbageCollectionAndReducesMemoryUsage(): void
+    {
+        $originalLimit = ini_get('memory_limit');
+
+        ini_set('memory_limit', '512M');
+
+        gc_disable();
+
+        $app = $this->statelessApplication();
+
+        for ($i = 0; $i < 25; $i++) {
+            $circular = new stdClass();
+
+            $circular->self = $circular;
+
+            $circular->data = array_fill(0, 100, "data-{$i}");
+
+            $_SERVER = [
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => "site/index?iteration={$i}",
+            ];
+
+            $response = $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
+
+            $obj1 = new stdClass();
+            $obj2 = new stdClass();
+
+            $obj1->ref = $obj2;
+            $obj2->ref = $obj1;
+            $obj1->circular = $circular;
+
+            unset($circular, $obj1, $obj2, $response);
+        }
+
+        $gcStatsBefore = gc_status();
+        $memoryBefore = memory_get_usage(true);
+        $app->clean();
+        $memoryAfter = memory_get_usage(true);
+        $gcStatsAfter = gc_status();
+
+        gc_enable();
+
+        $cyclesCollected = $gcStatsAfter['collected'] - $gcStatsBefore['collected'];
+
+        self::assertGreaterThan(
+            0,
+            $cyclesCollected,
+            "'clean()' should trigger garbage collection that collects circular references, but no cycles were " .
+            "collected. This indicates 'gc_collect_cycles()' was not called in 'StatelessApplication'.",
+        );
+
+        $memoryDifference = $memoryAfter - $memoryBefore;
+
+        self::assertLessThanOrEqual(
+            1_048_576,
+            $memoryDifference,
+            "'clean()' should reduce memory usage through garbage collection. Memory increased by {$memoryDifference}" .
+            " bytes, suggesting 'gc_collect_cycles()' was not called in 'StatelessApplication'.",
+        );
+
+        ini_set('memory_limit', $originalLimit);
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testClearOutputCleansLocalBuffers(): void
+    {
+        $levels = [];
+
+        ob_start();
+        $levels[] = ob_get_level();
+        ob_start();
+        $levels[] = ob_get_level();
+        ob_start();
+        $levels[] = ob_get_level();
+
+        $app = $this->statelessApplication();
+
+        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
+
+        self::assertGreaterThanOrEqual(
+            3,
+            end($levels),
+            'Should have at least 3 output buffer levels before clearing output.',
+        );
+
+        $app->errorHandler->clearOutput();
+
+        $closed = true;
+
+        foreach ($levels as $level) {
+            $closed = $closed && (ob_get_level() < $level);
+        }
+
+        self::assertTrue(
+            $closed,
+            "Should close all local output buffers after calling 'clearOutput()'.",
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testGetMemoryLimitHandlesUnlimitedMemoryCorrectly(): void
+    {
+        $originalLimit = ini_get('memory_limit');
+
+        ini_set('memory_limit', '-1');
+
+        $app = $this->statelessApplication();
+
+        self::assertSame(
+            PHP_INT_MAX,
+            $app->getMemoryLimit(),
+            "Memory limit should be 'PHP_INT_MAX' when set to '-1' (unlimited) in 'StatelessApplication'.",
+        );
+
+        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
+        $app->clean();
+
+        ini_set('memory_limit', $originalLimit);
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testRecalculateMemoryLimitAfterResetAndIniChange(): void
+    {
+        $originalLimit = ini_get('memory_limit');
+
+        ini_set('memory_limit', '256M');
+
+        $app = $this->statelessApplication();
+
+        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
+
+        $firstCalculation = $app->getMemoryLimit();
+        $app->setMemoryLimit(0);
+
+        ini_set('memory_limit', '128M');
+
+        $secondCalculation = $app->getMemoryLimit();
+
+        self::assertSame(
+            134_217_728,
+            $secondCalculation,
+            "'getMemoryLimit()' should return '134_217_728' ('128M') after resetting and updating 'memory_limit' to " .
+            "'128M' in 'StatelessApplication'.",
+        );
+        self::assertNotSame(
+            $firstCalculation,
+            $secondCalculation,
+            "'getMemoryLimit()' should return a different value after recalculation when 'memory_limit' changes in " .
+            "'StatelessApplication'.",
+        );
+
+        ini_set('memory_limit', $originalLimit);
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnFalseFromCleanWhenMemoryUsageIsBelowThreshold(): void
+    {
+        $originalLimit = ini_get('memory_limit');
+
+        ini_set('memory_limit', '1G');
+
+        $app = $this->statelessApplication();
+
+        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
+
+        self::assertFalse(
+            $app->clean(),
+            "'clean()' should return 'false' when memory usage is below '90%' of the configured 'memory_limit' in " .
+            "'StatelessApplication'.",
+        );
+
+        ini_set('memory_limit', $originalLimit);
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnPhpIntMaxWhenMemoryLimitIsUnlimited(): void
+    {
+        $originalLimit = ini_get('memory_limit');
+
+        ini_set('memory_limit', '-1');
+
+        $app = $this->statelessApplication();
+
+        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
+
+        self::assertSame(
+            PHP_INT_MAX,
+            $app->getMemoryLimit(),
+            "'getMemoryLimit()' should return 'PHP_INT_MAX' when 'memory_limit' is set to '-1' (unlimited) in " .
+            "'StatelessApplication'.",
+        );
+        self::assertSame(
+            PHP_INT_MAX,
+            $app->getMemoryLimit(),
+            "'getMemoryLimit()' should remain 'PHP_INT_MAX' after handling a request with unlimited memory in " .
+            "'StatelessApplication'.",
+        );
+
+        ini_set('memory_limit', $originalLimit);
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testSetMemoryLimitWithLargePositiveValueMaintainsValue(): void
+    {
+        $largeLimit = 2_147_483_647; // near 'PHP_INT_MAX'
+
+        $app = $this->statelessApplication();
+
+        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
+        $app->setMemoryLimit($largeLimit);
+
+        self::assertSame(
+            $largeLimit,
+            $app->getMemoryLimit(),
+            'Memory limit should handle large positive values correctly without overflow.',
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testSetMemoryLimitWithPositiveValueDisablesRecalculation(): void
+    {
+        $customLimit = 134_217_728; // '128MB' in bytes
+
+        $originalLimit = ini_get('memory_limit');
+
+        ini_set('memory_limit', '512M');
+
+        $app = $this->statelessApplication();
+
+        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
+        $app->setMemoryLimit($customLimit);
+
+        ini_set('memory_limit', '1G');
+
+        self::assertSame(
+            $customLimit,
+            $app->getMemoryLimit(),
+            'Memory limit should remain unchanged when recalculation is disabled after setting positive value.',
+        );
+
+        ini_set('memory_limit', $originalLimit);
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testSetMemoryLimitWithPositiveValueOverridesSystemRecalculation(): void
+    {
+        $originalLimit = ini_get('memory_limit');
+
+        $app = $this->statelessApplication();
+
+        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
+        $app->setMemoryLimit(0);
+
+        ini_set('memory_limit', '256M');
+
+        $systemBasedLimit = $app->getMemoryLimit();
+
+        $customLimit = 104_857_600; // '100MB' in bytes (different from system)
+
+        $app->setMemoryLimit($customLimit);
+
+        ini_set('memory_limit', '512M');
+
+        self::assertSame(
+            $customLimit,
+            $app->getMemoryLimit(),
+            'Memory limit should maintain custom value and ignore system changes when set to positive value.',
+        );
+        self::assertNotSame(
+            $systemBasedLimit,
+            $app->getMemoryLimit(),
+            'Memory limit should override system-based calculation when positive value is set.',
+        );
+
+        ini_set('memory_limit', $originalLimit);
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testSetMemoryLimitWithPositiveValueSetsLimitDirectly(): void
+    {
+        $memoryLimit = 268_435_456; // '256MB' in bytes
+
+        $app = $this->statelessApplication();
+
+        $app->setMemoryLimit($memoryLimit);
+        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
+
+        self::assertSame(
+            $memoryLimit,
+            $app->getMemoryLimit(),
+            'Memory limit should be set to the exact value when a positive limit is provided.',
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testSetMemoryLimitWithSmallPositiveValueSetsCorrectly(): void
+    {
+        $smallLimit = 1024; // '1KB'
+
+        $app = $this->statelessApplication();
+
+        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
+        $app->setMemoryLimit($smallLimit);
+
+        self::assertSame(
+            $smallLimit,
+            $app->getMemoryLimit(),
+            'Memory limit should handle small positive values correctly.',
+        );
+    }
+}

--- a/tests/http/stateless/ApplicationTest.php
+++ b/tests/http/stateless/ApplicationTest.php
@@ -16,19 +16,13 @@ use yii2\extensions\psrbridge\tests\provider\StatelessApplicationProvider;
 use yii2\extensions\psrbridge\tests\support\FactoryHelper;
 use yii2\extensions\psrbridge\tests\TestCase;
 
-use function array_fill;
 use function array_filter;
 use function array_key_exists;
 use function base64_encode;
-use function end;
 use function explode;
-use function gc_disable;
-use function gc_enable;
-use function gc_status;
 use function implode;
 use function ini_get;
 use function ini_set;
-use function memory_get_usage;
 use function ob_get_level;
 use function ob_start;
 use function preg_quote;
@@ -39,8 +33,6 @@ use function sprintf;
 use function str_contains;
 use function str_starts_with;
 use function uniqid;
-
-use const PHP_INT_MAX;
 
 #[Group('http')]
 final class ApplicationTest extends TestCase
@@ -226,180 +218,6 @@ final class ApplicationTest extends TestCase
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
-    public function testCleanCalculatesCorrectMemoryThresholdWith90Percent(): void
-    {
-        $originalLimit = ini_get('memory_limit');
-
-        ini_set('memory_limit', '100M');
-
-        $app = $this->statelessApplication();
-
-        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-        $memoryLimit = $app->getMemoryLimit();
-
-        self::assertFalse(
-            $app->clean(),
-            "'clean()' should return 'false' when memory usage is below the '90%' threshold of the configured memory " .
-            "limit ('100M'), confirming that no cleanup is needed in 'StatelessApplication'.",
-        );
-        self::assertSame(
-            104_857_600,
-            $memoryLimit,
-            "Memory limit should be exactly '104_857_600' bytes ('100M') for threshold calculation test in" .
-            "'StatelessApplication'.",
-        );
-        self::assertSame(
-            94_371_840.0,
-            $memoryLimit * 0.9,
-            "'90%' of '100M' should be exactly '94_371_840' bytes, not a division result like '116_508_444' bytes " .
-            "('100M' / '0.9') in 'StatelessApplication'.",
-        );
-
-        ini_set('memory_limit', $originalLimit);
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testCleanReturnsTrueWhenMemoryUsageExactlyEqualsThreshold(): void
-    {
-        $originalLimit = ini_get('memory_limit');
-
-        ini_set('memory_limit', '2G');
-
-        $app = $this->statelessApplication();
-
-        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-
-        $currentUsage = memory_get_usage(true);
-
-        $artificialLimit = (int) ($currentUsage / 0.9);
-
-        $app->setMemoryLimit($artificialLimit);
-        $memoryLimit = $app->getMemoryLimit();
-
-        self::assertTrue(
-            $app->clean(),
-            "'clean()' should return 'true' when memory usage is exactly at or above '90%' threshold ('>=' operator)" .
-            ", not only when strictly greater than ('>' operator) in 'StatelessApplication'.",
-        );
-        self::assertSame(
-            $artificialLimit,
-            $memoryLimit,
-            "Memory limit should be set to the artificial limit '{$artificialLimit}' for threshold calculation test " .
-            "in 'StatelessApplication'.",
-        );
-
-        ini_set('memory_limit', $originalLimit);
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testCleanTriggersGarbageCollectionAndReducesMemoryUsage(): void
-    {
-        $originalLimit = ini_get('memory_limit');
-
-        ini_set('memory_limit', '512M');
-
-        gc_disable();
-
-        $app = $this->statelessApplication();
-
-        for ($i = 0; $i < 25; $i++) {
-            $circular = new stdClass();
-
-            $circular->self = $circular;
-
-            $circular->data = array_fill(0, 100, "data-{$i}");
-
-            $_SERVER = [
-                'REQUEST_METHOD' => 'GET',
-                'REQUEST_URI' => "site/index?iteration={$i}",
-            ];
-
-            $response = $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-
-            $obj1 = new stdClass();
-            $obj2 = new stdClass();
-
-            $obj1->ref = $obj2;
-            $obj2->ref = $obj1;
-            $obj1->circular = $circular;
-
-            unset($circular, $obj1, $obj2, $response);
-        }
-
-        $gcStatsBefore = gc_status();
-        $memoryBefore = memory_get_usage(true);
-        $app->clean();
-        $memoryAfter = memory_get_usage(true);
-        $gcStatsAfter = gc_status();
-
-        gc_enable();
-
-        $cyclesCollected = $gcStatsAfter['collected'] - $gcStatsBefore['collected'];
-
-        self::assertGreaterThan(
-            0,
-            $cyclesCollected,
-            "'clean()' should trigger garbage collection that collects circular references, but no cycles were " .
-            "collected. This indicates 'gc_collect_cycles()' was not called in 'StatelessApplication'.",
-        );
-
-        $memoryDifference = $memoryAfter - $memoryBefore;
-
-        self::assertLessThanOrEqual(
-            1_048_576,
-            $memoryDifference,
-            "'clean()' should reduce memory usage through garbage collection. Memory increased by {$memoryDifference}" .
-            " bytes, suggesting 'gc_collect_cycles()' was not called in 'StatelessApplication'.",
-        );
-
-        ini_set('memory_limit', $originalLimit);
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testClearOutputCleansLocalBuffers(): void
-    {
-        $levels = [];
-
-        ob_start();
-        $levels[] = ob_get_level();
-        ob_start();
-        $levels[] = ob_get_level();
-        ob_start();
-        $levels[] = ob_get_level();
-
-        $app = $this->statelessApplication();
-
-        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-
-        self::assertGreaterThanOrEqual(
-            3,
-            end($levels),
-            'Should have at least 3 output buffer levels before clearing output.',
-        );
-
-        $app->errorHandler->clearOutput();
-
-        $closed = true;
-
-        foreach ($levels as $level) {
-            $closed = $closed && (ob_get_level() < $level);
-        }
-
-        self::assertTrue(
-            $closed,
-            "Should close all local output buffers after calling 'clearOutput()'.",
-        );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
     public function testFiltersSensitiveServerVariablesInFallbackExceptionMessage(): void
     {
         $_SERVER = [
@@ -570,29 +388,6 @@ final class ApplicationTest extends TestCase
             "Flash message array should be empty for new session 'flash-user-b', confirming session isolation in " .
             "'StatelessApplication'.",
         );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testGetMemoryLimitHandlesUnlimitedMemoryCorrectly(): void
-    {
-        $originalLimit = ini_get('memory_limit');
-
-        ini_set('memory_limit', '-1');
-
-        $app = $this->statelessApplication();
-
-        self::assertSame(
-            PHP_INT_MAX,
-            $app->getMemoryLimit(),
-            "Memory limit should be 'PHP_INT_MAX' when set to '-1' (unlimited) in 'StatelessApplication'.",
-        );
-
-        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-        $app->clean();
-
-        ini_set('memory_limit', $originalLimit);
     }
 
     /**
@@ -776,42 +571,6 @@ final class ApplicationTest extends TestCase
                 ),
             );
         }
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testRecalculateMemoryLimitAfterResetAndIniChange(): void
-    {
-        $originalLimit = ini_get('memory_limit');
-
-        ini_set('memory_limit', '256M');
-
-        $app = $this->statelessApplication();
-
-        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-
-        $firstCalculation = $app->getMemoryLimit();
-        $app->setMemoryLimit(0);
-
-        ini_set('memory_limit', '128M');
-
-        $secondCalculation = $app->getMemoryLimit();
-
-        self::assertSame(
-            134_217_728,
-            $secondCalculation,
-            "'getMemoryLimit()' should return '134_217_728' ('128M') after resetting and updating 'memory_limit' to " .
-            "'128M' in 'StatelessApplication'.",
-        );
-        self::assertNotSame(
-            $firstCalculation,
-            $secondCalculation,
-            "'getMemoryLimit()' should return a different value after recalculation when 'memory_limit' changes in " .
-            "'StatelessApplication'.",
-        );
-
-        ini_set('memory_limit', $originalLimit);
     }
 
     /**
@@ -1274,28 +1033,6 @@ final class ApplicationTest extends TestCase
             $response->getBody()->getContents(),
             'CookieCollection should be empty when validation is enabled but cookies are invalid.',
         );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testReturnFalseFromCleanWhenMemoryUsageIsBelowThreshold(): void
-    {
-        $originalLimit = ini_get('memory_limit');
-
-        ini_set('memory_limit', '1G');
-
-        $app = $this->statelessApplication();
-
-        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-
-        self::assertFalse(
-            $app->clean(),
-            "'clean()' should return 'false' when memory usage is below '90%' of the configured 'memory_limit' in " .
-            "'StatelessApplication'.",
-        );
-
-        ini_set('memory_limit', $originalLimit);
     }
 
     /**
@@ -1855,35 +1592,6 @@ final class ApplicationTest extends TestCase
             "Response 'body' should return username 'admin' and 'null' password when only 'PHP_AUTH_USER' is " .
             "present, confirming OR logic works correctly for 'site/auth' route in 'StatelessApplication'.",
         );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testReturnPhpIntMaxWhenMemoryLimitIsUnlimited(): void
-    {
-        $originalLimit = ini_get('memory_limit');
-
-        ini_set('memory_limit', '-1');
-
-        $app = $this->statelessApplication();
-
-        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-
-        self::assertSame(
-            PHP_INT_MAX,
-            $app->getMemoryLimit(),
-            "'getMemoryLimit()' should return 'PHP_INT_MAX' when 'memory_limit' is set to '-1' (unlimited) in " .
-            "'StatelessApplication'.",
-        );
-        self::assertSame(
-            PHP_INT_MAX,
-            $app->getMemoryLimit(),
-            "'getMemoryLimit()' should remain 'PHP_INT_MAX' after handling a request with unlimited memory in " .
-            "'StatelessApplication'.",
-        );
-
-        ini_set('memory_limit', $originalLimit);
     }
 
     /**
@@ -2616,127 +2324,6 @@ final class ApplicationTest extends TestCase
             $cookie[0] ?? '',
             "Response 'Set-Cookie' header should match the expected format for a new session 'ID' when no session " .
             "cookie is sent in 'StatelessApplication'. Value received: '" . ($cookie[0] ?? '') . "'.",
-        );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testSetMemoryLimitWithLargePositiveValueMaintainsValue(): void
-    {
-        $largeLimit = 2_147_483_647; // Near PHP_INT_MAX
-
-        $app = $this->statelessApplication();
-
-        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-        $app->setMemoryLimit($largeLimit);
-
-        self::assertSame(
-            $largeLimit,
-            $app->getMemoryLimit(),
-            'Memory limit should handle large positive values correctly without overflow.',
-        );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testSetMemoryLimitWithPositiveValueDisablesRecalculation(): void
-    {
-        $customLimit = 134_217_728; // 128MB in bytes
-
-        $originalLimit = ini_get('memory_limit');
-
-        ini_set('memory_limit', '512M');
-
-        $app = $this->statelessApplication();
-
-        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-        $app->setMemoryLimit($customLimit);
-
-        ini_set('memory_limit', '1G');
-
-        self::assertSame(
-            $customLimit,
-            $app->getMemoryLimit(),
-            'Memory limit should remain unchanged when recalculation is disabled after setting positive value.',
-        );
-
-        ini_set('memory_limit', $originalLimit);
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testSetMemoryLimitWithPositiveValueOverridesSystemRecalculation(): void
-    {
-        $originalLimit = ini_get('memory_limit');
-
-        $app = $this->statelessApplication();
-
-        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-        $app->setMemoryLimit(0);
-
-        ini_set('memory_limit', '256M');
-
-        $systemBasedLimit = $app->getMemoryLimit();
-
-        $customLimit = 104_857_600; // 100MB in bytes (different from system)
-
-        $app->setMemoryLimit($customLimit);
-
-        ini_set('memory_limit', '512M');
-
-        self::assertSame(
-            $customLimit,
-            $app->getMemoryLimit(),
-            'Memory limit should maintain custom value and ignore system changes when set to positive value.',
-        );
-
-        self::assertNotSame(
-            $systemBasedLimit,
-            $app->getMemoryLimit(),
-            'Memory limit should override system-based calculation when positive value is set.',
-        );
-
-        ini_set('memory_limit', $originalLimit);
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testSetMemoryLimitWithPositiveValueSetsLimitDirectly(): void
-    {
-        $memoryLimit = 268_435_456; // 256MB in bytes
-
-        $app = $this->statelessApplication();
-
-        $app->setMemoryLimit($memoryLimit);
-        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-
-        self::assertSame(
-            $memoryLimit,
-            $app->getMemoryLimit(),
-            'Memory limit should be set to the exact value when a positive limit is provided.',
-        );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testSetMemoryLimitWithSmallPositiveValueSetsCorrectly(): void
-    {
-        $smallLimit = 1024; // 1KB
-
-        $app = $this->statelessApplication();
-
-        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-        $app->setMemoryLimit($smallLimit);
-
-        self::assertSame(
-            $smallLimit,
-            $app->getMemoryLimit(),
-            'Memory limit should handle small positive values correctly.',
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a focused test suite validating memory-limit handling, cleanup thresholds (90%), garbage-collection effects, and output-buffer clearing across simulated requests.
  * Removed overlapping memory-related tests from the legacy suite to eliminate duplication.
  * Expanded coverage for unlimited memory, dynamic memory-limit recalculation after config changes, and consistent behavior across multiple requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->