### PR TITLE
test(http): Improve clarity of assertion messages in `ApplicationMemoryTest`.

### DIFF
--- a/tests/http/stateless/ApplicationMemoryTest.php
+++ b/tests/http/stateless/ApplicationMemoryTest.php
@@ -82,7 +82,7 @@ final class ApplicationMemoryTest extends TestCase
         self::assertGreaterThanOrEqual(
             3,
             end($levels),
-            'Should have at least 3 output buffer levels before clearing output.',
+            "Should have at least '3' output buffer levels before clearing output.",
         );
 
         $app->errorHandler->clearOutput();
@@ -179,7 +179,7 @@ final class ApplicationMemoryTest extends TestCase
         self::assertSame(
             PHP_INT_MAX,
             $app->getMemoryLimit(),
-            "Before 'handle()' memory limit should be 'PHP_INT_MAX' when set to '-1' (unlimited).",
+            "Before 'handle()' memory limit should be PHP_INT_MAX when set to '-1' (unlimited).",
         );
 
         $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
@@ -188,7 +188,7 @@ final class ApplicationMemoryTest extends TestCase
         self::assertSame(
             PHP_INT_MAX,
             $app->getMemoryLimit(),
-            "After 'clean()' memory limit should remain 'PHP_INT_MAX' when set to '-1'.",
+            "After 'clean()' memory limit should remain PHP_INT_MAX when set to '-1'.",
         );
 
         ini_set('memory_limit', $originalLimit);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Refined assertion messages in ApplicationMemoryTest for clearer expectations.
  - Clarified output buffer level check by quoting the numeric value (e.g., '3').
  - Simplified wording around unlimited memory limits (-1), referencing PHP_INT_MAX without quotes.
  - No changes to behavior, control flow, or public APIs; runtime remains unaffected.
  - End users are not impacted; improvements target test readability and diagnostics only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->