### PR TITLE
test(http): Rename test method for clarity in `ApplicationAuthTest` class.

### DIFF
--- a/tests/http/stateless/ApplicationAuthTest.php
+++ b/tests/http/stateless/ApplicationAuthTest.php
@@ -18,7 +18,7 @@ final class ApplicationAuthTest extends TestCase
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
     #[DataProviderExternal(StatelessApplicationProvider::class, 'authCredentials')]
-    public function testReturnAuthJsonResponseForHttpAuthorizationHeaders(
+    public function testReturnJsonBodyWithUsernameAndPasswordForHttpAuthorization(
         string $httpAuthorization,
         string $expectedJson,
         string $expectedAssertMessage,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
