### PR TITLE
test(http): Add memory limit parsing tests to improve coverage and handle various input cases in `parseMemoryLimit()` method.

### DIFF
--- a/src/http/StatelessApplication.php
+++ b/src/http/StatelessApplication.php
@@ -359,7 +359,9 @@ final class StatelessApplication extends Application implements RequestHandlerIn
     protected static function parseMemoryLimit(string $limit): int
     {
         if ($limit === '-1') {
+            // @codeCoverageIgnoreStart
             return PHP_INT_MAX;
+            // @codeCoverageIgnoreEnd
         }
 
         $number = 0;

--- a/src/http/StatelessApplication.php
+++ b/src/http/StatelessApplication.php
@@ -369,7 +369,6 @@ final class StatelessApplication extends Application implements RequestHandlerIn
 
         if ($suffix !== null) {
             $multipliers = [
-                ' ' => 1,
                 'K' => 1024,
                 'M' => 1048576,
                 'G' => 1073741824,

--- a/tests/http/stateless/ApplicationMemoryTest.php
+++ b/tests/http/stateless/ApplicationMemoryTest.php
@@ -194,6 +194,43 @@ final class ApplicationMemoryTest extends TestCase
         ini_set('memory_limit', $originalLimit);
     }
 
+    public function testParseMemoryLimitReturnsPhpIntMaxForUnlimitedValue(): void
+    {
+        $app = $this->statelessApplication();
+
+        self::assertSame(
+            PHP_INT_MAX,
+            self::invokeMethod($app, 'parseMemoryLimit', ['-1']),
+            "'parseMemoryLimit(-1)' must return PHP_INT_MAX for unlimited memory limit.",
+        );
+
+        $result64M = self::invokeMethod($app, 'parseMemoryLimit', ['64M']);
+
+        self::assertNotSame(
+            PHP_INT_MAX,
+            $result64M,
+            "'parseMemoryLimit(64M)' should not return PHP_INT_MAX.",
+        );
+        self::assertSame(
+            67_108_864,
+            $result64M,
+            "'parseMemoryLimit(64M)' should return ('64M') in bytes.",
+        );
+
+        $result1024 = self::invokeMethod($app, 'parseMemoryLimit', ['1024']);
+
+        self::assertSame(
+            1024,
+            $result1024,
+            "'parseMemoryLimit(1024)' should return ('1024 bytes').",
+        );
+        self::assertNotSame(
+            PHP_INT_MAX,
+            $result1024,
+            "'parseMemoryLimit(1024)' should not return PHP_INT_MAX.",
+        );
+    }
+
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */

--- a/tests/http/stateless/ApplicationMemoryTest.php
+++ b/tests/http/stateless/ApplicationMemoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace yii2\extensions\psrbridge\tests\http\stateless;
 
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group, TestWith};
+use ReflectionException;
 use stdClass;
 use yii\base\InvalidConfigException;
 use yii2\extensions\psrbridge\tests\provider\StatelessApplicationProvider;
@@ -194,41 +195,19 @@ final class ApplicationMemoryTest extends TestCase
         ini_set('memory_limit', $originalLimit);
     }
 
-    public function testParseMemoryLimitReturnsPhpIntMaxForUnlimitedValue(): void
-    {
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     * @throws ReflectionException if the method does not exist or is inaccessible.
+     */
+    #[DataProviderExternal(StatelessApplicationProvider::class, 'parseMemoryLimit')]
+    public function testParseMemoryLimitHandlesAllCasesCorrectly(
+        string $input,
+        int $expected,
+        string $assertionMessage,
+    ): void {
         $app = $this->statelessApplication();
 
-        self::assertSame(
-            PHP_INT_MAX,
-            self::invokeMethod($app, 'parseMemoryLimit', ['-1']),
-            "'parseMemoryLimit(-1)' must return PHP_INT_MAX for unlimited memory limit.",
-        );
-
-        $result64M = self::invokeMethod($app, 'parseMemoryLimit', ['64M']);
-
-        self::assertNotSame(
-            PHP_INT_MAX,
-            $result64M,
-            "'parseMemoryLimit(64M)' should not return PHP_INT_MAX.",
-        );
-        self::assertSame(
-            67_108_864,
-            $result64M,
-            "'parseMemoryLimit(64M)' should return ('64M') in bytes.",
-        );
-
-        $result1024 = self::invokeMethod($app, 'parseMemoryLimit', ['1024']);
-
-        self::assertSame(
-            1024,
-            $result1024,
-            "'parseMemoryLimit(1024)' should return ('1024 bytes').",
-        );
-        self::assertNotSame(
-            PHP_INT_MAX,
-            $result1024,
-            "'parseMemoryLimit(1024)' should not return PHP_INT_MAX.",
-        );
+        self::assertSame($expected, self::invokeMethod($app, 'parseMemoryLimit', [$input]), $assertionMessage);
     }
 
     /**

--- a/tests/provider/StatelessApplicationProvider.php
+++ b/tests/provider/StatelessApplicationProvider.php
@@ -387,6 +387,100 @@ final class StatelessApplicationProvider
     }
 
     /**
+     * @phpstan-return array<string, array{string, int, string}>
+     */
+    public static function parseMemoryLimit(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                0,
+                "'parseMemoryLimit('')' should return '0' when no parsing is possible.",
+            ],
+            'gigabytes lowercase' => [
+                '1g',
+                1_073_741_824,
+                "'parseMemoryLimit('1g')' should return '1_073_741_824 bytes'.",
+            ],
+            'gigabytes uppercase' => [
+                '2G',
+                2_147_483_648,
+                "'parseMemoryLimit('2G')' should return '2_147_483_648 bytes'.",
+            ],
+            'invalid string' => [
+                'abc',
+                0,
+                "'parseMemoryLimit('abc')' should return '0' when string starts with non-numeric characters.",
+            ],
+            'kilobytes lowercase' => [
+                '32k',
+                32_768,
+                "'parseMemoryLimit('32k')' should return '32_768 bytes'.",
+            ],
+            'kilobytes uppercase' => [
+                '64K',
+                65_536,
+                "'parseMemoryLimit('64K')' should return '65_536 bytes'.",
+            ],
+            'megabytes lowercase' => [
+                '64m',
+                67_108_864,
+                "'parseMemoryLimit('64m')' should return '67_108_864 bytes'.",
+            ],
+            'megabytes uppercase' => [
+                '128M',
+                134_217_728,
+                "'parseMemoryLimit('128M')' should return '134_217_728 bytes'.",
+            ],
+            'mixed case unknown suffix' => [
+                '50Z',
+                50,
+                "'parseMemoryLimit('50Z')' should return '50 bytes' for unknown suffix.",
+            ],
+            'number with space suffix should multiply by 1' => [
+                '512 ',
+                512,
+                "'parseMemoryLimit('512 ')' should handle space suffix correctly ('multiplier = 1').",
+            ],
+            'number with trailing characters' => [
+                '256MB',
+                268_435_456,
+                "'parseMemoryLimit('256MB')' should parse only first suffix 'M' and return '268_435_456 bytes'.",
+            ],
+            'plain number' => [
+                '1024',
+                1024,
+                "'parseMemoryLimit('1024')' should return '1024 bytes' for plain numeric input.",
+            ],
+            'special characters' => [
+                '@#$%',
+                0,
+                "'parseMemoryLimit('@#\$%')' should return '0' when only special characters are present.",
+            ],
+            'unknown suffix lowercase' => [
+                '200x',
+                200,
+                "'parseMemoryLimit('200x')' should return '200 bytes'.",
+            ],
+            'unknown suffix' => [
+                '100T',
+                100,
+                "'parseMemoryLimit('100T')' should return '100 bytes' using fallback multiplier.",
+            ],
+            'unlimited' => [
+                '-1',
+                PHP_INT_MAX,
+                "'parseMemoryLimit('-1')' should return PHP_INT_MAX for unlimited memory.",
+            ],
+            'zero should work correctly' => [
+                '0',
+                0,
+                "'parseMemoryLimit('0')' should return '0 bytes'.",
+            ],
+        ];
+    }
+
+    /**
      * @phpstan-return array<array{int|string, string|null, string}>
      */
     public static function remoteIPAddresses(): array

--- a/tests/provider/StatelessApplicationProvider.php
+++ b/tests/provider/StatelessApplicationProvider.php
@@ -452,6 +452,16 @@ final class StatelessApplicationProvider
                 1024,
                 "'parseMemoryLimit('1024')' should return '1024 bytes' for plain numeric input.",
             ],
+            'space suffix edge case' => [
+                '1 ',
+                1,
+                "'parseMemoryLimit('1 ')' should handle space suffix correctly.",
+            ],
+            'space suffix with different number' => [
+                '256 ',
+                256,
+                "'parseMemoryLimit('256 ')' should multiply by '1' with space suffix.",
+            ],
             'special characters' => [
                 '@#$%',
                 0,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added a data-driven unit test covering memory-limit parsing across empty, suffixed (k/m/g), numeric, special, whitespace, and edge-case values (including unlimited and zero).
  - Added a shared data provider supplying comprehensive test cases for those scenarios; no production or user-facing changes.
- Chores
  - Adjusted memory-limit parsing behavior to normalize suffix handling (improves robustness; no visible user impact).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->