### PR TITLE
test(http): Move event trigger test from `ApplicationTest` to `ApplicationCoreTest` for better organization.

### DIFF
--- a/tests/http/stateless/ApplicationCoreTest.php
+++ b/tests/http/stateless/ApplicationCoreTest.php
@@ -131,12 +131,7 @@ final class ApplicationCoreTest extends TestCase
         $app = $this->statelessApplication();
 
         // first request - verify adapter caching behavior
-        $_SERVER = [
-            'REQUEST_METHOD' => 'GET',
-            'REQUEST_URI' => 'site/index',
-        ];
-
-        $response1 = $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
+        $response1 = $app->handle(FactoryHelper::createRequest('GET', 'site/index'));
 
         self::assertSame(
             200,
@@ -170,12 +165,7 @@ final class ApplicationCoreTest extends TestCase
         );
 
         // second request with different route - verify stateless behavior
-        $_SERVER = [
-            'REQUEST_METHOD' => 'GET',
-            'REQUEST_URI' => 'site/statuscode',
-        ];
-
-        $response2 = $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
+        $response2 = $app->handle(FactoryHelper::createRequest('GET', 'site/statuscode'));
 
         self::assertSame(
             201,
@@ -222,13 +212,7 @@ final class ApplicationCoreTest extends TestCase
         );
 
         // third request - verify adapter isolation between requests
-        $_COOKIE = ['test_cookie' => 'test_value'];
-        $_SERVER = [
-            'REQUEST_METHOD' => 'GET',
-            'REQUEST_URI' => 'site/add-cookies-to-response',
-        ];
-
-        $response3 = $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
+        $response3 = $app->handle(FactoryHelper::createRequest('GET', 'site/add-cookies-to-response'));
 
         self::assertSame(
             200,
@@ -267,9 +251,14 @@ final class ApplicationCoreTest extends TestCase
             "PSR-7 Response should contain 'test=test' or 'test2=test2' in 'Set-Cookie' headers, confirming correct " .
             'adapter behavior.',
         );
-        self::assertSame(
-            'test=test; Path=/; HttpOnly; SameSite=Lax test2=test2; Path=/; HttpOnly; SameSite=Lax',
-            implode(' ', $cookieHeaders),
+        self::assertContains(
+            'test=test; Path=/; HttpOnly; SameSite=Lax',
+            $cookieHeaders,
+            'PSR-7 Response Set-Cookie headers should match the expected values, confirming correct adapter behavior.',
+        );
+        self::assertContains(
+            'test2=test2; Path=/; HttpOnly; SameSite=Lax',
+            $cookieHeaders,
             'PSR-7 Response Set-Cookie headers should match the expected values, confirming correct adapter behavior.',
         );
     }

--- a/tests/http/stateless/ApplicationTest.php
+++ b/tests/http/stateless/ApplicationTest.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace yii2\extensions\psrbridge\tests\http\stateless;
 
-use PHPUnit\Framework\Attributes\{Group, RequiresPhpExtension, TestWith};
+use PHPUnit\Framework\Attributes\{Group, RequiresPhpExtension};
 use yii\base\InvalidConfigException;
-use yii2\extensions\psrbridge\http\StatelessApplication;
 use yii2\extensions\psrbridge\tests\support\FactoryHelper;
 use yii2\extensions\psrbridge\tests\TestCase;
 
@@ -255,28 +254,5 @@ final class ApplicationTest extends TestCase
             $response->getStatusCode(),
             "Response 'status code' should be '201' for 'site/statuscode' route in 'StatelessApplication'.",
         );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    #[TestWith([StatelessApplication::EVENT_AFTER_REQUEST])]
-    #[TestWith([StatelessApplication::EVENT_BEFORE_REQUEST])]
-    public function testTriggerEventDuringHandle(string $eventName): void
-    {
-        $eventTriggered = false;
-
-        $app = $this->statelessApplication();
-
-        $app->on(
-            $eventName,
-            static function () use (&$eventTriggered): void {
-                $eventTriggered = true;
-            },
-        );
-
-        $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-
-        self::assertTrue($eventTriggered, "Should trigger '{$eventName}' event during handle()");
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added parameterized tests covering BEFORE/AFTER request lifecycle and their ordering during stateless handling.
  * Added new event-related verifications for event triggering during handle.
  * Removed a duplicated event-driven test from another suite.
  * Refactored tests to use a unified request creation approach and consolidated handle invocations.
  * Adjusted response-related assertions (status, Content-Type, cookie header checks).
  * No production-code changes or user-facing impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->