### PR TITLE
test(http): Simplify response body assertion messages in `StatelessApplicationProvider` for improved clarity.

### DIFF
--- a/tests/provider/StatelessApplicationProvider.php
+++ b/tests/provider/StatelessApplicationProvider.php
@@ -29,7 +29,7 @@ final class StatelessApplicationProvider
                 {"username":"user","password":"pa:ss"}
                 JSON,
                 "Response body should be a JSON string with 'username' and 'password' where the password may contain " .
-                "colon(s) in HTTP_AUTHORIZATION.",
+                'colon(s) in HTTP_AUTHORIZATION.',
             ],
             'empty password' => [
                 'Basic ' . base64_encode('user:'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized expected error message strings in authentication tests to a generic, consistent format (e.g., “Response body should be a JSON string with 'username' and 'password'.”), including edge cases like missing delimiter, whitespace issues, and credentials with colons.
  * No changes to application behavior, public APIs, or runtime logic; this update only affects test expectations for clearer, uniform messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->