### PR TITLE
fix(http): Enhance cookie configuration in Response class to conditionally set `secure` and `httpOnly` flags.

### DIFF
--- a/src/http/Response.php
+++ b/src/http/Response.php
@@ -100,7 +100,7 @@ final class Response extends \yii\web\Response
                 'httponly' => 'httpOnly',
                 'path' => 'path',
                 'samesite' => 'sameSite',
-                'secure' => 'secure'
+                'secure' => 'secure',
             ];
 
             foreach ($paramMapping as $sessionKey => $configKey) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cookie attributes (Secure, HttpOnly, Path, Domain, SameSite) are no longer applied by default. These attributes are now included only when explicitly provided, ensuring response cookies match the exact parameters supplied and avoiding unintended defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->