### PR TITLE
test(http): Simplify assertion messages in `ApplicationAuthTest` for clarity.

### DIFF
--- a/tests/http/stateless/ApplicationAuthTest.php
+++ b/tests/http/stateless/ApplicationAuthTest.php
@@ -35,12 +35,12 @@ final class ApplicationAuthTest extends TestCase
         self::assertSame(
             200,
             $response->getStatusCode(),
-            "Response 'status code' should be '200' for 'site/auth' route.",
+            "Expected HTTP '200' for route 'site/auth'.",
         );
         self::assertSame(
             'application/json; charset=UTF-8',
             $response->getHeaderLine('Content-Type'),
-            "Response 'Content-Type' should be 'application/json; charset=UTF-8' for 'site/auth' route.",
+            "Expected Content-Type 'application/json; charset=UTF-8' for route 'site/auth'.",
         );
         self::assertJsonStringEqualsJsonString(
             $expectedJson,
@@ -67,20 +67,20 @@ final class ApplicationAuthTest extends TestCase
         self::assertSame(
             200,
             $response->getStatusCode(),
-            "Response 'status code' should be '200' for 'site/auth' route.",
+            "Expected HTTP '200' for route 'site/auth'.",
         );
         self::assertSame(
             'application/json; charset=UTF-8',
             $response->getHeaderLine('Content-Type'),
-            "Response 'Content-Type' should be 'application/json; charset=UTF-8' for 'site/auth' route.",
+            "Expected Content-Type 'application/json; charset=UTF-8' for route 'site/auth'.",
         );
         self::assertJsonStringEqualsJsonString(
             <<<JSON
             {"username":"admin","password":null}
             JSON,
             $response->getBody()->getContents(),
-            "Response 'body' should be a JSON string with 'username' and 'password' as 'null' for 'PHP_AUTH_USER' " .
-            "header in 'site/auth' route.",
+            "Expected JSON body with 'username' and 'null' password when only 'PHP_AUTH_USER' is present for route " .
+            "'site/auth'.",
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refined assertion messages in authentication HTTP tests: removed internal class context from failure messages and standardized route references to "site/auth". Error messages for status, content-type, and JSON body expectations were clarified. No changes to application behavior, test logic, or coverage—only improved test output readability for development and CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->