### PR TITLE
test(http): Simplify assertion messages in `ApplicationCookieTest` for improved clarity.

### DIFF
--- a/tests/http/stateless/ApplicationAuthTest.php
+++ b/tests/http/stateless/ApplicationAuthTest.php
@@ -79,8 +79,7 @@ final class ApplicationAuthTest extends TestCase
             {"username":"admin","password":null}
             JSON,
             $response->getBody()->getContents(),
-            "Expected JSON body with 'username' and 'null' password when only PHP_AUTH_USER is present for route " .
-            "'site/auth'.",
+            "Expected JSON body with 'username' and 'null' password when only PHP_AUTH_USER is present.",
         );
     }
 }

--- a/tests/http/stateless/ApplicationCookieTest.php
+++ b/tests/http/stateless/ApplicationCookieTest.php
@@ -94,8 +94,7 @@ final class ApplicationCookieTest extends TestCase
             ["user_preference=; Expires=Fri, 22-Aug-2025 13:03:16 GMT; Max-Age=0; Path=/app; Secure; HttpOnly; SameSite=Lax"]
             JSON,
             Json::encode($response->getHeader('Set-Cookie')),
-            "Response Set-Cookie headers should contain the deletion header for 'user_preference' cookie in " .
-            "'site/deletecookie' route.",
+            "Response Set-Cookie headers should contain the deletion header for 'user_preference' cookie.",
         );
     }
 
@@ -133,7 +132,7 @@ final class ApplicationCookieTest extends TestCase
         self::assertCount(
             2,
             $testCookieHeaders,
-            "Response should contain exactly '2' non-session Set-Cookie headers for 'site/multiplecookies' route.",
+            "Response should contain exactly '2' non-session Set-Cookie headers.",
         );
 
         $headerString = implode('|', $testCookieHeaders);
@@ -141,19 +140,17 @@ final class ApplicationCookieTest extends TestCase
         self::assertStringContainsString(
             'theme=dark',
             $headerString,
-            "Response Set-Cookie headers should contain 'theme=dark' for 'site/multiplecookies' route,",
+            "Response Set-Cookie headers should contain 'theme=dark' for regular cookie.",
         );
         self::assertStringContainsString(
             'old_session=',
             $headerString,
-            "Response Set-Cookie headers should contain 'old_session=' for cookie deletion in " .
-            "'site/multiplecookies' route.",
+            "Response Set-Cookie headers should contain 'old_session=' for regular cookie.",
         );
         self::assertStringNotContainsString(
             'temp_data=',
             $headerString,
-            "Response Set-Cookie headers should NOT contain 'temp_data=' for deleted cookie in " .
-            "'site/multiplecookies' route.",
+            "Response Set-Cookie headers should NOT contain 'temp_data=' for deleted cookie.",
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Refined assertion messages for authentication and cookie-related HTTP route tests.
  - Standardized wording for HTTP status and Content-Type expectations.
  - Simplified Set-Cookie header validations and removed redundant framework mentions.
  - No changes to asserted values or test logic; behavior remains unchanged.
  - Improves clarity of failure messages and consistency across tests.

- Notes
  - No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->