### PR TITLE
refactor(docs): Remove redundant 'Basic Usage' section from `README.md`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,6 @@ composer require yii2-extensions/psr-bridge:^0.1@dev
 
 ### Quick start
 
-
-### Basic Usage
-
 Describe how to use your extension in a basic way.
 
 ## Documentation


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined the Quick start section by removing the redundant “Basic Usage” subheading; the guidance now appears as a plain paragraph for clearer readability.
  * No content changes beyond formatting; instructions remain the same.
* **Chores**
  * No functional or API changes; end-user behavior is unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->