### PR TITLE
test(http): Refactor `ApplicationErrorHandlerTest` to use `createRequest` for improved clarity and remove redundant server variable assignments.

### DIFF
--- a/src/exception/Message.php
+++ b/src/exception/Message.php
@@ -127,9 +127,9 @@ enum Message: string
     /**
      * Error when the page is not found.
      *
-     * Format: "Page not found."
+     * Format: "Page not found in StatelessApplication."
      */
-    case PAGE_NOT_FOUND = 'Page not found.';
+    case PAGE_NOT_FOUND = 'Page not found in StatelessApplication.';
 
     /**
      * Error when the PSR-7 request adapter is not set.

--- a/tests/http/stateless/ApplicationErrorHandlerTest.php
+++ b/tests/http/stateless/ApplicationErrorHandlerTest.php
@@ -226,7 +226,7 @@ final class ApplicationErrorHandlerTest extends TestCase
         self::assertTrue(
             $exceptionLogFound,
             "Logger should contain an error log entry with category '{$expectedCategory}' and message " .
-            "'Exception error message.'.",
+            "'Exception error message'.",
         );
         self::assertFalse(
             $app->flushLogger,

--- a/tests/http/stateless/ApplicationRoutingTest.php
+++ b/tests/http/stateless/ApplicationRoutingTest.php
@@ -6,8 +6,6 @@ namespace yii2\extensions\psrbridge\tests\http\stateless;
 
 use PHPUnit\Framework\Attributes\Group;
 use yii\base\InvalidConfigException;
-use yii\web\NotFoundHttpException;
-use yii2\extensions\psrbridge\exception\Message;
 use yii2\extensions\psrbridge\tests\support\FactoryHelper;
 use yii2\extensions\psrbridge\tests\TestCase;
 
@@ -149,44 +147,5 @@ final class ApplicationRoutingTest extends TestCase
             $request->getUri()->getPath(),
             "Request path should be 'site/update/123'.",
         );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testThrowNotFoundHttpExceptionWhenRouteNotFound(): void
-    {
-        $app = $this->statelessApplication(
-            [
-                'components' => [
-                    'urlManager' => [
-                        'enableStrictParsing' => true,
-                    ],
-                ],
-            ],
-        );
-
-        $response = $app->handle(FactoryHelper::createRequest('GET', '/nonexistent/route'));
-
-        self::assertSame(
-            404,
-            $response->getStatusCode(),
-            "Expected HTTP '404' for route '/nonexistent/route'.",
-        );
-        self::assertSame(
-            'text/html; charset=UTF-8',
-            $response->getHeaderLine('Content-Type'),
-            "Expected Content-Type 'text/html; charset=UTF-8' for route '/nonexistent/route'.",
-        );
-        self::assertSame(
-            '<pre>Not Found: Page not found.</pre>',
-            $response->getBody()->getContents(),
-            "Response body should match expected HTML string '<pre>Not Found: Page not found.</pre>'.",
-        );
-
-        $this->expectException(NotFoundHttpException::class);
-        $this->expectExceptionMessage(Message::PAGE_NOT_FOUND->getMessage());
-
-        $app->request->resolve();
     }
 }

--- a/tests/http/stateless/ApplicationRoutingTest.php
+++ b/tests/http/stateless/ApplicationRoutingTest.php
@@ -6,6 +6,8 @@ namespace yii2\extensions\psrbridge\tests\http\stateless;
 
 use PHPUnit\Framework\Attributes\Group;
 use yii\base\InvalidConfigException;
+use yii\web\NotFoundHttpException;
+use yii2\extensions\psrbridge\exception\Message;
 use yii2\extensions\psrbridge\tests\support\FactoryHelper;
 use yii2\extensions\psrbridge\tests\TestCase;
 
@@ -46,8 +48,7 @@ final class ApplicationRoutingTest extends TestCase
             {"foo":"bar","a":{"b":"c"}}
             JSON,
             $response->getBody()->getContents(),
-            "Response body should match expected JSON string '{\"foo\":\"bar\",\"a\":{\"b\":\"c\"}}' for " .
-            "'site/post' route.",
+            "Response body should match expected JSON string '{\"foo\":\"bar\",\"a\":{\"b\":\"c\"}}'.",
         );
     }
 
@@ -80,8 +81,7 @@ final class ApplicationRoutingTest extends TestCase
             {"foo":"bar","a":{"b":"c"}}
             JSON,
             $response->getBody()->getContents(),
-            "Response body should match expected JSON string '{\"foo\":\"bar\",\"a\":{\"b\":\"c\"}}' for " .
-            "'site/get' route.",
+            "Response body should match expected JSON string '{\"foo\":\"bar\",\"a\":{\"b\":\"c\"}}'.",
         );
     }
 
@@ -114,7 +114,7 @@ final class ApplicationRoutingTest extends TestCase
             {"test":"foo","q":"1","queryParams":{"test":"foo","q":"1"}}
             JSON,
             $response->getBody()->getContents(),
-            "Response body should contain valid JSON with route and query parameters for 'site/query/foo?q=1' route.",
+            'Response body should contain valid JSON with route and query parameters.',
         );
     }
 
@@ -142,12 +142,51 @@ final class ApplicationRoutingTest extends TestCase
         self::assertSame(
             '{"site/update":"123"}',
             $response->getBody()->getContents(),
-            "Response body should contain valid JSON with the route parameter for 'site/update/123' route.",
+            'Response body should contain valid JSON with the route parameter.',
         );
         self::assertSame(
             'site/update/123',
             $request->getUri()->getPath(),
-            "Request path should be 'site/update/123' for 'site/update/123' route.",
+            "Request path should be 'site/update/123'.",
         );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testThrowNotFoundHttpExceptionWhenRouteNotFound(): void
+    {
+        $app = $this->statelessApplication(
+            [
+                'components' => [
+                    'urlManager' => [
+                        'enableStrictParsing' => true,
+                    ],
+                ],
+            ],
+        );
+
+        $response = $app->handle(FactoryHelper::createRequest('GET', '/nonexistent/route'));
+
+        self::assertSame(
+            404,
+            $response->getStatusCode(),
+            "Expected HTTP '404' for route '/nonexistent/route'.",
+        );
+        self::assertSame(
+            'text/html; charset=UTF-8',
+            $response->getHeaderLine('Content-Type'),
+            "Expected Content-Type 'text/html; charset=UTF-8' for route '/nonexistent/route'.",
+        );
+        self::assertSame(
+            '<pre>Not Found: Page not found.</pre>',
+            $response->getBody()->getContents(),
+            "Response body should match expected HTML string '<pre>Not Found: Page not found.</pre>'.",
+        );
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage(Message::PAGE_NOT_FOUND->getMessage());
+
+        $app->request->resolve();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized and simplified assertions to be route‑agnostic, removed reliance on global server state, switched tests to explicit request construction, updated error‑handling tests to validate JSON 404 responses under strict parsing, and added a test requirement attribute for an optional PHP extension.
* **Chores**
  * Updated public missing‑page error text to "Page not found in StatelessApplication." (no behavioral change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->