### PR TITLE
test(http): Add assertions to verify non-null adapter in `Request` and `Response` components after handling a request.

### DIFF
--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -728,25 +728,6 @@ final class Request extends \yii\web\Request
     }
 
     /**
-     * Reset the PSR-7 ServerRequestInterface adapter to its initial state.
-     *
-     * Sets the internal adapter property to `null`, removing any previously set PSR-7 ServerRequestInterface adapter
-     * and restoring the default behavior of the request component.
-     *
-     * This method is used to clear the PSR-7 bridge in worker mode, ensuring that subsequent request operations fall
-     * back to the parent Yii2 implementation.
-     *
-     * Usage example:
-     * ```php
-     * $request->reset();
-     * ```
-     */
-    public function reset(): void
-    {
-        $this->adapter = null;
-    }
-
-    /**
      * Resolves the current request into a route and parameters, supporting PSR-7 and Yii2 fallback.
      *
      * Parses the request using the Yii2 UrlManager and merges parameters with those from the PSR-7 adapter if present.

--- a/src/http/Response.php
+++ b/src/http/Response.php
@@ -117,23 +117,6 @@ final class Response extends \yii\web\Response
     }
 
     /**
-     * Resets the PSR-7 ResponseAdapter instance for the current Response.
-     *
-     * Sets the internal {@see ResponseAdapter} property to `null`, ensuring that a new adapter will be created on the
-     * next access. This is useful for clearing cached adapter state between requests or after significant changes to
-     * the Response component.
-     *
-     * Usage example:
-     * ```php
-     * $response->reset();
-     * ```
-     */
-    public function reset(): void
-    {
-        $this->adapter = null;
-    }
-
-    /**
      * Retrieves the PSR-7 ResponseAdapter instance for the current Response.
      *
      * Instantiates and returns a {@see ResponseAdapter} for bridging the Yii2 Response component with PSR-7

--- a/src/http/StatelessApplication.php
+++ b/src/http/StatelessApplication.php
@@ -417,8 +417,7 @@ final class StatelessApplication extends Application implements RequestHandlerIn
         // re-register error handler to reset its state
         $this->errorHandler->setResponse($this->response);
 
-        // reset and inject the PSR-7 request into the Yii2 Request adapter
-        $this->request->reset();
+        // inject the PSR-7 request into the Yii2 Request adapter
         $this->request->setPsr7Request($request);
 
         // synchronize cookie validation settings between request and response

--- a/src/http/StatelessApplication.php
+++ b/src/http/StatelessApplication.php
@@ -424,9 +424,7 @@ final class StatelessApplication extends Application implements RequestHandlerIn
         $this->response->cookieValidationKey = $this->request->cookieValidationKey;
         $this->response->enableCookieValidation = $this->request->enableCookieValidation;
 
-        // reset the PSR-7 adapter cache for the response
-        $this->response->reset();
-
+        // reset the session to ensure a clean state
         $this->session->close();
         $sessionId = $this->request->getCookies()->get($this->session->getName())->value ?? '';
         $this->session->setId($sessionId);

--- a/tests/adapter/CookiesPsr7Test.php
+++ b/tests/adapter/CookiesPsr7Test.php
@@ -33,7 +33,6 @@ final class CookiesPsr7Test extends TestCase
         $request->setPsr7Request($psr7Request);
 
         $cookies1 = $request->getCookies();
-        $request->reset();
 
         $newPsr7Request = FactoryHelper::createRequest('GET', '/test');
 

--- a/tests/adapter/HeadersPsr7Test.php
+++ b/tests/adapter/HeadersPsr7Test.php
@@ -148,9 +148,6 @@ final class HeadersPsr7Test extends TestCase
     {
         $request = new Request();
 
-        // ensure adapter is `null` (default state)
-        $request->reset();
-
         self::assertNull(
             $request->getCsrfTokenFromHeader(),
             "CSRF token from header should return parent implementation result when adapter is 'null'.",

--- a/tests/adapter/ServerParamsPsr7Test.php
+++ b/tests/adapter/ServerParamsPsr7Test.php
@@ -72,8 +72,6 @@ final class ServerParamsPsr7Test extends TestCase
             "'REMOTE_HOST' should return the initial host value from the first PSR-7 request.",
         );
 
-        $request->reset();
-
         $request->setPsr7Request(
             FactoryHelper::createRequest('POST', '/second', serverParams: ['REMOTE_HOST' => $newHost]),
         );
@@ -438,8 +436,6 @@ final class ServerParamsPsr7Test extends TestCase
             "'SERVER_NAME' should return '{$initialServerName}' from initial PSR-7 request.",
         );
 
-        $request->reset();
-
         $request->setPsr7Request(
             FactoryHelper::createRequest('GET', '/test', serverParams: ['SERVER_NAME' => $newServerName]),
         );
@@ -515,8 +511,6 @@ final class ServerParamsPsr7Test extends TestCase
             $result1,
             "'SERVER_PORT' should return '{$initialPort}' from initial PSR-7 request.",
         );
-
-        $request->reset();
 
         $request->setPsr7Request(
             FactoryHelper::createRequest('GET', '/test', serverParams: ['SERVER_PORT' => $newPort]),

--- a/tests/adapter/ServerRequestAdapterTest.php
+++ b/tests/adapter/ServerRequestAdapterTest.php
@@ -266,9 +266,6 @@ final class ServerRequestAdapterTest extends TestCase
     {
         $request = new Request();
 
-        // ensure adapter is `null` (default state)
-        $request->reset();
-
         self::assertEmpty(
             $request->getParsedBody(),
             "Parsed body should return empty array when PSR-7 request has no parsed body and adapter is 'null'.",
@@ -279,18 +276,12 @@ final class ServerRequestAdapterTest extends TestCase
     {
         $request = new Request();
 
-        // ensure adapter is `null` (default state)
-        $request->reset();
-
         self::assertNotEmpty($request->getMethod(), "HTTP method should not be empty when adapter is 'null'.");
     }
 
     public function testReturnParentQueryParamsWhenAdapterIsNull(): void
     {
         $request = new Request();
-
-        // ensure adapter is `null` (default state)
-        $request->reset();
 
         self::assertEmpty(
             $request->getQueryParams(),
@@ -311,9 +302,6 @@ final class ServerRequestAdapterTest extends TestCase
     public function testReturnParentRawBodyWhenAdapterIsNull(): void
     {
         $request = new Request();
-
-        // ensure adapter is `null` (default state)
-        $request->reset();
 
         self::assertEmpty(
             $request->getRawBody(),

--- a/tests/http/RequestTest.php
+++ b/tests/http/RequestTest.php
@@ -619,8 +619,6 @@ final class RequestTest extends TestCase
 
         $request->csrfHeader = 'X-CSRF-Token';
 
-        $request->reset();
-
         self::assertSame(
             'parent-csrf-token-456',
             $request->getCsrfTokenFromHeader(),
@@ -1598,9 +1596,6 @@ final class RequestTest extends TestCase
         $_SERVER['SCRIPT_NAME'] = '/test.php';
         $_SERVER['SCRIPT_FILENAME'] = '/path/to/test.php';
 
-        // ensure adapter is `null` (default state)
-        $request->reset();
-
         // verify the method executes without throwing exception when adapter is `null`
         self::assertSame(
             '/test.php',
@@ -1658,9 +1653,6 @@ final class RequestTest extends TestCase
         $_SERVER['REQUEST_URI'] = '/legacy/path?param=value';
 
         $request = new Request();
-
-        // ensure adapter is `null` (default state)
-        $request->reset();
 
         self::assertSame(
             '/legacy/path?param=value',

--- a/tests/http/stateless/ApplicationCoreTest.php
+++ b/tests/http/stateless/ApplicationCoreTest.php
@@ -254,6 +254,11 @@ final class ApplicationCoreTest extends TestCase
 
         $adapter1 = self::inaccessibleProperty($bridgeResponse1, 'adapter');
 
+        self::assertNotNull(
+            $adapter1,
+            'Response adapter must be initialized (non-null) after handling the first request.',
+        );
+
         $bridgeResponse1->getPsr7Response();
 
         // verify adapter is cached (same instance across multiple calls)
@@ -286,6 +291,10 @@ final class ApplicationCoreTest extends TestCase
 
         $adapter2 = self::inaccessibleProperty($bridgeResponse2, 'adapter');
 
+        self::assertNotNull(
+            $adapter2,
+            'Response adapter must be initialized (non-null) after handling the second request.',
+        );
         self::assertNotSame(
             $bridgeResponse1,
             $bridgeResponse2,
@@ -317,6 +326,10 @@ final class ApplicationCoreTest extends TestCase
 
         $adapter3 = self::inaccessibleProperty($bridgeResponse3, 'adapter');
 
+        self::assertNotNull(
+            $adapter3,
+            'Response adapter must be initialized (non-null) after handling the third request.',
+        );
         self::assertNotSame(
             $bridgeResponse1,
             $bridgeResponse3,

--- a/tests/http/stateless/ApplicationCoreTest.php
+++ b/tests/http/stateless/ApplicationCoreTest.php
@@ -265,6 +265,16 @@ final class ApplicationCoreTest extends TestCase
             "Multiple calls to 'getPsr7Response()' should return the same cached adapter instance, " .
             'confirming adapter caching behavior.',
         );
+        self::assertNotNull(
+            self::inaccessibleProperty($app->request, 'adapter'),
+            'Request component should have a non-null adapter after handling a request, confirming adapter ' .
+            'caching behavior.',
+        );
+        self::assertNotNull(
+            self::inaccessibleProperty($bridgeResponse1, 'adapter'),
+            'Response component should have a non-null adapter after handling a request, confirming adapter ' .
+            'caching behavior.',
+        );
 
         // second request with different route - verify stateless behavior
         $response2 = $app->handle(FactoryHelper::createRequest('GET', 'site/statuscode'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Refactored tests to remove explicit adapter-reset steps and tightened per-request adapter isolation checks, relying on default initialization and direct cross-request comparisons for clarity and reliability.

- **Chores**
  - Removed public reset APIs and adjusted the stateless request flow; no changes to public signatures or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->