### PR TITLE
Introduce `UploadedFile` class bridge implementation with tests.

### DIFF
--- a/src/adapter/ServerRequestAdapter.php
+++ b/src/adapter/ServerRequestAdapter.php
@@ -313,7 +313,7 @@ final class ServerRequestAdapter
      *
      * @return array Uploaded files from the PSR-7 ServerRequestInterface.
      *
-     * @phpstan-return array<mixed, mixed>
+     * @phpstan-return array<array-key, mixed>
      *
      * Usage example:
      * ```php

--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -7,7 +7,7 @@ namespace yii2\extensions\psrbridge\http;
 use Psr\Http\Message\{ServerRequestInterface, UploadedFileInterface};
 use Yii;
 use yii\base\InvalidConfigException;
-use yii\web\{CookieCollection, HeaderCollection, NotFoundHttpException, UploadedFile};
+use yii\web\{CookieCollection, HeaderCollection, NotFoundHttpException};
 use yii2\extensions\psrbridge\adapter\ServerRequestAdapter;
 use yii2\extensions\psrbridge\exception\Message;
 
@@ -793,6 +793,8 @@ final class Request extends \yii\web\Request
         $this->adapter = new ServerRequestAdapter(
             $request->withHeader('statelessAppStartTime', (string) microtime(true)),
         );
+
+        UploadedFile::setPsr7Adapter($this->adapter);
     }
 
     /**
@@ -851,6 +853,7 @@ final class Request extends \yii\web\Request
                 'size' => $psrFile->getSize(),
                 'tempName' => $psrFile->getStream()->getMetadata('uri') ?? '',
                 'type' => $psrFile->getClientMediaType() ?? '',
+                'tempResource' => $psrFile->getStream()->detach(),
             ],
         );
     }

--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -777,8 +777,7 @@ final class Request extends \yii\web\Request
      * This method injects a stateless application start time header (`statelessAppStartTime`) into the request for
      * tracing and debugging purposes.
      *
-     * Once set, all request operations will use the PSR-7 ServerRequestInterface via the adapter until {@see reset()}
-     * is called.
+     * Once set, all request operations will use the PSR-7 ServerRequestInterface via the adapter until is called.
      *
      * @param ServerRequestInterface $request PSR-7 ServerRequestInterface instance to bridge.
      *

--- a/src/http/StatelessApplication.php
+++ b/src/http/StatelessApplication.php
@@ -441,7 +441,7 @@ final class StatelessApplication extends Application implements RequestHandlerIn
     /**
      * Finalizes the application lifecycle and converts the Yii2 Response to a PSR-7 ResponseInterface.
      *
-     * Cleans up registered events, resets uploaded files, flushes the logger.
+     * Cleans up registered events, and flushes the logger.
      *
      * This method ensures that all application resources are released and the response is converted to a PSR-7
      * ResponseInterface for interoperability with PSR-7 compatible HTTP stacks.
@@ -456,8 +456,6 @@ final class StatelessApplication extends Application implements RequestHandlerIn
     protected function terminate(Response $response): ResponseInterface
     {
         $this->cleanupEvents();
-
-        UploadedFile::reset();
 
         if ($this->flushLogger) {
             $this->getLog()->getLogger()->flush(true);

--- a/src/http/StatelessApplication.php
+++ b/src/http/StatelessApplication.php
@@ -9,7 +9,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Throwable;
 use yii\base\{Event, InvalidConfigException};
 use yii\di\{Container, NotInstantiableException};
-use yii\web\{Application, UploadedFile};
+use yii\web\Application;
 
 use function array_merge;
 use function array_reverse;

--- a/src/http/StatelessApplication.php
+++ b/src/http/StatelessApplication.php
@@ -387,7 +387,7 @@ final class StatelessApplication extends Application implements RequestHandlerIn
      * Resets the StatelessApplication state and prepares the Yii2 environment for handling a PSR-7 request.
      *
      * Performs a full reinitialization of the application state, including event tracking, error handler cleanup,
-     * request adapter reset, session management, and PSR-7 request injection.
+     * request adapter reset, session management, uploaded file state reset, and PSR-7 request injection.
      *
      * This method ensures that the application is ready to process a new stateless request in worker or SAPI
      * environments, maintaining strict type safety and compatibility with Yii2 core components.
@@ -401,6 +401,9 @@ final class StatelessApplication extends Application implements RequestHandlerIn
     protected function reset(ServerRequestInterface $request): void
     {
         $this->startEventTracking();
+
+        // reset UploadedFile static state to avoid cross-request contamination
+        UploadedFile::reset();
 
         // parent constructor is called because StatelessApplication uses a custom initialization pattern
         // @phpstan-ignore-next-line

--- a/src/http/UploadedFile.php
+++ b/src/http/UploadedFile.php
@@ -189,24 +189,6 @@ final class UploadedFile extends \yii\web\UploadedFile
     }
 
     /**
-     * Resets the internal uploaded files cache and PSR-7 adapter state.
-     *
-     * Clears all cached uploaded file data and PSR-7 adapter references, ensuring a clean state for subsequent file
-     * handling operations. This method should be called to fully reset the file handling environment, including both
-     * legacy and PSR-7 file sources.
-     *
-     * Usage example:
-     * ```php
-     * UploadedFile::reset();
-     * ```
-     */
-    public static function reset(): void
-    {
-        self::$_files = [];
-        self::$psr7FilesLoaded = false;
-    }
-
-    /**
      * Sets the PSR-7 ServerRequestAdapter for file handling.
      *
      * Configures the bridge to use PSR-7 UploadedFileInterface data instead of reading from $_FILES global.

--- a/src/http/UploadedFile.php
+++ b/src/http/UploadedFile.php
@@ -195,7 +195,11 @@ final class UploadedFile extends \yii\web\UploadedFile
     }
 
     /**
-     * Resets the internal uploaded files cache.
+     * Resets the internal uploaded files cache and PSR-7 adapter state.
+     *
+     * Clears all cached uploaded file data and PSR-7 adapter references, ensuring a clean state for subsequent file
+     * handling operations. This method should be called to fully reset the file handling environment, including both
+     * legacy and PSR-7 file sources.
      *
      * Usage example:
      * ```php
@@ -205,6 +209,7 @@ final class UploadedFile extends \yii\web\UploadedFile
     public static function reset(): void
     {
         self::$_files = [];
+        self::$psr7Adapter = null;
     }
 
     /**

--- a/src/http/UploadedFile.php
+++ b/src/http/UploadedFile.php
@@ -53,8 +53,6 @@ final class UploadedFile extends \yii\web\UploadedFile
      *     fullPath: string|null
      *   }
      * >
-     *
-     * @phpstan-ignore property.phpDocType
      */
     public static $_files = [];
 

--- a/src/http/UploadedFile.php
+++ b/src/http/UploadedFile.php
@@ -12,7 +12,9 @@ use yii2\extensions\psrbridge\adapter\ServerRequestAdapter;
 use function is_array;
 use function is_resource;
 use function is_string;
+use function str_ends_with;
 use function str_starts_with;
+use function substr;
 
 /**
  * Uploaded file handler with PSR-7 bridge support.
@@ -173,6 +175,10 @@ final class UploadedFile extends \yii\web\UploadedFile
     {
         $files = self::loadFiles();
 
+        if (str_ends_with($name, '[]')) {
+            $name = substr($name, 0, -2);
+        }
+
         if (isset($files[$name])) {
             return [new self($files[$name])];
         }
@@ -189,11 +195,7 @@ final class UploadedFile extends \yii\web\UploadedFile
     }
 
     /**
-     * Resets the internal uploaded files cache and PSR-7 adapter state.
-     *
-     * Clears all cached uploaded file data and PSR-7 adapter references, ensuring a clean state for subsequent file
-     * handling operations. This method should be called to fully reset the file handling environment, including both
-     * legacy and PSR-7 file sources.
+     * Resets the internal uploaded files cache.
      *
      * Usage example:
      * ```php
@@ -203,8 +205,6 @@ final class UploadedFile extends \yii\web\UploadedFile
     public static function reset(): void
     {
         self::$_files = [];
-        self::$psr7Adapter = null;
-        self::$psr7FilesLoaded = false;
     }
 
     /**

--- a/src/http/UploadedFile.php
+++ b/src/http/UploadedFile.php
@@ -278,6 +278,20 @@ final class UploadedFile extends \yii\web\UploadedFile
      */
     private static function convertPsr7FileToLegacyFormat(UploadedFileInterface $psr7File): array
     {
+        $error = $psr7File->getError();
+
+        if ($error !== UPLOAD_ERR_OK) {
+            return [
+                'name' => $psr7File->getClientFilename() ?? '',
+                'tempName' => '',
+                'tempResource' => null,
+                'type' => $psr7File->getClientMediaType() ?? '',
+                'size' => $psr7File->getSize() ?? 0,
+                'error' => $error,
+                'fullPath' => null,
+            ];
+        }
+
         $stream = $psr7File->getStream();
         $uri = $stream->getMetadata('uri');
 
@@ -287,7 +301,7 @@ final class UploadedFile extends \yii\web\UploadedFile
             'tempResource' => $stream->detach(),
             'type' => $psr7File->getClientMediaType() ?? '',
             'size' => $psr7File->getSize() ?? 0,
-            'error' => $psr7File->getError(),
+            'error' => $error,
             'fullPath' => null,
         ];
     }

--- a/src/http/UploadedFile.php
+++ b/src/http/UploadedFile.php
@@ -229,9 +229,6 @@ final class UploadedFile extends \yii\web\UploadedFile
      */
     public static function setPsr7Adapter(ServerRequestAdapter $adapter): void
     {
-        self::closeResources();
-
-        self::$_files = [];
         self::$psr7Adapter = $adapter;
     }
 

--- a/src/http/UploadedFile.php
+++ b/src/http/UploadedFile.php
@@ -247,7 +247,7 @@ final class UploadedFile extends \yii\web\UploadedFile
     private static function closeResources(): void
     {
         foreach (self::$_files as $entry) {
-            if (isset($entry['tempResource']) && is_resource($entry['tempResource'])) {
+            if (is_resource($entry['tempResource'])) {
                 @fclose($entry['tempResource']);
             }
         }

--- a/src/http/UploadedFile.php
+++ b/src/http/UploadedFile.php
@@ -1,0 +1,454 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\psrbridge\http;
+
+use Psr\Http\Message\UploadedFileInterface;
+use yii\base\{Model};
+use yii\helpers\Html;
+use yii2\extensions\psrbridge\adapter\ServerRequestAdapter;
+
+use function is_array;
+use function is_resource;
+use function is_string;
+use function str_starts_with;
+
+/**
+ * Uploaded file handler with PSR-7 bridge support.
+ *
+ * Provides a drop-in replacement for {@see \yii\web\UploadedFile} that integrates PSR-7 UploadedFileInterface handling,
+ * enabling seamless interoperability with PSR-7 compatible HTTP stacks and modern PHP runtimes.
+ *
+ * This class allows file data to be sourced from either the global $_FILES array or a PSR-7 ServerRequestAdapter,
+ * supporting both traditional SAPI and worker-based environments. The internal file cache is populated accordingly,
+ * ensuring compatibility with Yii2 file validation and processing workflows.
+ *
+ * Key features.
+ * - Compatible with both legacy and modern PHP runtimes.
+ * - Conversion utilities for PSR-7 UploadedFileInterface to Yii2 format.
+ * - Immutable, type-safe access to uploaded file metadata and streams.
+ * - Internal cache for efficient file lookup and repeated access.
+ * - PSR-7 ServerRequestAdapter integration for file handling without global state.
+ *
+ * @see ServerRequestAdapter for PSR-7 to Yii2 file adapter.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class UploadedFile extends \yii\web\UploadedFile
+{
+    /**
+     * @var array[] Uploaded files cache.
+     *
+     * @phpstan-var array<
+     *   string,
+     *   array{
+     *     name: string,
+     *     tempName: string,
+     *     tempResource: resource|null,
+     *     type: string,
+     *     size: int,
+     *     error: int,
+     *     fullPath: string|null
+     *   }
+     * >
+     *
+     * @phpstan-ignore property.phpDocType
+     */
+    public static $_files = [];
+
+    /**
+     * PSR-7 ServerRequestAdapter for bridging PSR-7 UploadedFileInterface.
+     */
+    private static ServerRequestAdapter|null $psr7Adapter = null;
+
+    /**
+     * Flag indicating whether PSR-7 files have been loaded into the internal cache.
+     */
+    private static bool $psr7FilesLoaded = false;
+
+    /**
+     * Returns the instance of the uploaded file associated with the specified model attribute.
+     *
+     * Retrieves the uploaded file instance for the given model and attribute, supporting array-indexed attribute names
+     * such as '[1]file' for tabular uploads or 'file[1]' for file arrays. The method resolves the input name using
+     * {@see Html::getInputName()} and delegates to {@see getInstanceByName()} for file lookup.
+     *
+     * @param Model $model Data model.
+     * @param string $attribute Attribute name, which may contain array indexes (for example, '[1]file', 'file[1]').
+     *
+     * @return UploadedFile|null Instance of the uploaded file, or `null` if no file was uploaded for the attribute.
+     *
+     * Usage example:
+     * ```php
+     * $file = UploadedFile::getInstance($model, 'file');
+     *
+     * if ($file !== null) {
+     *     // process the uploaded file
+     * }
+     * ```
+     */
+    public static function getInstance($model, $attribute): UploadedFile|null
+    {
+        $name = Html::getInputName($model, $attribute);
+
+        return self::getInstanceByName($name);
+    }
+
+    /**
+     * Returns the instance of the uploaded file for the specified input name.
+     *
+     * @param string $name Name of the file input field.
+     *
+     * @return UploadedFile|null Instance of the uploaded file, or `null` if no file was uploaded for the name.
+     *
+     * Usage example:
+     * ```php
+     * $file = UploadedFile::getInstanceByName('file');
+     *
+     * if ($file !== null) {
+     *     // process the uploaded file
+     * }
+     * ```
+     */
+    public static function getInstanceByName($name): UploadedFile|null
+    {
+        $files = self::loadFiles();
+
+        return isset($files[$name]) ? new self($files[$name]) : null;
+    }
+
+    /**
+     * Returns an array of uploaded file instances associated with the specified model attribute.
+     *
+     * Resolves the input name for the given model and attribute using {@see Html::getInputName()} and delegates to
+     * {@see getInstancesByName()} for file lookup. Supports array-indexed attribute names for tabular file uploading,
+     * such as '[1]file'.
+     *
+     * @param Model $model Data model.
+     * @param string $attribute Attribute name, which may contain array indexes (for example, '[1]file').
+     *
+     * @return array Array of UploadedFile objects for the specified attribute. Returns an empty array if no
+     * files were uploaded.
+     *
+     * @phpstan-return UploadedFile[]
+     *
+     * Usage example:
+     * ```php
+     * $files = UploadedFile::getInstances($model, 'file');
+     *
+     * foreach ($files as $file) {
+     *     // process each uploaded file
+     * }
+     * ```
+     */
+    public static function getInstances($model, $attribute): array
+    {
+        $name = Html::getInputName($model, $attribute);
+
+        return self::getInstancesByName($name);
+    }
+
+    /**
+     * Returns an array of uploaded file instances for the specified input name.
+     *
+     * Iterates over the internal file cache and collects all uploaded files whose keys match the given input name or
+     * are prefixed with the input name followed by an opening bracket (for array-style file inputs).
+     *
+     * @param string $name Name of the file input field or array of files.
+     *
+     * @return array Array of UploadedFile objects for the specified input name. Returns an empty array if no files were
+     * uploaded.
+     *
+     * @phpstan-return UploadedFile[]
+     *
+     * Usage example:
+     * ```php
+     * $files = UploadedFile::getInstancesByName('file');
+     * foreach ($files as $file) {
+     *     // process each uploaded file
+     * }
+     * ```
+     */
+    public static function getInstancesByName($name): array
+    {
+        $files = self::loadFiles();
+
+        if (isset($files[$name])) {
+            return [new self($files[$name])];
+        }
+
+        $results = [];
+
+        foreach ($files as $key => $file) {
+            if (str_starts_with($key, "{$name}[")) {
+                $results[] = new self($file);
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Resets the internal uploaded files cache and PSR-7 adapter state.
+     *
+     * Clears all cached uploaded file data and PSR-7 adapter references, ensuring a clean state for subsequent file
+     * handling operations. This method should be called to fully reset the file handling environment, including both
+     * legacy and PSR-7 file sources.
+     *
+     * Usage example:
+     * ```php
+     * UploadedFile::reset();
+     * ```
+     */
+    public static function reset(): void
+    {
+        self::$_files = [];
+        self::$psr7Adapter = null;
+        self::$psr7FilesLoaded = false;
+    }
+
+    /**
+     * Sets the PSR-7 ServerRequestAdapter for file handling.
+     *
+     * Configures the bridge to use PSR-7 UploadedFileInterface data instead of reading from $_FILES global.
+     *
+     * This method should be called when initializing PSR-7 request processing to enable clean file handling without
+     * global state modification.
+     *
+     * The adapter will be used by {@see loadFiles()} to populate the internal file cache directly from PSR-7 data,
+     * ensuring compatibility with both worker environments and traditional SAPI setups.
+     *
+     * @param ServerRequestAdapter $adapter PSR-7 adapter containing UploadedFileInterface instances.
+     *
+     * Usage example:
+     * ```php
+     * UploadedFile::setPsr7Adapter($serverRequestAdapter);
+     * ```
+     */
+    public static function setPsr7Adapter(ServerRequestAdapter $adapter): void
+    {
+        self::$_files = [];
+        self::$psr7Adapter = $adapter;
+        self::$psr7FilesLoaded = false;
+    }
+
+    /**
+     * Converts a PSR-7 UploadedFileInterface to Yii2 UploadedFile format.
+     *
+     * Maps PSR-7 file properties to the array structure expected by Yii2 UploadedFile constructor, ensuring proper
+     * handling of file metadata, error codes, and stream resources.
+     *
+     * Handles edge cases such as missing metadata, stream resource extraction, and proper error code mapping to
+     * maintain full compatibility with Yii2 file validation and processing workflows.
+     *
+     * @param UploadedFileInterface $psr7File PSR-7 UploadedFileInterface to convert.
+     *
+     * @return array Yii2 compatible file data array.
+     *
+     * @phpstan-return array{
+     *   name: string,
+     *   tempName: string,
+     *   tempResource: resource|null,
+     *   type: string,
+     *   size: int,
+     *   error: int,
+     *   fullPath: string|null
+     * }
+     */
+    private static function convertPsr7FileToLegacyFormat(UploadedFileInterface $psr7File): array
+    {
+        $stream = $psr7File->getStream();
+        $uri = $stream->getMetadata('uri');
+
+        return [
+            'name' => $psr7File->getClientFilename() ?? '',
+            'tempName' => is_string($uri) ? $uri : '',
+            'tempResource' => $stream->detach(),
+            'type' => $psr7File->getClientMediaType() ?? '',
+            'size' => $psr7File->getSize() ?? 0,
+            'error' => $psr7File->getError(),
+            'fullPath' => null,
+        ];
+    }
+
+    /**
+     * Loads and returns the internal uploaded files cache.
+     *
+     * Populates the internal file cache from either the PSR-7 adapter or the legacy $_FILES global, depending on the
+     * current configuration and state.
+     *
+     * This method ensures that the file cache is initialized only once per request lifecycle, and subsequent calls
+     * return the cached result.
+     *
+     * @return array Internal uploaded files cache.
+     *
+     * @phpstan-return array<
+     *   string,
+     *   array{
+     *     name: string,
+     *     tempName: string,
+     *     tempResource: resource|null,
+     *     type: string,
+     *     size: int,
+     *     error: int,
+     *     fullPath: string|null,
+     *   }
+     * >
+     */
+    private static function loadFiles(): array
+    {
+        if (self::$_files === []) {
+            if (self::$psr7Adapter !== null && self::$psr7FilesLoaded === false) {
+                self::$psr7FilesLoaded = true;
+
+                self::loadPsr7Files();
+            } elseif (self::$psr7Adapter === null) {
+                self::loadLegacyFiles();
+            }
+        }
+
+        return self::$_files;
+    }
+
+    /**
+     * Recursive reformats data of uploaded file(s) for legacy compatibility.
+     *
+     * This is a copy of the parent class private method to maintain compatibility with legacy $_FILES processing.
+     *
+     * The method handles both single files and array structures, preserving the original Yii2 logic.
+     *
+     * @param string $key Key for identifying uploaded file (sub-array index).
+     * @param string[]|string $names File name(s) provided by PHP.
+     * @param string[]|string $tempNames Temporary file name(s) provided by PHP.
+     * @param string[]|string $types File type(s) provided by PHP.
+     * @param int[]|int $sizes File size(s) provided by PHP.
+     * @param int[]|int $errors Uploading issue(s) provided by PHP.
+     * @param mixed[]|string|null $fullPaths Full path(s) as submitted by the browser/PHP.
+     * @param mixed[]|mixed $tempResources Resource(s) of temporary file(s) provided by PHP.
+     */
+    private static function loadFilesRecursiveInternal(
+        string $key,
+        array|string $names,
+        array|string $tempNames,
+        array|string $types,
+        array|int $sizes,
+        array|int $errors,
+        array|string|null $fullPaths,
+        mixed $tempResources,
+    ): void {
+        if (is_array($names)) {
+            foreach ($names as $i => $name) {
+                self::loadFilesRecursiveInternal(
+                    $key . '[' . $i . ']',
+                    $name,
+                    $tempNames[$i] ?? '',
+                    $types[$i] ?? '',
+                    $sizes[$i] ?? 0,
+                    $errors[$i] ?? UPLOAD_ERR_NO_FILE,
+                    isset($fullPaths[$i]) && is_string($fullPaths[$i]) ? $fullPaths[$i] : null,
+                    (is_array($tempResources) && isset($tempResources[$i])) ? $tempResources[$i] : null,
+                );
+            }
+        } elseif ($errors !== UPLOAD_ERR_NO_FILE) {
+            self::$_files[$key] = [
+                'name' => $names,
+                'tempName' => is_array($tempNames) ? '' : $tempNames,
+                'tempResource' => is_resource($tempResources) ? $tempResources : null,
+                'type' => is_array($types) ? '' : $types,
+                'size' => is_array($sizes) ? 0 : $sizes,
+                'error' => is_array($errors) ? UPLOAD_ERR_NO_FILE : $errors,
+                'fullPath' => is_string($fullPaths) ? $fullPaths : null,
+            ];
+        }
+    }
+
+    /**
+     * Loads uploaded files from legacy $_FILES global array.
+     *
+     * Provides fallback functionality for traditional SAPI environments where PSR-7 is not available.
+     *
+     * This method is called automatically when no PSR-7 adapter is set, ensuring seamless operation in legacy
+     * environments without any configuration changes.
+     */
+    private static function loadLegacyFiles(): void
+    {
+        /**
+         * @phpstan-var array<
+         *   string,
+         *     array{
+         *       name: string|string[],
+         *       tmp_name: string|string[],
+         *       type: string|string[],
+         *       size: int|int[],
+         *       error: int|int[],
+         *       full_path?: string|string[]|null,
+         *       tmp_resource?: resource|null|array<mixed>,
+         *    }
+         * > $_FILES
+         */
+        foreach ($_FILES as $key => $info) {
+            self::loadFilesRecursiveInternal(
+                $key,
+                $info['name'],
+                $info['tmp_name'],
+                $info['type'],
+                $info['size'],
+                $info['error'],
+                $info['full_path'] ?? null,
+                $info['tmp_resource'] ?? null,
+            );
+        }
+    }
+
+    /**
+     * Loads uploaded files from PSR-7 UploadedFileInterface instances.
+     *
+     * Converts PSR-7 UploadedFileInterface data to Yii2 compatible format and populates the internal file cache
+     * directly, avoiding global $_FILES manipulation while maintaining full compatibility with Yii2 file handling
+     * expectations.
+     *
+     * Handles both simple file uploads and complex nested file arrays, ensuring proper structure preservation for
+     * form-based file uploads with array notation.
+     *
+     * This method enables clean separation of PSR-7 file handling from global state, improving testability and worker
+     * environment compatibility.
+     */
+    private static function loadPsr7Files(): void
+    {
+        /** @phpstan-var array<string, UploadedFileInterface|mixed[]> */
+        $uploadedFiles = self::$psr7Adapter?->getUploadedFiles() ?? [];
+
+        foreach ($uploadedFiles as $name => $file) {
+            self::processPsr7File($name, $file);
+        }
+    }
+
+    /**
+     * Processes a PSR-7 UploadedFileInterface and converts it to Yii2 format.
+     *
+     * Handles both single files and arrays of files, recursively processing nested structures to maintain compatibility
+     * with complex form-based file uploads using array notation.
+     *
+     * Converts PSR-7 UploadedFileInterface properties to the format expected by Yii2 UploadedFile, including proper
+     * error code mapping and stream resource handling.
+     *
+     * @param string $name Field name for the uploaded file(s).
+     * @param UploadedFileInterface|mixed[] $file PSR-7 UploadedFileInterface or array of files.
+     */
+    private static function processPsr7File(string $name, UploadedFileInterface|array $file): void
+    {
+        if ($file instanceof UploadedFileInterface) {
+            self::$_files[$name] = self::convertPsr7FileToLegacyFormat($file);
+        } elseif (is_array($file)) {
+            foreach ($file as $key => $nestedFile) {
+                $nestedName = $name . '[' . $key . ']';
+
+                if ($nestedFile instanceof UploadedFileInterface || is_array($nestedFile)) {
+                    self::processPsr7File($nestedName, $nestedFile);
+                }
+            }
+        }
+    }
+}

--- a/src/http/UploadedFile.php
+++ b/src/http/UploadedFile.php
@@ -89,7 +89,7 @@ final class UploadedFile extends \yii\web\UploadedFile
      * }
      * ```
      */
-    public static function getInstance($model, $attribute): UploadedFile|null
+    public static function getInstance($model, $attribute): self|null
     {
         $name = Html::getInputName($model, $attribute);
 
@@ -112,7 +112,7 @@ final class UploadedFile extends \yii\web\UploadedFile
      * }
      * ```
      */
-    public static function getInstanceByName($name): UploadedFile|null
+    public static function getInstanceByName($name): self|null
     {
         $files = self::loadFiles();
 
@@ -320,13 +320,13 @@ final class UploadedFile extends \yii\web\UploadedFile
      * The method handles both single files and array structures, preserving the original Yii2 logic.
      *
      * @param string $key Key for identifying uploaded file (sub-array index).
-     * @param string[]|string $names File name(s) provided by PHP.
-     * @param string[]|string $tempNames Temporary file name(s) provided by PHP.
-     * @param string[]|string $types File type(s) provided by PHP.
-     * @param int[]|int $sizes File size(s) provided by PHP.
-     * @param int[]|int $errors Uploading issue(s) provided by PHP.
+     * @param string|string[] $names File name(s) provided by PHP.
+     * @param string|string[] $tempNames Temporary file name(s) provided by PHP.
+     * @param string|string[] $types File type(s) provided by PHP.
+     * @param int|int[] $sizes File size(s) provided by PHP.
+     * @param int|int[] $errors Uploading issue(s) provided by PHP.
      * @param mixed[]|string|null $fullPaths Full path(s) as submitted by the browser/PHP.
-     * @param mixed[]|mixed $tempResources Resource(s) of temporary file(s) provided by PHP.
+     * @param mixed|mixed[] $tempResources Resource(s) of temporary file(s) provided by PHP.
      */
     private static function loadFilesRecursiveInternal(
         string $key,
@@ -435,7 +435,7 @@ final class UploadedFile extends \yii\web\UploadedFile
      * error code mapping and stream resource handling.
      *
      * @param string $name Field name for the uploaded file(s).
-     * @param UploadedFileInterface|mixed[] $file PSR-7 UploadedFileInterface or array of files.
+     * @param mixed[]|UploadedFileInterface $file PSR-7 UploadedFileInterface or array of files.
      */
     private static function processPsr7File(string $name, UploadedFileInterface|array $file): void
     {

--- a/src/http/UploadedFile.php
+++ b/src/http/UploadedFile.php
@@ -280,7 +280,7 @@ final class UploadedFile extends \yii\web\UploadedFile
                 'tempName' => '',
                 'tempResource' => null,
                 'type' => $psr7File->getClientMediaType() ?? '',
-                'size' => $psr7File->getSize() ?? 0,
+                'size' => (int) $psr7File->getSize(),
                 'error' => $error,
                 'fullPath' => null,
             ];
@@ -294,7 +294,7 @@ final class UploadedFile extends \yii\web\UploadedFile
             'tempName' => is_string($uri) ? $uri : '',
             'tempResource' => $stream->detach(),
             'type' => $psr7File->getClientMediaType() ?? '',
-            'size' => $psr7File->getSize() ?? 0,
+            'size' => (int) $psr7File->getSize(),
             'error' => $error,
             'fullPath' => null,
         ];

--- a/src/http/UploadedFile.php
+++ b/src/http/UploadedFile.php
@@ -189,6 +189,25 @@ final class UploadedFile extends \yii\web\UploadedFile
     }
 
     /**
+     * Resets the internal uploaded files cache and PSR-7 adapter state.
+     *
+     * Clears all cached uploaded file data and PSR-7 adapter references, ensuring a clean state for subsequent file
+     * handling operations. This method should be called to fully reset the file handling environment, including both
+     * legacy and PSR-7 file sources.
+     *
+     * Usage example:
+     * ```php
+     * UploadedFile::reset();
+     * ```
+     */
+    public static function reset(): void
+    {
+        self::$_files = [];
+        self::$psr7Adapter = null;
+        self::$psr7FilesLoaded = false;
+    }
+
+    /**
      * Sets the PSR-7 ServerRequestAdapter for file handling.
      *
      * Configures the bridge to use PSR-7 UploadedFileInterface data instead of reading from $_FILES global.

--- a/src/http/UploadedFile.php
+++ b/src/http/UploadedFile.php
@@ -64,11 +64,6 @@ final class UploadedFile extends \yii\web\UploadedFile
     private static ServerRequestAdapter|null $psr7Adapter = null;
 
     /**
-     * Flag indicating whether PSR-7 files have been loaded into the internal cache.
-     */
-    private static bool $psr7FilesLoaded = false;
-
-    /**
      * Returns the instance of the uploaded file associated with the specified model attribute.
      *
      * Retrieves the uploaded file instance for the given model and attribute, supporting array-indexed attribute names
@@ -238,7 +233,6 @@ final class UploadedFile extends \yii\web\UploadedFile
 
         self::$_files = [];
         self::$psr7Adapter = $adapter;
-        self::$psr7FilesLoaded = false;
     }
 
     /**
@@ -333,10 +327,8 @@ final class UploadedFile extends \yii\web\UploadedFile
     private static function loadFiles(): array
     {
         if (self::$_files === []) {
-            if (self::$psr7Adapter !== null && self::$psr7FilesLoaded === false) {
+            if (self::$psr7Adapter !== null) {
                 self::loadPsr7Files();
-
-                self::$psr7FilesLoaded = true;
             } elseif (self::$psr7Adapter === null) {
                 self::loadLegacyFiles();
             }

--- a/src/http/UploadedFile.php
+++ b/src/http/UploadedFile.php
@@ -208,10 +208,10 @@ final class UploadedFile extends \yii\web\UploadedFile
      */
     public static function reset(): void
     {
+        self::closeResources();
+
         self::$_files = [];
         self::$psr7Adapter = null;
-
-        self::closeResources();
     }
 
     /**

--- a/src/http/UploadedFile.php
+++ b/src/http/UploadedFile.php
@@ -203,7 +203,6 @@ final class UploadedFile extends \yii\web\UploadedFile
     public static function reset(): void
     {
         self::$_files = [];
-        self::$psr7Adapter = null;
         self::$psr7FilesLoaded = false;
     }
 

--- a/tests/http/UploadedFileTest.php
+++ b/tests/http/UploadedFileTest.php
@@ -219,6 +219,57 @@ final class UploadedFileTest extends TestCase
         );
     }
 
+    public function testReturnUploadedFileInstanceWhenLegacyFilesSizeIsArray(): void
+    {
+        $_FILES = [
+            'file' => [
+                'name' => 'file1.txt',
+                'type' => 'text/plain',
+                'tmp_name' => '/tmp/phptest1',
+                'error' => UPLOAD_ERR_OK,
+                'size' => [0],
+            ],
+        ];
+
+        $uploadFiles = UploadedFile::getInstancesByName('file');
+
+        self::assertCount(
+            1,
+            $uploadFiles,
+            'Should process the malformed array structure.',
+        );
+        self::assertInstanceOf(
+            UploadedFile::class,
+            $uploadFiles[0] ?? null,
+            'Should return an instance of UploadedFile when a single file is uploaded.',
+        );
+        self::assertSame(
+            'file1.txt',
+            $uploadFiles[0]->name,
+            'Should preserve \'name\' from $_FILES.',
+        );
+        self::assertSame(
+            'text/plain',
+            $uploadFiles[0]->type,
+            'Should preserve \'type\' from $_FILES.',
+        );
+        self::assertSame(
+            '/tmp/phptest1',
+            $uploadFiles[0]->tempName,
+            'Should preserve \'tmp_name\' from $_FILES.',
+        );
+        self::assertSame(
+            UPLOAD_ERR_OK,
+            $uploadFiles[0]->error,
+            'Should preserve \'error\' from $_FILES.',
+        );
+        self::assertSame(
+            0,
+            $uploadFiles[0]->size,
+            "Should default to exactly '0' when legacy file 'size' is an array.",
+        );
+    }
+
     public function testReturnUploadedFileInstanceWhenMultipleFilesAreUploadedViaPsr7(): void
     {
         $tmpFile1 = $this->createTmpFile();

--- a/tests/http/UploadedFileTest.php
+++ b/tests/http/UploadedFileTest.php
@@ -176,10 +176,10 @@ final class UploadedFileTest extends TestCase
             }
         }
 
-        self::assertGreaterThan(
+        self::assertSame(
             0,
             $stillOpenAfterReset,
-            "Resources should still be open after current 'reset()' implementation, showing the need for improvement.",
+            "All resources should be closed after `reset()` method.",
         );
     }
 

--- a/tests/http/UploadedFileTest.php
+++ b/tests/http/UploadedFileTest.php
@@ -102,6 +102,42 @@ final class UploadedFileTest extends TestCase
 
         UploadedFile::setPsr7Adapter($adapter);
 
+        $allFiles = UploadedFile::getInstancesByName('files');
+
+        self::assertCount(
+            2,
+            $allFiles,
+            'Should return both files when querying by base name.',
+        );
+        self::assertInstanceOf(
+            UploadedFile::class,
+            $allFiles[0] ?? null,
+            'Should return an instance of UploadedFile when a single file is uploaded.',
+        );
+        self::assertSame(
+            'file1.txt',
+            $allFiles[0]->name,
+            "Should preserve 'name' from PSR-7 UploadedFile.",
+        );
+        self::assertInstanceOf(
+            UploadedFile::class,
+            $allFiles[1] ?? null,
+            'Should return an instance of UploadedFile when a single file is uploaded.',
+        );
+        self::assertSame(
+            'file2.txt',
+            $allFiles[1]->name,
+            "Should preserve 'name' from PSR-7 UploadedFile.",
+        );
+
+        $filesWithBrackets = UploadedFile::getInstancesByName('files[]');
+
+        self::assertCount(
+            2,
+            $filesWithBrackets,
+            "Should handle trailing '[]' notation.",
+        );
+
         $uploadFile1 = UploadedFile::getInstanceByName('files[0]');
 
         self::assertInstanceOf(

--- a/tests/http/UploadedFileTest.php
+++ b/tests/http/UploadedFileTest.php
@@ -12,6 +12,7 @@ use yii2\extensions\psrbridge\tests\TestCase;
 use function file_put_contents;
 use function stream_get_meta_data;
 
+use const UPLOAD_ERR_CANT_WRITE;
 use const UPLOAD_ERR_OK;
 
 final class UploadedFileTest extends TestCase

--- a/tests/http/UploadedFileTest.php
+++ b/tests/http/UploadedFileTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\psrbridge\tests\http;
+
+use yii2\extensions\psrbridge\adapter\ServerRequestAdapter;
+use yii2\extensions\psrbridge\http\UploadedFile;
+use yii2\extensions\psrbridge\tests\support\FactoryHelper;
+use yii2\extensions\psrbridge\tests\TestCase;
+
+use function file_put_contents;
+use function stream_get_meta_data;
+
+use const UPLOAD_ERR_OK;
+
+final class UploadedFileTest extends TestCase
+{
+    public function testLegacyFilesLoadingWhenNotPsr7Adapter(): void
+    {
+        $_FILES = [
+            'upload' => [
+                'name' => 'test.txt',
+                'type' => 'text/plain',
+                'tmp_name' => '/tmp/phptest',
+                'error' => UPLOAD_ERR_OK,
+                'size' => 100,
+            ],
+        ];
+
+        $uploadFile = UploadedFile::getInstanceByName('upload');
+
+        self::assertInstanceOf(
+            UploadedFile::class,
+            $uploadFile,
+            'Should return an instance of UploadedFile when a single file is uploaded.',
+        );
+        self::assertSame(
+            'test.txt',
+            $uploadFile->name,
+            'Should preserve \'name\' from $_FILES.',
+        );
+        self::assertSame(
+            'text/plain',
+            $uploadFile->type,
+            'Should preserve \'type\' from $_FILES.',
+        );
+        self::assertSame(
+            '/tmp/phptest',
+            $uploadFile->tempName,
+            'Should preserve \'tmp_name\' from $_FILES.',
+        );
+        self::assertSame(
+            UPLOAD_ERR_OK,
+            $uploadFile->error,
+            'Should preserve \'error\' from $_FILES.',
+        );
+        self::assertSame(
+            100,
+            $uploadFile->size,
+            'Should preserve \'size\' from $_FILES.',
+        );
+    }
+
+    public function testReturnUploadedFileInstanceWhenMultipleFilesAreUploadedViaPsr7(): void
+    {
+        $tmpFile1 = $this->createTmpFile();
+
+        $tmpPathFile1 = stream_get_meta_data($tmpFile1)['uri'];
+        file_put_contents($tmpPathFile1, 'content1');
+
+        $tmpFile2 = $this->createTmpFile();
+
+        $tmpPathFile2 = stream_get_meta_data($tmpFile2)['uri'];
+        file_put_contents($tmpPathFile2, 'content2');
+
+        $adapter = new ServerRequestAdapter(
+            FactoryHelper::createRequest('POST', 'http://example.com')
+                ->withUploadedFiles(
+                    [
+                        'files' => [
+                            FactoryHelper::createUploadedFile(
+                                'file1.txt',
+                                'text/plain',
+                                FactoryHelper::createStream($tmpPathFile1),
+                                UPLOAD_ERR_OK,
+                                8,
+                            ),
+                            FactoryHelper::createUploadedFile(
+                                'file2.txt',
+                                'text/plain',
+                                FactoryHelper::createStream($tmpPathFile2),
+                                UPLOAD_ERR_OK,
+                                8,
+                            ),
+                        ],
+                    ],
+                ),
+        );
+
+        UploadedFile::setPsr7Adapter($adapter);
+
+        $uploadFile1 = UploadedFile::getInstanceByName('files[0]');
+
+        self::assertInstanceOf(
+            UploadedFile::class,
+            $uploadFile1,
+            'Should return an instance of UploadedFile when a single file is uploaded.',
+        );
+        self::assertSame(
+            'file1.txt',
+            $uploadFile1->name,
+            "Should preserve 'name' from PSR-7 UploadedFile.",
+        );
+
+        $uploadFile2 = UploadedFile::getInstanceByName('files[1]');
+
+        self::assertInstanceOf(
+            UploadedFile::class,
+            $uploadFile2,
+            'Should return an instance of UploadedFile when a single file is uploaded.',
+        );
+        self::assertSame(
+            'file2.txt',
+            $uploadFile2->name,
+            "Should preserve 'name' from PSR-7 UploadedFile.",
+        );
+        self::assertNotSame(
+            $uploadFile1,
+            $uploadFile2,
+            'Should return different instances for different files.',
+        );
+    }
+}

--- a/tests/http/UploadedFileTest.php
+++ b/tests/http/UploadedFileTest.php
@@ -16,6 +16,13 @@ use const UPLOAD_ERR_OK;
 
 final class UploadedFileTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        UploadedFile::reset();
+    }
+
     public function testConvertPsr7FileWithErrorShouldNotThrowException(): void
     {
         $tmpFile = $this->createTmpFile();
@@ -82,8 +89,6 @@ final class UploadedFileTest extends TestCase
                 'size' => 100,
             ],
         ];
-
-        UploadedFile::reset();
 
         $uploadFile = UploadedFile::getInstanceByName('upload');
 

--- a/tests/http/UploadedFileTest.php
+++ b/tests/http/UploadedFileTest.php
@@ -179,7 +179,7 @@ final class UploadedFileTest extends TestCase
         self::assertSame(
             0,
             $stillOpenAfterReset,
-            'All resources should be closed after `reset()` method.',
+            "All resources should be closed after 'reset()' method.",
         );
     }
 

--- a/tests/http/UploadedFileTest.php
+++ b/tests/http/UploadedFileTest.php
@@ -7,6 +7,7 @@ namespace yii2\extensions\psrbridge\tests\http;
 use yii2\extensions\psrbridge\adapter\ServerRequestAdapter;
 use yii2\extensions\psrbridge\http\UploadedFile;
 use yii2\extensions\psrbridge\tests\support\FactoryHelper;
+use yii2\extensions\psrbridge\tests\support\stub\{ComplexUploadedFileModel, UploadedFileModel};
 use yii2\extensions\psrbridge\tests\TestCase;
 
 use function file_put_contents;
@@ -114,6 +115,263 @@ final class UploadedFileTest extends TestCase
         );
     }
 
+    public function testGetInstanceWithModelAndArrayAttributeReturnsUploadedFile(): void
+    {
+        $_FILES = [
+            'UploadedFileModel[files][0]' => [
+                'name' => 'array-test.txt',
+                'type' => 'text/plain',
+                'tmp_name' => '/tmp/phparray',
+                'error' => UPLOAD_ERR_OK,
+                'size' => 150,
+            ],
+        ];
+
+        $uploadedFile = UploadedFile::getInstance(new UploadedFileModel(), 'files[0]');
+
+        self::assertInstanceOf(
+            UploadedFile::class,
+            $uploadedFile,
+            'Should return an instance of UploadedFile when using array-indexed attribute.',
+        );
+        self::assertSame(
+            'array-test.txt',
+            $uploadedFile->name,
+            'Should preserve name from $_FILES when using array-indexed attribute.',
+        );
+        self::assertSame(
+            150,
+            $uploadedFile->size,
+            'Should preserve size from $_FILES when using array-indexed attribute.',
+        );
+    }
+
+    public function testGetInstanceWithModelAndAttributeHandlesComplexModelName(): void
+    {
+        $_FILES = [
+            'Complex_Model-Name[file_attribute]' => [
+                'name' => 'complex-name-test.txt',
+                'type' => 'text/plain',
+                'tmp_name' => '/tmp/phpcomplex',
+                'error' => UPLOAD_ERR_OK,
+                'size' => 250,
+            ],
+        ];
+
+        $uploadedFile = UploadedFile::getInstance(new ComplexUploadedFileModel(), 'file_attribute');
+
+        self::assertInstanceOf(
+            UploadedFile::class,
+            $uploadedFile,
+            'Should return an instance of UploadedFile when using complex model name.',
+        );
+        self::assertSame(
+            'complex-name-test.txt',
+            $uploadedFile->name,
+            'Should preserve name from $_FILES when using complex model name.',
+        );
+        self::assertSame(
+            250,
+            $uploadedFile->size,
+            'Should preserve size from $_FILES when using complex model name.',
+        );
+    }
+
+    public function testGetInstanceWithModelAndAttributeHandlesErrorFiles(): void
+    {
+        $tmpFile = $this->createTmpFile();
+
+        $tmpPath = stream_get_meta_data($tmpFile)['uri'];
+
+        $uploadedFileWithError = FactoryHelper::createUploadedFile(
+            'error-model-test.txt',
+            'text/plain',
+            FactoryHelper::createStream($tmpPath),
+            UPLOAD_ERR_CANT_WRITE,
+            50,
+        );
+
+        UploadedFile::setPsr7Adapter(
+            new ServerRequestAdapter(
+                FactoryHelper::createRequest('POST', 'site/upload')
+                    ->withUploadedFiles(['UploadedFileModel[file]' => $uploadedFileWithError]),
+            ),
+        );
+
+        $uploadedFile = UploadedFile::getInstance(new UploadedFileModel(), 'file');
+
+        self::assertInstanceOf(
+            UploadedFile::class,
+            $uploadedFile,
+            'Should return an instance of UploadedFile even when there is an upload error using model and attribute.',
+        );
+        self::assertSame(
+            'error-model-test.txt',
+            $uploadedFile->name,
+            'Should preserve the original file name even when there is an upload error using model and attribute.',
+        );
+        self::assertSame(
+            '',
+            $uploadedFile->tempName,
+            'Should have an empty tempName when there is an upload error using model and attribute.',
+        );
+        self::assertSame(
+            UPLOAD_ERR_CANT_WRITE,
+            $uploadedFile->error,
+            'Should preserve the upload error code from PSR-7 UploadedFile when using model and attribute.',
+        );
+        self::assertSame(
+            50,
+            $uploadedFile->size,
+            'Should preserve the original file size even when there is an upload error using model and attribute.',
+        );
+    }
+
+    public function testGetInstanceWithModelAndAttributeReturnsNullWhenNoFileUploaded(): void
+    {
+        $_FILES = [];
+
+        $uploadedFile = UploadedFile::getInstance(new UploadedFileModel(), 'file');
+
+        self::assertNull(
+            $uploadedFile,
+            'Should return null when no file was uploaded for the specified model attribute.',
+        );
+    }
+
+    public function testGetInstanceWithModelAndAttributeReturnsUploadedFileForLegacyFiles(): void
+    {
+        $_FILES = [
+            'UploadedFileModel[file]' => [
+                'name' => 'model-test.txt',
+                'type' => 'text/plain',
+                'tmp_name' => '/tmp/phpmodel',
+                'error' => UPLOAD_ERR_OK,
+                'size' => 200,
+            ],
+        ];
+
+        $uploadedFile = UploadedFile::getInstance(new UploadedFileModel(), 'file');
+
+        self::assertInstanceOf(
+            UploadedFile::class,
+            $uploadedFile,
+            'Should return an instance of UploadedFile when using model and attribute.',
+        );
+        self::assertSame(
+            'model-test.txt',
+            $uploadedFile->name,
+            'Should preserve name from $_FILES when using model and attribute.',
+        );
+        self::assertSame(
+            'text/plain',
+            $uploadedFile->type,
+            'Should preserve type from $_FILES when using model and attribute.',
+        );
+        self::assertSame(
+            '/tmp/phpmodel',
+            $uploadedFile->tempName,
+            'Should preserve tmp_name from $_FILES when using model and attribute.',
+        );
+        self::assertSame(
+            UPLOAD_ERR_OK,
+            $uploadedFile->error,
+            'Should preserve error from $_FILES when using model and attribute.',
+        );
+        self::assertSame(
+            200,
+            $uploadedFile->size,
+            'Should preserve size from $_FILES when using model and attribute.',
+        );
+    }
+
+    public function testGetInstanceWithModelAndAttributeReturnsUploadedFileForPsr7Files(): void
+    {
+        $tmpFile = $this->createTmpFile();
+
+        $tmpPath = stream_get_meta_data($tmpFile)['uri'];
+        file_put_contents($tmpPath, 'PSR-7 model test content');
+
+        $uploadedFile = FactoryHelper::createUploadedFile(
+            'psr7-model-test.txt',
+            'text/plain',
+            FactoryHelper::createStream($tmpPath),
+            UPLOAD_ERR_OK,
+            24,
+        );
+
+        UploadedFile::setPsr7Adapter(
+            new ServerRequestAdapter(
+                FactoryHelper::createRequest('POST', 'site/upload')
+                    ->withUploadedFiles(['UploadedFileModel[file]' => $uploadedFile]),
+            ),
+        );
+
+        $retrievedFile = UploadedFile::getInstance(new UploadedFileModel(), 'file');
+
+        self::assertInstanceOf(
+            UploadedFile::class,
+            $retrievedFile,
+            'Should return an instance of UploadedFile when using PSR-7 with model and attribute.',
+        );
+        self::assertSame(
+            'psr7-model-test.txt',
+            $retrievedFile->name,
+            'Should preserve name from PSR-7 UploadedFile when using model and attribute.',
+        );
+        self::assertSame(
+            'text/plain',
+            $retrievedFile->type,
+            'Should preserve type from PSR-7 UploadedFile when using model and attribute.',
+        );
+        self::assertSame(
+            UPLOAD_ERR_OK,
+            $retrievedFile->error,
+            'Should preserve error from PSR-7 UploadedFile when using model and attribute.',
+        );
+        self::assertSame(
+            24,
+            $retrievedFile->size,
+            'Should preserve size from PSR-7 UploadedFile when using model and attribute.',
+        );
+    }
+
+    public function testGetInstanceWithModelAndTabularAttributeReturnsUploadedFile(): void
+    {
+        $_FILES = [
+            'UploadedFileModel[1][file]' => [
+                'name' => 'tabular-test.txt',
+                'type' => 'application/json',
+                'tmp_name' => '/tmp/phptabular',
+                'error' => UPLOAD_ERR_OK,
+                'size' => 300,
+            ],
+        ];
+
+        $uploadedFile = UploadedFile::getInstance(new UploadedFileModel(), '[1]file');
+
+        self::assertInstanceOf(
+            UploadedFile::class,
+            $uploadedFile,
+            'Should return an instance of UploadedFile when using tabular-style attribute.',
+        );
+        self::assertSame(
+            'tabular-test.txt',
+            $uploadedFile->name,
+            'Should preserve name from $_FILES when using tabular-style attribute.',
+        );
+        self::assertSame(
+            'application/json',
+            $uploadedFile->type,
+            'Should preserve type from $_FILES when using tabular-style attribute.',
+        );
+        self::assertSame(
+            300,
+            $uploadedFile->size,
+            'Should preserve size from $_FILES when using tabular-style attribute.',
+        );
+    }
+
     public function testLegacyFilesLoadingWhenNotPsr7Adapter(): void
     {
         $_FILES = [
@@ -157,6 +415,148 @@ final class UploadedFileTest extends TestCase
             100,
             $uploadFile->size,
             'Should preserve \'size\' from $_FILES.',
+        );
+    }
+
+    public function testLoadFilesRecursiveInternalWithArrayNamesAndMissingIndices(): void
+    {
+        $_FILES = [
+            'documents' => [
+                'name' => ['doc1.pdf', 'doc2.docx', 'doc3.txt'],
+                'type' => ['application/pdf', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
+                'tmp_name' => ['/tmp/php1', '/tmp/php2', '/tmp/php3'],
+                'size' => [1024, 2048],
+                'error' => [UPLOAD_ERR_OK, UPLOAD_ERR_OK, UPLOAD_ERR_CANT_WRITE],
+            ],
+        ];
+
+        $uploadFiles = UploadedFile::getInstancesByName('documents');
+
+        self::assertCount(
+            3,
+            $uploadFiles,
+            'Should process all files in the array structure.',
+        );
+        self::assertInstanceOf(
+            UploadedFile::class,
+            $uploadFiles[0] ?? null,
+            'Should return an instance of UploadedFile for first file.',
+        );
+        self::assertSame(
+            'doc1.pdf',
+            $uploadFiles[0]->name,
+            "Should preserve 'name' from array at index '0'.",
+        );
+        self::assertSame(
+            'application/pdf',
+            $uploadFiles[0]->type,
+            "Should preserve 'type' from array at index '0'.",
+        );
+        self::assertSame(
+            '/tmp/php1',
+            $uploadFiles[0]->tempName,
+            "Should preserve 'tmp_name' from array at index '0'.",
+        );
+        self::assertSame(
+            1024,
+            $uploadFiles[0]->size,
+            "Should preserve 'size' from array at index '0'.",
+        );
+        self::assertSame(
+            UPLOAD_ERR_OK,
+            $uploadFiles[0]->error,
+            "Should preserve 'error' from array at index '0'.",
+        );
+        self::assertInstanceOf(
+            UploadedFile::class,
+            $uploadFiles[1] ?? null,
+            'Should return an instance of UploadedFile for second file.',
+        );
+        self::assertSame(
+            'doc2.docx',
+            $uploadFiles[1]->name,
+            "Should preserve 'name' from array at index '1'.",
+        );
+        self::assertSame(
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            $uploadFiles[1]->type,
+            "Should preserve 'type' from array at index '1'.",
+        );
+        self::assertSame(
+            '/tmp/php2',
+            $uploadFiles[1]->tempName,
+            "Should preserve 'tmp_name' from array at index '1'.",
+        );
+        self::assertSame(
+            2048,
+            $uploadFiles[1]->size,
+            "Should preserve 'size' from array at index '1'.",
+        );
+        self::assertSame(
+            UPLOAD_ERR_OK,
+            $uploadFiles[1]->error,
+            "Should preserve 'error' from array at index '1'.",
+        );
+        self::assertInstanceOf(
+            UploadedFile::class,
+            $uploadFiles[2] ?? null,
+            'Should return an instance of UploadedFile for third file.',
+        );
+        self::assertSame(
+            'doc3.txt',
+            $uploadFiles[2]->name,
+            "Should preserve 'name' from array at index '2'.",
+        );
+        self::assertSame(
+            '',
+            $uploadFiles[2]->type,
+            "Should default to empty string when 'types[2]' is missing.",
+        );
+        self::assertSame(
+            '/tmp/php3',
+            $uploadFiles[2]->tempName,
+            "Should preserve 'tmp_name' from array at index '2'.",
+        );
+        self::assertSame(
+            0,
+            $uploadFiles[2]->size,
+            "Should default to 0 when 'sizes[2]' is missing.",
+        );
+        self::assertSame(
+            UPLOAD_ERR_CANT_WRITE,
+            $uploadFiles[2]->error,
+            "Should preserve 'error' from array at index '2'.",
+        );
+
+        $document1 = UploadedFile::getInstanceByName('documents[0]');
+
+        self::assertInstanceOf(
+            UploadedFile::class,
+            $document1,
+            'Should return instance when accessing by array index notation.',
+        );
+        self::assertSame(
+            'doc1.pdf',
+            $document1->name,
+            "Should preserve 'name' when accessing via 'documents[0]'.",
+        );
+
+        $document3 = UploadedFile::getInstanceByName('documents[2]');
+
+        self::assertInstanceOf(
+            UploadedFile::class,
+            $document3,
+            'Should return instance for file with missing indices.',
+        );
+        self::assertSame(
+            '',
+            $document3->type,
+            'Should have default empty type when accessing file with missing type index.',
+        );
+        self::assertSame(
+            0,
+            $document3->size,
+            "Should have default size of '0' when accessing file with missing size index.",
         );
     }
 

--- a/tests/http/UploadedFileTest.php
+++ b/tests/http/UploadedFileTest.php
@@ -179,7 +179,7 @@ final class UploadedFileTest extends TestCase
         self::assertSame(
             0,
             $stillOpenAfterReset,
-            "All resources should be closed after `reset()` method.",
+            'All resources should be closed after `reset()` method.',
         );
     }
 

--- a/tests/http/UploadedFileTest.php
+++ b/tests/http/UploadedFileTest.php
@@ -169,4 +169,63 @@ final class UploadedFileTest extends TestCase
             'Should return different instances for different files.',
         );
     }
+
+    public function testResetMethodShouldCloseDetachedResources(): void
+    {
+        $tmpFile = $this->createTmpFile();
+
+        $tmpPath = stream_get_meta_data($tmpFile)['uri'];
+        file_put_contents($tmpPath, 'Test content for reset method test');
+
+        $uploadedFile = FactoryHelper::createUploadedFile(
+            'reset-test.txt',
+            'text/plain',
+            FactoryHelper::createStream($tmpPath),
+            UPLOAD_ERR_OK,
+            32
+        );
+
+        UploadedFile::setPsr7Adapter(
+            new ServerRequestAdapter(
+                FactoryHelper::createRequest('POST', 'site/post')
+                    ->withUploadedFiles(['reset-test' => $uploadedFile])
+            ),
+        );
+
+        $uploadedFile = UploadedFile::getInstanceByName('reset-test');
+
+        self::assertNotNull(
+            $uploadedFile,
+            'Should retrieve uploaded file for reset test.',
+        );
+
+        $resourcesBeforeReset = [];
+
+        foreach (UploadedFile::$_files as $fileData) {
+            if (isset($fileData['tempResource']) && is_resource($fileData['tempResource'])) {
+                $resourcesBeforeReset[] = $fileData['tempResource'];
+            }
+        }
+
+        self::assertNotEmpty(
+            $resourcesBeforeReset,
+            'Should have detached resources before reset.',
+        );
+
+        UploadedFile::reset();
+
+        $stillOpenAfterReset = 0;
+
+        foreach ($resourcesBeforeReset as $resource) {
+            if (is_resource($resource)) {
+                $stillOpenAfterReset++;
+            }
+        }
+
+        self::assertGreaterThan(
+            0,
+            $stillOpenAfterReset,
+            "Resources should still be open after current 'reset()' implementation, showing the need for improvement.",
+        );
+    }
 }

--- a/tests/http/UploadedFileTest.php
+++ b/tests/http/UploadedFileTest.php
@@ -28,6 +28,8 @@ final class UploadedFileTest extends TestCase
             ],
         ];
 
+        UploadedFile::reset();
+
         $uploadFile = UploadedFile::getInstanceByName('upload');
 
         self::assertInstanceOf(

--- a/tests/http/stateless/StatelessApplicationUploadedTest.php
+++ b/tests/http/stateless/StatelessApplicationUploadedTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\psrbridge\tests\http;
+
+use PHPUnit\Framework\Attributes\Group;
+use yii2\extensions\psrbridge\http\UploadedFile;
+use yii2\extensions\psrbridge\tests\support\FactoryHelper;
+use yii2\extensions\psrbridge\tests\TestCase;
+
+#[Group('http')]
+final class StatelessApplicationUploadedTest extends TestCase
+{
+    public function testUploadedFilesAreResetBetweenRequests(): void
+    {
+        $tmpFile1 = $this->createTmpFile();
+
+        $tmpPath1 = stream_get_meta_data($tmpFile1)['uri'];
+        $size1 = filesize($tmpPath1);
+
+        self::assertIsInt(
+            $size1,
+            'Temporary file should have a valid size greater than zero.',
+        );
+
+        $app = $this->statelessApplication();
+
+        $response = $app->handle(
+            FactoryHelper::createRequest('POST', '/site/post', parsedBody: ['action' => 'upload'])
+                ->withUploadedFiles(
+                    [
+                        'file1' => FactoryHelper::createUploadedFile(
+                            'test1.txt',
+                            'text/plain',
+                            $tmpPath1,
+                            size: $size1,
+                        ),
+                    ],
+                ),
+        );
+
+        self::assertSame(
+            200,
+            $response->getStatusCode(),
+            "Expected HTTP '200' for route '/site/post'.",
+        );
+        self::assertSame(
+            'application/json; charset=UTF-8',
+            $response->getHeaderLine('Content-Type'),
+            "Expected Content-Type 'application/json; charset=UTF-8' for route '/site/post'.",
+        );
+        self::assertJsonStringEqualsJsonString(
+            <<<JSON
+            {"action": "upload"}
+            JSON,
+            $response->getBody()->getContents(),
+            "Expected PSR-7 Response body '{\"action\":\"upload\"}'.",
+        );
+        self::assertNotEmpty(
+            UploadedFile::getInstancesByName('file1'),
+            'Expected PSR-7 Request should have uploaded files.',
+        );
+
+        $response = $app->handle(
+            FactoryHelper::createRequest('GET', '/site/post')
+                ->withQueryParams(['action' => 'check']),
+        );
+
+        self::assertSame(
+            200,
+            $response->getStatusCode(),
+            "Expected HTTP '200' for route '/site/post'.",
+        );
+        self::assertSame(
+            'application/json; charset=UTF-8',
+            $response->getHeaderLine('Content-Type'),
+            "Expected Content-Type 'application/json; charset=UTF-8' for route '/site/post'.",
+        );
+        self::assertSame(
+            '[]',
+            $response->getBody()->getContents(),
+            'Expected PSR-7 Response body to be empty for POST request with no uploaded files.',
+        );
+
+        self::assertEmpty(
+            UploadedFile::getInstancesByName('file1'),
+            'PSR-7 Request should NOT have uploaded files from previous request.',
+        );
+
+        $tmpFile3 = $this->createTmpFile();
+
+        $tmpPath3 = stream_get_meta_data($tmpFile3)['uri'];
+        $size3 = filesize($tmpPath3);
+
+        self::assertIsInt(
+            $size3,
+            'Temporary file should have a valid size greater than zero.',
+        );
+
+        $response = $app->handle(
+            FactoryHelper::createRequest('POST', '/site/post', parsedBody: ['action' => 'upload'])
+                ->withUploadedFiles(
+                    [
+                        'file2' => FactoryHelper::createUploadedFile(
+                            'test3.txt',
+                            'text/plain',
+                            $tmpPath3,
+                            size: $size3,
+                        ),
+                    ],
+                ),
+        );
+
+        self::assertSame(
+            200,
+            $response->getStatusCode(),
+            "Expected HTTP '200' for route '/site/post'.",
+        );
+        self::assertSame(
+            'application/json; charset=UTF-8',
+            $response->getHeaderLine('Content-Type'),
+            "Expected Content-Type 'application/json; charset=UTF-8' for route '/site/post'.",
+        );
+        self::assertJsonStringEqualsJsonString(
+            <<<JSON
+            {"action": "upload"}
+            JSON,
+            $response->getBody()->getContents(),
+            "Expected PSR-7 Response body '{\"action\":\"upload\"}'.",
+        );
+        self::assertNotEmpty(
+            UploadedFile::getInstancesByName('file2'),
+            'Expected PSR-7 Request should have uploaded files.',
+        );
+        self::assertEmpty(
+            UploadedFile::getInstancesByName('file1'),
+            'Files from first request should still not be present after third request',
+        );
+    }
+}

--- a/tests/support/FactoryHelper.php
+++ b/tests/support/FactoryHelper.php
@@ -213,7 +213,7 @@ final class FactoryHelper
      *
      * @param string $name Client filename.
      * @param string $type Client media type.
-     * @param string $tmpName Temporary file name.
+     * @param string|StreamInterface $tmpName Temporary file name or stream.
      * @param int $error Upload error code.
      * @param int $size File size.
      *
@@ -227,7 +227,7 @@ final class FactoryHelper
     public static function createUploadedFile(
         string $name = '',
         string $type = '',
-        string $tmpName = '',
+        string|StreamInterface $tmpName = '',
         int $error = 0,
         int $size = 0,
     ): UploadedFileInterface {

--- a/tests/support/stub/ComplexUploadedFileModel.php
+++ b/tests/support/stub/ComplexUploadedFileModel.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace yii2\extensions\psrbridge\tests\support\stub;
 
 use yii\base\Model;
+use yii2\extensions\psrbridge\http\UploadedFile;
 
 final class ComplexUploadedFileModel extends Model
 {
-    public string $file_attribute = '';
+    /**
+     * @phpstan-var UploadedFile|UploadedFile[]|null
+     */
+    public UploadedFile|array|null $file_attribute = null;
 
     public function formName(): string
     {

--- a/tests/support/stub/ComplexUploadedFileModel.php
+++ b/tests/support/stub/ComplexUploadedFileModel.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\psrbridge\tests\support\stub;
+
+use yii\base\Model;
+
+final class ComplexUploadedFileModel extends Model
+{
+    public string $file_attribute = '';
+
+    public function formName(): string
+    {
+        return 'Complex_Model-Name';
+    }
+}

--- a/tests/support/stub/UploadedFileModel.php
+++ b/tests/support/stub/UploadedFileModel.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\psrbridge\tests\support\stub;
+
+use yii\base\Model;
+
+final class UploadedFileModel extends Model
+{
+    public string $file = '';
+
+    public function formName(): string
+    {
+        return 'UploadedFileModel';
+    }
+}

--- a/tests/support/stub/UploadedFileModel.php
+++ b/tests/support/stub/UploadedFileModel.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace yii2\extensions\psrbridge\tests\support\stub;
 
 use yii\base\Model;
+use yii2\extensions\psrbridge\http\UploadedFile;
 
 final class UploadedFileModel extends Model
 {
-    public string $file = '';
+    /**
+     * @phpstan-var UploadedFile|UploadedFile[]|null
+     */
+    public UploadedFile|array|null $file = null;
 
     public function formName(): string
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PSR‑7–aware file upload bridge added, enabling direct stream/resource uploads and adapter propagation across the request lifecycle.

* **Bug Fixes**
  * Uploaded files are isolated per request in stateless environments; static file state is reset between requests.

* **Tests**
  * New tests cover PSR‑7 and legacy upload flows, multi-file scenarios, stream-backed uploads, instance separation, and per-request isolation.

* **Chores**
  * Refined static-analysis annotations, adjusted imports, test factory now accepts streams, and added test stubs/helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->