### PR TITLE
refactor(http): Remove error handler unregistration from `StatelessApplication` constructor for cleaner initialization.

### DIFF
--- a/src/http/StatelessApplication.php
+++ b/src/http/StatelessApplication.php
@@ -402,10 +402,6 @@ final class StatelessApplication extends Application implements RequestHandlerIn
     {
         $this->startEventTracking();
 
-        if ($this->has('errorHandler')) {
-            $this->errorHandler->unregister();
-        }
-
         // parent constructor is called because StatelessApplication uses a custom initialization pattern
         // @phpstan-ignore-next-line
         parent::__construct($this->config);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling continuity during application resets. The error handler is no longer unregistered during reset, preventing gaps in error reporting and ensuring consistent responses after a reset. This delivers more predictable behavior when recovering from errors or reinitializing the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->