### PR TITLE
test(http): Replace `DataProviderExternal` with `TestWith` for event handling tests in `ApplicationTest` class.

### DIFF
--- a/tests/http/stateless/ApplicationTest.php
+++ b/tests/http/stateless/ApplicationTest.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace yii2\extensions\psrbridge\tests\http\stateless;
 
-use PHPUnit\Framework\Attributes\{DataProviderExternal, Group, RequiresPhpExtension};
+use PHPUnit\Framework\Attributes\{Group, RequiresPhpExtension, TestWith};
 use yii\base\{Exception, InvalidConfigException};
 use yii\helpers\Json;
 use yii\log\{FileTarget, Logger};
 use yii\web\NotFoundHttpException;
 use yii2\extensions\psrbridge\exception\Message;
-use yii2\extensions\psrbridge\http\Response;
-use yii2\extensions\psrbridge\tests\provider\StatelessApplicationProvider;
+use yii2\extensions\psrbridge\http\{Response, StatelessApplication};
 use yii2\extensions\psrbridge\tests\support\FactoryHelper;
 use yii2\extensions\psrbridge\tests\TestCase;
 
@@ -992,7 +991,8 @@ final class ApplicationTest extends TestCase
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
-    #[DataProviderExternal(StatelessApplicationProvider::class, 'eventDataProvider')]
+    #[TestWith([StatelessApplication::EVENT_AFTER_REQUEST])]
+    #[TestWith([StatelessApplication::EVENT_BEFORE_REQUEST])]
     public function testTriggerEventDuringHandle(string $eventName): void
     {
         $eventTriggered = false;

--- a/tests/provider/StatelessApplicationProvider.php
+++ b/tests/provider/StatelessApplicationProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace yii2\extensions\psrbridge\tests\provider;
 
 use stdClass;
-use yii2\extensions\psrbridge\http\StatelessApplication;
 
 use function base64_encode;
 
@@ -187,17 +186,6 @@ final class StatelessApplicationProvider
                 JSON,
                 'Response body should contain signed cookies with their properties when validation is enabled.',
             ],
-        ];
-    }
-
-    /**
-     * @phpstan-return array<string, array{string}>
-     */
-    public static function eventDataProvider(): array
-    {
-        return [
-            'after request' => [StatelessApplication::EVENT_AFTER_REQUEST],
-            'before request' => [StatelessApplication::EVENT_BEFORE_REQUEST],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
