### PR TITLE
test(http): Update `ApplicationTest` to remove cookie test and add new `actionAddResponseForCookie` method in `SiteController`.

### DIFF
--- a/tests/http/stateless/ApplicationCoreTest.php
+++ b/tests/http/stateless/ApplicationCoreTest.php
@@ -184,8 +184,8 @@ final class ApplicationCoreTest extends TestCase
         self::assertNotSame(
             $adapter3,
             $adapter4,
-            "'reset()' should force creation of a new adapter instance, resulting in different PSR-7 Response " .
-            'objects before and after reset.',
+            "'reset()' should force creation of a new adapter instance; the cached adapter before and after reset " .
+            'must be different.',
         );
 
         // third request - verify adapter isolation between requests

--- a/tests/http/stateless/ApplicationCoreTest.php
+++ b/tests/http/stateless/ApplicationCoreTest.php
@@ -192,7 +192,7 @@ final class ApplicationCoreTest extends TestCase
         $_COOKIE = ['test_cookie' => 'test_value'];
         $_SERVER = [
             'REQUEST_METHOD' => 'GET',
-            'REQUEST_URI' => 'site/add-response-for-cookie',
+            'REQUEST_URI' => 'site/add-cookies-to-response',
         ];
 
         $response3 = $app->handle(
@@ -202,12 +202,12 @@ final class ApplicationCoreTest extends TestCase
         self::assertSame(
             200,
             $response3->getStatusCode(),
-            "Expected HTTP '200' for route 'site/add-response-for-cookie'.",
+            "Expected HTTP '200' for route 'site/add-cookies-to-response'.",
         );
         self::assertSame(
             'text/html; charset=UTF-8',
             $response3->getHeaderLine('Content-Type'),
-            "Expected Content-Type 'text/html; charset=UTF-8' for route 'site/add-response-for-cookie'.",
+            "Expected Content-Type 'text/html; charset=UTF-8' for route 'site/add-cookies-to-response'.",
         );
 
         $bridgeResponse3 = $app->response;

--- a/tests/http/stateless/ApplicationCoreTest.php
+++ b/tests/http/stateless/ApplicationCoreTest.php
@@ -22,7 +22,6 @@ use yii2\extensions\psrbridge\tests\TestCase;
 use function array_filter;
 use function dirname;
 use function str_contains;
-use function str_starts_with;
 
 #[Group('http')]
 final class ApplicationCoreTest extends TestCase
@@ -240,7 +239,7 @@ final class ApplicationCoreTest extends TestCase
         self::assertSame(
             'test=test; Path=/; HttpOnly; SameSite=Lax test2=test2; Path=/; HttpOnly; SameSite=Lax',
             implode(' ', $cookieHeaders),
-            "PSR-7 Response Set-Cookie headers should match the expected values, confirming correct adapter behavior.",
+            'PSR-7 Response Set-Cookie headers should match the expected values, confirming correct adapter behavior.',
         );
     }
 

--- a/tests/http/stateless/ApplicationCoreTest.php
+++ b/tests/http/stateless/ApplicationCoreTest.php
@@ -193,7 +193,7 @@ final class ApplicationCoreTest extends TestCase
         $_COOKIE = ['test_cookie' => 'test_value'];
         $_SERVER = [
             'REQUEST_METHOD' => 'GET',
-            'REQUEST_URI' => 'site/cookie',
+            'REQUEST_URI' => 'site/add-response-for-cookie',
         ];
 
         $response3 = $app->handle(

--- a/tests/http/stateless/ApplicationTest.php
+++ b/tests/http/stateless/ApplicationTest.php
@@ -10,13 +10,10 @@ use yii2\extensions\psrbridge\http\StatelessApplication;
 use yii2\extensions\psrbridge\tests\support\FactoryHelper;
 use yii2\extensions\psrbridge\tests\TestCase;
 
-use function explode;
 use function ini_get;
 use function ini_set;
 use function ob_get_level;
 use function ob_start;
-use function sprintf;
-use function str_starts_with;
 
 #[Group('http')]
 final class ApplicationTest extends TestCase
@@ -84,79 +81,6 @@ final class ApplicationTest extends TestCase
             }
 
             @\runkit_constant_redefine('YII_ENV_TEST', true);
-        }
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testReturnCookiesHeadersForSiteCookieRoute(): void
-    {
-        $_SERVER = [
-            'REQUEST_METHOD' => 'GET',
-            'REQUEST_URI' => 'site/cookie',
-        ];
-
-        $app = $this->statelessApplication();
-
-        $response = $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-
-        self::assertSame(
-            200,
-            $response->getStatusCode(),
-            "Response 'status code' should be '200' for 'site/cookie' route in 'StatelessApplication'.",
-        );
-
-        foreach ($response->getHeader('Set-Cookie') as $cookie) {
-            // skip the session cookie header
-            if (str_starts_with($cookie, $app->session->getName()) === false) {
-                $params = explode('; ', $cookie);
-
-                self::assertContains(
-                    $params[0],
-                    [
-                        'test=test',
-                        'test2=test2',
-                    ],
-                    sprintf(
-                        "Cookie header should contain either 'test=test' or 'test2=test2', got '%s' for " .
-                        "'site/cookie' route.",
-                        $params[0],
-                    ),
-                );
-                self::assertStringContainsString(
-                    'Path=/',
-                    $cookie,
-                    "Cookie header should contain 'Path=/' for 'site/cookie' route.",
-                );
-                self::assertStringNotContainsString(
-                    'Secure',
-                    $cookie,
-                    sprintf(
-                        "Cookie header should not contain 'Secure' flag for '%s', got '%s' for 'site/cookie' route.",
-                        $params[0],
-                        $cookie,
-                    ),
-                );
-                self::assertStringNotContainsString(
-                    'HttpOnly',
-                    $cookie,
-                    sprintf(
-                        "Cookie header should not contain 'HttpOnly' flag for '%s', got '%s' for 'site/cookie' route.",
-                        $params[0],
-                        $cookie,
-                    ),
-                );
-                self::assertStringContainsString(
-                    'SameSite=Lax',
-                    $cookie,
-                    sprintf(
-                        "Cookie header should contain 'SameSite=Lax' for '%s', got '%s' for 'site/cookie' route.",
-                        $params[0],
-                        $cookie,
-                    ),
-                );
-            }
         }
     }
 

--- a/tests/support/stub/SiteController.php
+++ b/tests/support/stub/SiteController.php
@@ -31,7 +31,7 @@ final class SiteController extends Controller
                     'name' => 'test',
                     'value' => 'test',
                     'secure' => false,
-                    'httpOnly' => false,
+                    'httpOnly' => true,
                 ],
             ),
         );
@@ -42,7 +42,7 @@ final class SiteController extends Controller
                     'name' => 'test2',
                     'value' => 'test2',
                     'secure' => false,
-                    'httpOnly' => false,
+                    'httpOnly' => true,
                 ],
             ),
         );

--- a/tests/support/stub/SiteController.php
+++ b/tests/support/stub/SiteController.php
@@ -23,7 +23,7 @@ final class SiteController extends Controller
      */
     private const MOCK_TIME = 1755867797;
 
-    public function actionAddResponseForCookie(): void
+    public function actionAddCookiesToResponse(): void
     {
         $this->response->cookies->add(
             new Cookie(

--- a/tests/support/stub/SiteController.php
+++ b/tests/support/stub/SiteController.php
@@ -23,6 +23,31 @@ final class SiteController extends Controller
      */
     private const MOCK_TIME = 1755867797;
 
+    public function actionAddResponseForCookie(): void
+    {
+        $this->response->cookies->add(
+            new Cookie(
+                [
+                    'name' => 'test',
+                    'value' => 'test',
+                    'secure' => false,
+                    'httpOnly' => false,
+                ],
+            ),
+        );
+
+        $this->response->cookies->add(
+            new Cookie(
+                [
+                    'name' => 'test2',
+                    'value' => 'test2',
+                    'secure' => false,
+                    'httpOnly' => false,
+                ],
+            ),
+        );
+    }
+
     /**
      * @phpstan-return array{password: string|null, username: string|null}
      */
@@ -50,31 +75,6 @@ final class SiteController extends Controller
             'isGuest' => $user->isGuest,
             'identity' => $username,
         ];
-    }
-
-    public function actionCookie(): void
-    {
-        $this->response->cookies->add(
-            new Cookie(
-                [
-                    'name' => 'test',
-                    'value' => 'test',
-                    'secure' => false,
-                    'httpOnly' => false,
-                ],
-            ),
-        );
-
-        $this->response->cookies->add(
-            new Cookie(
-                [
-                    'name' => 'test2',
-                    'value' => 'test2',
-                    'secure' => false,
-                    'httpOnly' => false,
-                ],
-            ),
-        );
     }
 
     public function actionDeletecookie(): Response


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Updated stateless HTTP tests to target a new cookie response route and adjusted assertions/messages to reference "PSR-7 Response".
  - Removed a redundant test for the old route and simplified Set-Cookie header verification; cleaned up unused imports.

- Refactor
  - Renamed stub controller action to add cookies to the response and aligned tests to the new route.

No user-facing functionality changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->