### PR TITLE
test(http): Extract content types from `ApplicationTest` to `ApplicationContentTypesTest` class.

### DIFF
--- a/tests/http/stateless/ApplicationContentTypesTest.php
+++ b/tests/http/stateless/ApplicationContentTypesTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\psrbridge\tests\http\stateless;
+
+use yii\base\InvalidConfigException;
+use yii2\extensions\psrbridge\tests\support\FactoryHelper;
+use yii2\extensions\psrbridge\tests\TestCase;
+
+final class ApplicationContentTypesTest extends TestCase
+{
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testFileDownloadResponse(): void
+    {
+        $app = $this->statelessApplication();
+
+        $response = $app->handle(FactoryHelper::createRequest('GET', '/site/file'));
+
+        self::assertSame(
+            200,
+            $response->getStatusCode(),
+            "Expected HTTP '200' for route 'site/file'.",
+        );
+        self::assertSame(
+            'text/plain',
+            $response->getHeaderLine('Content-Type'),
+            "Expected Content-Type 'text/plain' for route 'site/file'.",
+        );
+        self::assertSame(
+            'This is a test file content.',
+            $response->getBody()->getContents(),
+            "Expected response 'body' to match plain text 'This is a test file content.'.",
+        );
+        self::assertSame(
+            'attachment; filename="testfile.txt"',
+            $response->getHeaderLine('Content-Disposition'),
+            "Expected Content-Disposition 'attachment; filename=\"testfile.txt\"'.",
+        );
+    }
+}

--- a/tests/http/stateless/ApplicationContentTypesTest.php
+++ b/tests/http/stateless/ApplicationContentTypesTest.php
@@ -13,7 +13,7 @@ final class ApplicationContentTypesTest extends TestCase
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
-    public function testFileDownloadResponse(): void
+    public function testFileDownloadWhenRequestingFileRoute(): void
     {
         $app = $this->statelessApplication();
 
@@ -32,12 +32,38 @@ final class ApplicationContentTypesTest extends TestCase
         self::assertSame(
             'This is a test file content.',
             $response->getBody()->getContents(),
-            "Expected response 'body' to match plain text 'This is a test file content.'.",
+            "Expected Response body to match plain text 'This is a test file content.'.",
         );
         self::assertSame(
             'attachment; filename="testfile.txt"',
             $response->getHeaderLine('Content-Disposition'),
             "Expected Content-Disposition 'attachment; filename=\"testfile.txt\"'.",
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testStreamContentWhenRequestingStreamRoute(): void
+    {
+        $app = $this->statelessApplication();
+
+        $response = $app->handle(FactoryHelper::createRequest('GET', '/site/stream'));
+
+        self::assertSame(
+            200,
+            $response->getStatusCode(),
+            "Expected HTTP '200' for route 'site/stream'.",
+        );
+        self::assertSame(
+            'text/plain',
+            $response->getHeaderLine('Content-Type'),
+            "Expected Content-Type 'text/plain' for route 'site/stream'.",
+        );
+        self::assertSame(
+            'This is a test file content.',
+            $response->getBody()->getContents(),
+            "Expected Response body to match plain text 'This is a test file content.'.",
         );
     }
 }

--- a/tests/http/stateless/ApplicationTest.php
+++ b/tests/http/stateless/ApplicationTest.php
@@ -86,44 +86,6 @@ final class ApplicationTest extends TestCase
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
-    public function testReturnPlainTextFileResponseForSiteFileRoute(): void
-    {
-        $_SERVER = [
-            'REQUEST_METHOD' => 'GET',
-            'REQUEST_URI' => 'site/file',
-        ];
-
-        $app = $this->statelessApplication();
-
-        $response = $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-
-        self::assertSame(
-            200,
-            $response->getStatusCode(),
-            "Response 'status code' should be '200' for 'site/file' route in 'StatelessApplication'.",
-        );
-        self::assertSame(
-            'text/plain',
-            $response->getHeaderLine('Content-Type'),
-            "Response 'Content-Type' should be 'text/plain' for 'site/file' route in 'StatelessApplication'.",
-        );
-        self::assertSame(
-            'This is a test file content.',
-            $response->getBody()->getContents(),
-            "Response 'body' should match expected plain text 'This is a test file content.' for 'site/file' route " .
-            "in 'StatelessApplication'.",
-        );
-        self::assertSame(
-            'attachment; filename="testfile.txt"',
-            $response->getHeaderLine('Content-Disposition'),
-            "Response 'Content-Disposition' should be 'attachment; filename=\"testfile.txt\"' for 'site/file' route " .
-            "in 'StatelessApplication'.",
-        );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
     public function testReturnPlainTextResponseWithFileContentForSiteStreamRoute(): void
     {
         $_SERVER = [

--- a/tests/http/stateless/ApplicationTest.php
+++ b/tests/http/stateless/ApplicationTest.php
@@ -86,38 +86,6 @@ final class ApplicationTest extends TestCase
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
-    public function testReturnPlainTextResponseWithFileContentForSiteStreamRoute(): void
-    {
-        $_SERVER = [
-            'REQUEST_METHOD' => 'GET',
-            'REQUEST_URI' => 'site/stream',
-        ];
-
-        $app = $this->statelessApplication();
-
-        $response = $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-
-        self::assertSame(
-            200,
-            $response->getStatusCode(),
-            "Response 'status code' should be '200' for 'site/stream' route in 'StatelessApplication'.",
-        );
-        self::assertSame(
-            'text/plain',
-            $response->getHeaderLine('Content-Type'),
-            "Response 'Content-Type' should be 'text/plain' for 'site/stream' route in 'StatelessApplication'.",
-        );
-        self::assertSame(
-            'This is a test file content.',
-            $response->getBody()->getContents(),
-            "Response 'body' should match expected plain text 'This is a test file content.' for 'site/stream' route " .
-            "in 'StatelessApplication'.",
-        );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
     public function testReturnRedirectResponseForSiteRedirectRoute(): void
     {
         $_SERVER = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added test coverage to validate file download responses in a stateless HTTP context, ensuring correct status code, Content-Type, Content-Disposition, and body content.
  - Consolidated and reorganized related tests by removing a redundant case from a broader suite to reduce duplication and improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->