### PR TITLE
test(http): Move JSON response test from `ApplicationTest` to `ApplicationCoreTest` for better organization.

### DIFF
--- a/tests/http/stateless/ApplicationCoreTest.php
+++ b/tests/http/stateless/ApplicationCoreTest.php
@@ -115,6 +115,13 @@ final class ApplicationCoreTest extends TestCase
             $response->getHeaderLine('Content-Type'),
             "Expected Content-Type 'application/json; charset=UTF-8' for route 'site/index'.",
         );
+        self::assertJsonStringEqualsJsonString(
+            <<<JSON
+            {"hello":"world"}
+            JSON,
+            $response->getBody()->getContents(),
+            "Expected JSON Response body '{\"hello\":\"world\"}'.",
+        );
         self::assertSame(
             ['before', 'after'],
             $sequence,
@@ -142,6 +149,13 @@ final class ApplicationCoreTest extends TestCase
             'application/json; charset=UTF-8',
             $response1->getHeaderLine('Content-Type'),
             "Expected Content-Type 'application/json; charset=UTF-8' for route 'site/index'.",
+        );
+        self::assertJsonStringEqualsJsonString(
+            <<<JSON
+            {"hello":"world"}
+            JSON,
+            $response1->getBody()->getContents(),
+            "Expected JSON Response body '{\"hello\":\"world\"}'.",
         );
 
         // access the Response component to test adapter behavior
@@ -340,6 +354,13 @@ final class ApplicationCoreTest extends TestCase
             $response->getHeaderLine('Content-Type'),
             "Expected Content-Type 'application/json; charset=UTF-8' for route 'site/index'.",
         );
+        self::assertJsonStringEqualsJsonString(
+            <<<JSON
+            {"hello":"world"}
+            JSON,
+            $response->getBody()->getContents(),
+            "Expected JSON Response body '{\"hello\":\"world\"}'.",
+        );
 
         $psr7Request = $app->request->getPsr7Request();
         $statelessAppStartTime = $psr7Request->getHeaderLine('statelessAppStartTime');
@@ -373,6 +394,13 @@ final class ApplicationCoreTest extends TestCase
             'application/json; charset=UTF-8',
             $response->getHeaderLine('Content-Type'),
             "Expected Content-Type 'application/json; charset=UTF-8' for route 'site/index'.",
+        );
+        self::assertJsonStringEqualsJsonString(
+            <<<JSON
+            {"hello":"world"}
+            JSON,
+            $response->getBody()->getContents(),
+            "Expected JSON Response body '{\"hello\":\"world\"}'.",
         );
         self::assertSame(
             '',
@@ -419,6 +447,13 @@ final class ApplicationCoreTest extends TestCase
             'application/json; charset=UTF-8',
             $response->getHeaderLine('Content-Type'),
             "Expected Content-Type 'application/json; charset=UTF-8' for route 'site/index'.",
+        );
+        self::assertJsonStringEqualsJsonString(
+            <<<JSON
+            {"hello":"world"}
+            JSON,
+            $response->getBody()->getContents(),
+            "Expected JSON Response body '{\"hello\":\"world\"}'.",
         );
         self::assertSame(
             1,

--- a/tests/http/stateless/ApplicationTest.php
+++ b/tests/http/stateless/ApplicationTest.php
@@ -140,34 +140,6 @@ final class ApplicationTest extends TestCase
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
-    public function testReturnsJsonResponse(): void
-    {
-        $app = $this->statelessApplication();
-
-        $response = $app->handle(FactoryHelper::createServerRequestCreator()->createFromGlobals());
-
-        self::assertSame(
-            200,
-            $response->getStatusCode(),
-            "Response 'status code' should be '200' for successful 'StatelessApplication' handling.",
-        );
-        self::assertSame(
-            'application/json; charset=UTF-8',
-            $response->getHeaderLine('Content-Type'),
-            "Response 'Content-Type' should be 'application/json; charset=UTF-8' for JSON output.",
-        );
-        self::assertSame(
-            <<<JSON
-            {"hello":"world"}
-            JSON,
-            $response->getBody()->getContents(),
-            "Response 'body' should match expected JSON string '{\"hello\":\"world\"}'.",
-        );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
     public function testReturnsStatusCode201ForSiteStatusCodeRoute(): void
     {
         $_SERVER = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Enhanced stateless HTTP test coverage by adding JSON body validations across multiple scenarios to ensure consistent responses.
  - Consolidated and simplified tests by removing a redundant case that duplicated status, header, and body checks.
  - No changes to runtime behavior or public APIs; these updates improve test reliability and clarity without affecting end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->