### PR TITLE
test(http): Rename test method for clarity and remove redundant test for unlimited memory limit in `ApplicationMemoryTest` class.

### DIFF
--- a/tests/http/stateless/ApplicationMemoryTest.php
+++ b/tests/http/stateless/ApplicationMemoryTest.php
@@ -179,7 +179,7 @@ final class ApplicationMemoryTest extends TestCase
         self::assertSame(
             PHP_INT_MAX,
             $app->getMemoryLimit(),
-            "Memory limit should be 'PHP_INT_MAX' when set to '-1' (unlimited) in 'StatelessApplication'.",
+            "Before 'handle()' memory limit should be 'PHP_INT_MAX' when set to '-1' (unlimited).",
         );
 
         $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
@@ -188,7 +188,7 @@ final class ApplicationMemoryTest extends TestCase
         self::assertSame(
             PHP_INT_MAX,
             $app->getMemoryLimit(),
-            "Memory limit should be 'PHP_INT_MAX' when set to '-1' (unlimited) in 'StatelessApplication'.",
+            "After 'clean()' memory limit should remain 'PHP_INT_MAX' when set to '-1'.",
         );
 
         ini_set('memory_limit', $originalLimit);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Consolidated duplicate tests for the unlimited-memory scenario into a single, unified test.
  - Renamed the test to better reflect its scope and updated assertion messages for clarity (pre/post checks now in one test).
  - Ensured environment cleanup and restoration remain intact.
  - No changes to runtime behavior, configuration, or public interfaces for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->