### PR TITLE
test(http): Add data provider for `memoryLimitPositive` tests in `StatelessApplicationProvider` and refactor related tests in `ApplicationMemoryTest` class.

### DIFF
--- a/tests/http/stateless/ApplicationMemoryTest.php
+++ b/tests/http/stateless/ApplicationMemoryTest.php
@@ -351,19 +351,16 @@ final class ApplicationMemoryTest extends TestCase
     #[DataProviderExternal(StatelessApplicationProvider::class, 'memoryLimitPositive')]
     public function testSetMemoryLimitWithPositiveValueSetsLimitDirectly(
         int $memoryLimit,
-        int $expectedLimit,
         string $assertionMessage,
     ): void {
         $app = $this->statelessApplication();
 
         $app->setMemoryLimit($memoryLimit);
 
+        self::assertSame($memoryLimit, $app->getMemoryLimit(), $assertionMessage);
+
         $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
 
-        self::assertSame(
-            $expectedLimit,
-            $app->getMemoryLimit(),
-            $assertionMessage,
-        );
+        self::assertSame($memoryLimit, $app->getMemoryLimit(), $assertionMessage);
     }
 }

--- a/tests/http/stateless/ApplicationMemoryTest.php
+++ b/tests/http/stateless/ApplicationMemoryTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace yii2\extensions\psrbridge\tests\http\stateless;
 
+use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 use yii\base\InvalidConfigException;
+use yii2\extensions\psrbridge\tests\provider\StatelessApplicationProvider;
 use yii2\extensions\psrbridge\tests\support\FactoryHelper;
 use yii2\extensions\psrbridge\tests\TestCase;
 
@@ -313,52 +315,6 @@ final class ApplicationMemoryTest extends TestCase
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
-    public function testSetMemoryLimitWithLargePositiveValueMaintainsValue(): void
-    {
-        $largeLimit = 2_147_483_647; // near '32-bit' 'INT_MAX'; well below '64-bit' 'PHP_INT_MAX'
-
-        $app = $this->statelessApplication();
-
-        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-        $app->setMemoryLimit($largeLimit);
-
-        self::assertSame(
-            $largeLimit,
-            $app->getMemoryLimit(),
-            'Memory limit should handle large positive values correctly without overflow.',
-        );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testSetMemoryLimitWithPositiveValueDisablesRecalculation(): void
-    {
-        $customLimit = 134_217_728; // '128MB' in bytes
-
-        $originalLimit = ini_get('memory_limit');
-
-        ini_set('memory_limit', '512M');
-
-        $app = $this->statelessApplication();
-
-        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-        $app->setMemoryLimit($customLimit);
-
-        ini_set('memory_limit', '1G');
-
-        self::assertSame(
-            $customLimit,
-            $app->getMemoryLimit(),
-            'Memory limit should remain unchanged when recalculation is disabled after setting positive value.',
-        );
-
-        ini_set('memory_limit', $originalLimit);
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
     public function testSetMemoryLimitWithPositiveValueOverridesSystemRecalculation(): void
     {
         $originalLimit = ini_get('memory_limit');
@@ -392,41 +348,22 @@ final class ApplicationMemoryTest extends TestCase
         ini_set('memory_limit', $originalLimit);
     }
 
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testSetMemoryLimitWithPositiveValueSetsLimitDirectly(): void
-    {
-        $memoryLimit = 268_435_456; // '256MB' in bytes
-
+    #[DataProviderExternal(StatelessApplicationProvider::class, 'memoryLimitPositive')]
+    public function testSetMemoryLimitWithPositiveValueSetsLimitDirectly(
+        int $memoryLimit,
+        int $expectedLimit,
+        string $assertionMessage,
+    ): void {
         $app = $this->statelessApplication();
 
         $app->setMemoryLimit($memoryLimit);
+
         $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
 
         self::assertSame(
-            $memoryLimit,
+            $expectedLimit,
             $app->getMemoryLimit(),
-            'Memory limit should be set to the exact value when a positive limit is provided.',
-        );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testSetMemoryLimitWithSmallPositiveValueSetsCorrectly(): void
-    {
-        $smallLimit = 1024; // '1KB'
-
-        $app = $this->statelessApplication();
-
-        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-        $app->setMemoryLimit($smallLimit);
-
-        self::assertSame(
-            $smallLimit,
-            $app->getMemoryLimit(),
-            'Memory limit should handle small positive values correctly.',
+            $assertionMessage,
         );
     }
 }

--- a/tests/provider/StatelessApplicationProvider.php
+++ b/tests/provider/StatelessApplicationProvider.php
@@ -194,28 +194,34 @@ final class StatelessApplicationProvider
      */
     public static function memoryLimitPositive(): array
     {
-        return [
+        $data = [
             'small value 1KB' => [
-                1024,
                 1024,
                 "Memory limit should be set to exactly '1024' bytes ('1KB') when positive value is provided.",
             ],
             'medium value 128MB' => [
                 134_217_728,
-                134_217_728,
                 "Memory limit should be set to exactly '134_217_728' bytes ('128MB') when positive value is provided.",
             ],
             'large value 256MB' => [
-                268_435_456,
                 268_435_456,
                 "Memory limit should be set to exactly '268_435_456' bytes ('256MB') when positive value is provided.",
             ],
             'very large value near 32-bit INT_MAX' => [
                 2_147_483_647,
-                2_147_483_647,
                 'Memory limit should handle large positive values correctly without overflow when set to ' .
                 "'2_147_483_647' bytes.",
             ],
         ];
+
+        if (PHP_INT_SIZE >= 8) {
+            $data['ultra large value 4GiB (64-bit only)'] = [
+                4_294_967_296,
+                "Memory limit should be set to exactly '4_294_967_296' bytes ('4GiB') when a positive value is " .
+                "provided on '64-bit'.",
+            ];
+        }
+
+        return $data;
     }
 }

--- a/tests/provider/StatelessApplicationProvider.php
+++ b/tests/provider/StatelessApplicationProvider.php
@@ -218,7 +218,7 @@ final class StatelessApplicationProvider
             $data['ultra large value 4GiB (64-bit only)'] = [
                 4_294_967_296,
                 "Memory limit should be set to exactly '4_294_967_296' bytes ('4GiB') when a positive value is " .
-                "provided on '64-bit'.",
+                "provided on '64-bit' builds.",
             ];
         }
 

--- a/tests/provider/StatelessApplicationProvider.php
+++ b/tests/provider/StatelessApplicationProvider.php
@@ -190,7 +190,7 @@ final class StatelessApplicationProvider
     }
 
     /**
-     * @phpstan-return array<string, array{int, int, string}>
+     * @phpstan-return array<string, array{int, string}>
      */
     public static function memoryLimitPositive(): array
     {

--- a/tests/provider/StatelessApplicationProvider.php
+++ b/tests/provider/StatelessApplicationProvider.php
@@ -188,4 +188,34 @@ final class StatelessApplicationProvider
             ],
         ];
     }
+
+    /**
+     * @phpstan-return array<string, array{int, int, string}>
+     */
+    public static function memoryLimitPositive(): array
+    {
+        return [
+            'small value 1KB' => [
+                1024,
+                1024,
+                "Memory limit should be set to exactly '1024' bytes ('1KB') when positive value is provided.",
+            ],
+            'medium value 128MB' => [
+                134_217_728,
+                134_217_728,
+                "Memory limit should be set to exactly '134_217_728' bytes ('128MB') when positive value is provided.",
+            ],
+            'large value 256MB' => [
+                268_435_456,
+                268_435_456,
+                "Memory limit should be set to exactly '268_435_456' bytes ('256MB') when positive value is provided.",
+            ],
+            'very large value near 32-bit INT_MAX' => [
+                2_147_483_647,
+                2_147_483_647,
+                'Memory limit should handle large positive values correctly without overflow when set to ' .
+                "'2_147_483_647' bytes.",
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Converted memory-limit checks to a parameterized, data-driven test to remove duplication and clarify intent.
  * Added a shared data provider supplying multiple positive memory-limit cases (small KB, mid/large MB, near 32-bit max; includes an extra 64-bit-only 4GiB case).
  * Removed redundant single-case tests while retaining coverage for override/recalculation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->