### PR TITLE
test(http): Move `testRenderExceptionSetsDisplayErrorsInDebugMode` from `ApplicationTest` to `ApplicationErrorHandlerTest` for better organization.

### DIFF
--- a/src/http/ErrorHandler.php
+++ b/src/http/ErrorHandler.php
@@ -86,9 +86,7 @@ final class ErrorHandler extends \yii\web\ErrorHandler
 
         while ($currentLevel > $minLevel) {
             if (@ob_end_clean() === false) {
-                // @codeCoverageIgnoreStart
                 ob_clean();
-                // @codeCoverageIgnoreEnd
             }
 
             $currentLevel = ob_get_level();

--- a/tests/http/stateless/ApplicationErrorHandlerTest.php
+++ b/tests/http/stateless/ApplicationErrorHandlerTest.php
@@ -668,5 +668,4 @@ final class ApplicationErrorHandlerTest extends TestCase
 
         $app->request->resolve();
     }
-
 }

--- a/tests/http/stateless/ApplicationErrorHandlerTest.php
+++ b/tests/http/stateless/ApplicationErrorHandlerTest.php
@@ -19,7 +19,6 @@ use function array_filter;
 use function is_array;
 use function ob_get_level;
 use function ob_start;
-use function PHPSTORM_META\map;
 use function restore_error_handler;
 use function set_error_handler;
 use function str_contains;
@@ -363,9 +362,9 @@ final class ApplicationErrorHandlerTest extends TestCase
         ];
 
         ob_start();
-        echo "buffer content that should be cleared";
+        echo 'buffer content that should be cleared';
         ob_start();
-        echo "nested buffer content";
+        echo 'nested buffer content';
 
         $originalDisplayErrors = ini_get('display_errors');
 
@@ -404,7 +403,6 @@ final class ApplicationErrorHandlerTest extends TestCase
                 $buffersAfterTest,
                 "'clearOutput()'' should properly clean output buffers",
             );
-
         } finally {
             while (ob_get_level() < $initialBufferLevel) {
                 ob_start();

--- a/tests/http/stateless/ApplicationTest.php
+++ b/tests/http/stateless/ApplicationTest.php
@@ -4,15 +4,10 @@ declare(strict_types=1);
 
 namespace yii2\extensions\psrbridge\tests\http\stateless;
 
-use PHPUnit\Framework\Attributes\{Group, RequiresPhpExtension};
+use PHPUnit\Framework\Attributes\{Group};
 use yii\base\InvalidConfigException;
 use yii2\extensions\psrbridge\tests\support\FactoryHelper;
 use yii2\extensions\psrbridge\tests\TestCase;
-
-use function ini_get;
-use function ini_set;
-use function ob_get_level;
-use function ob_start;
 
 #[Group('http')]
 final class ApplicationTest extends TestCase
@@ -22,65 +17,6 @@ final class ApplicationTest extends TestCase
         $this->closeApplication();
 
         parent::tearDown();
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    #[RequiresPhpExtension('runkit7')]
-    public function testRenderExceptionSetsDisplayErrorsInDebugMode(): void
-    {
-        @\runkit_constant_redefine('YII_ENV_TEST', false);
-
-        $initialBufferLevel = ob_get_level();
-
-        $_SERVER = [
-            'REQUEST_METHOD' => 'GET',
-            'REQUEST_URI' => 'site/trigger-exception',
-        ];
-
-        $originalDisplayErrors = ini_get('display_errors');
-
-        try {
-            $app = $this->statelessApplication(
-                [
-                    'components' => [
-                        'errorHandler' => ['errorAction' => null],
-                    ],
-                ],
-            );
-
-            $response = $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-
-            self::assertSame(
-                500,
-                $response->getStatusCode(),
-                "Expected HTTP '500' for route 'site/trigger-exception'.",
-            );
-            self::assertSame(
-                'text/html; charset=UTF-8',
-                $response->getHeaderLine('Content-Type'),
-                "Expected Content-Type 'text/html; charset=UTF-8' for route 'site/trigger-exception'.",
-            );
-            self::assertSame(
-                '1',
-                ini_get('display_errors'),
-                "'display_errors' should be set to '1' when YII_DEBUG mode is enabled and rendering exception view.",
-            );
-            self::assertStringContainsString(
-                'yii\base\Exception: Exception error message.',
-                $response->getBody()->getContents(),
-                'Response should contain exception details when YII_DEBUG mode is enabled.',
-            );
-        } finally {
-            ini_set('display_errors', $originalDisplayErrors);
-
-            while (ob_get_level() < $initialBufferLevel) {
-                ob_start();
-            }
-
-            @\runkit_constant_redefine('YII_ENV_TEST', true);
-        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test verifying exception rendering in debug mode, ensuring HTTP 500 responses render HTML and that display-errors is enabled during the request.
  * Ensures output buffering and environment state are restored after the test.
  * Removed a redundant duplicate test that relied on an optional PHP extension.
* **Chores**
  * No user-facing functionality changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->