### PR TITLE
refactor(tests): Remove redundant cookie collection tests in `CookiesPsr7Test` for clarity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bug #180: Add `phpunit-dev` job to `build.yml` for enhanced testing capabilities (@terabytesoftw)
 - Bug #181: Add permissions to workflow files for enhanced access control (@terabytesoftw)
+- Bug #182: Remove redundant cookie collection tests in `CookiesPsr7Test` for clarity (@terabytesoftw)
 
 ## 0.1.0 September 26, 2025
 

--- a/tests/adapter/CookiesPsr7Test.php
+++ b/tests/adapter/CookiesPsr7Test.php
@@ -12,78 +12,23 @@ use yii2\extensions\psrbridge\http\Request;
 use yii2\extensions\psrbridge\tests\support\FactoryHelper;
 use yii2\extensions\psrbridge\tests\TestCase;
 
+/**
+ * Test suite for PSR-7 cookies adapter in the Yii2 bridge layer.
+ *
+ * Verifies correct behavior of the Request cookie handling when using PSR-7 requests, including read-only cookie
+ * collections and validation key requirements.
+ *
+ * Test coverage.
+ * - Exception thrown when cookie validation is enabled but no validation key is provided.
+ * - Read-only cookie collection enforcement when adapter is set.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
 #[Group('adapter')]
 #[Group('cookies')]
 final class CookiesPsr7Test extends TestCase
 {
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testResetCookieCollectionAfterReset(): void
-    {
-        $psr7Request = FactoryHelper::createRequest('GET', '/test');
-
-        $psr7Request = $psr7Request->withCookieParams(['reset_cookie' => 'test_value']);
-
-        $request = new Request();
-
-        $request->enableCookieValidation = false;
-        $request->cookieValidationKey = self::COOKIE_VALIDATION_KEY;
-
-        $request->setPsr7Request($psr7Request);
-
-        $cookies1 = $request->getCookies();
-
-        $newPsr7Request = FactoryHelper::createRequest('GET', '/test');
-
-        $newPsr7Request = $newPsr7Request->withCookieParams(['new_cookie' => 'new_value']);
-
-        $request->setPsr7Request($newPsr7Request);
-
-        $cookies2 = $request->getCookies();
-
-        self::assertNotSame(
-            $cookies1,
-            $cookies2,
-            "After 'reset' method, 'getCookies()' should return a new CookieCollection instance.",
-        );
-        self::assertTrue(
-            $cookies2->has('new_cookie'),
-            "New CookieCollection should contain 'new_cookie' after 'reset' method.",
-        );
-        self::assertSame(
-            'new_value',
-            $cookies2->getValue('new_cookie'),
-            "New cookie 'new_cookie' should have the expected value after 'reset' method.",
-        );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testReturnNewCookieCollectionInstanceOnEachCall(): void
-    {
-        $psr7Request = FactoryHelper::createRequest('GET', '/test');
-
-        $psr7Request = $psr7Request->withCookieParams(['cached_cookie' => 'test_value']);
-
-        $request = new Request();
-
-        $request->enableCookieValidation = false;
-        $request->cookieValidationKey = self::COOKIE_VALIDATION_KEY;
-
-        $request->setPsr7Request($psr7Request);
-
-        $cookies1 = $request->getCookies();
-        $cookies2 = $request->getCookies();
-
-        self::assertNotSame(
-            $cookies1,
-            $cookies2,
-            "Each call to 'getCookies()' should return a new CookieCollection instance, not a cached one.",
-        );
-    }
-
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the in-progress 0.1.1 changelog with an entry referencing bug #182.
* **Tests**
  * Removed redundant cookie collection tests to streamline coverage.
  * Maintained existing test structure and visibility; remaining tests unchanged.
  * No impact on application behavior, functionality, or public APIs.
  * No user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->