### PR TITLE
refactor(tests): Remove redundant cookie tests from `ResponseAdapterTest` for improved clarity and maintainability.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bug #180: Add `phpunit-dev` job to `build.yml` for enhanced testing capabilities (@terabytesoftw)
 - Bug #181: Add permissions to workflow files for enhanced access control (@terabytesoftw)
 - Bug #182: Remove redundant cookie collection tests in `CookiesPsr7Test` for clarity (@terabytesoftw)
+- Bug #183: Remove redundant cookie tests from `ResponseAdapterTest` for clarity (@terabytesoftw)
 
 ## 0.1.0 September 26, 2025
 

--- a/tests/adapter/ResponseAdapterTest.php
+++ b/tests/adapter/ResponseAdapterTest.php
@@ -29,6 +29,22 @@ use function time;
 use function unlink;
 use function urlencode;
 
+/**
+ * Tests for the ResponseAdapter class.
+ *
+ * Validates conversion of Yii2 Response objects to PSR-7 responses, including file streaming, cookie formatting, header
+ * preservation, and error handling.
+ *
+ * Key features:
+ * - Checks header preservation and exception cases.
+ * - Ensures correct stream and content handling for various response scenarios.
+ * - Verifies cookie formatting and validation logic.
+ *
+ * @see ResponseAdapter for the implementation under test.
+ *
+ * @copyright Copyright (C) 2025
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
 #[Group('adapter')]
 final class ResponseAdapterTest extends TestCase
 {
@@ -308,68 +324,6 @@ final class ResponseAdapterTest extends TestCase
             1,
             strlen($body),
             "PSR-7 response body should contain exactly one 'byte'.",
-        );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testCookieWithEmptyValueIsIncludedInHeaders(): void
-    {
-        $response = new Response(
-            [
-                'charset' => 'UTF-8',
-                'cookieValidationKey' => self::COOKIE_VALIDATION_KEY,
-                'enableCookieValidation' => true,
-            ],
-        );
-
-        $deletionCookie = new Cookie(
-            [
-                'name' => 'session_id',
-                'value' => '', // empty value for deletion
-                'expire' => time() - 3600, // past expiration date
-                'path' => '/',
-                'domain' => 'example.com',
-            ],
-        );
-
-        $response->cookies->add($deletionCookie);
-
-        $adapter = new ResponseAdapter(
-            $response,
-            FactoryHelper::createResponseFactory(),
-            FactoryHelper::createStreamFactory(),
-            new Security(),
-        );
-
-        $psr7Response = $adapter->toPsr7();
-        $setCookieHeaders = $psr7Response->getHeader('Set-Cookie');
-
-        self::assertNotEmpty(
-            $setCookieHeaders,
-            "'Set-Cookie' header should be present when a cookie with an empty value is added for deletion.",
-        );
-
-        $deletionHeaderFound = false;
-
-        foreach ($setCookieHeaders as $header) {
-            if (str_starts_with($header, 'session_id=')) {
-                $deletionHeaderFound = true;
-
-                self::assertStringContainsString(
-                    'session_id=',
-                    $header,
-                    "'Set-Cookie' header for deletion should start with 'session_id=' and include the cookie name.",
-                );
-
-                break;
-            }
-        }
-
-        self::assertTrue(
-            $deletionHeaderFound,
-            "A 'Set-Cookie' header for the deletion cookie ('session_id=') must be present in the response headers.",
         );
     }
 
@@ -1803,68 +1757,6 @@ final class ResponseAdapterTest extends TestCase
             $hashedValue1,
             $hashedValue2,
             "Cookies with same value but different names should produce different hashes ('name' is included in hash).",
-        );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testMultipleCookiesIncludingDeletionCookies(): void
-    {
-        $response = new Response(
-            [
-                'charset' => 'UTF-8',
-                'cookieValidationKey' => self::COOKIE_VALIDATION_KEY,
-                'enableCookieValidation' => false,
-            ],
-        );
-
-        $regularCookie = new Cookie(
-            [
-                'name' => 'theme',
-                'value' => 'dark',
-                'expire' => time() + 3600,
-            ],
-        );
-
-        $deletionCookie = new Cookie(
-            [
-                'name' => 'old_session',
-                'value' => '',
-                'expire' => time() - 3600,
-            ],
-        );
-
-        $response->cookies->add($regularCookie);
-        $response->cookies->add($deletionCookie);
-
-        $adapter = new ResponseAdapter(
-            $response,
-            FactoryHelper::createResponseFactory(),
-            FactoryHelper::createStreamFactory(),
-            new Security(),
-        );
-
-        $psr7Response = $adapter->toPsr7();
-        $setCookieHeaders = $psr7Response->getHeader('Set-Cookie');
-
-        self::assertCount(
-            2,
-            $setCookieHeaders,
-            "Should be exactly two 'Set-Cookie' headers: one for the regular cookie and one for the deletion cookie.",
-        );
-
-        $headerStrings = implode('|', $setCookieHeaders);
-
-        self::assertStringContainsString(
-            'theme=dark',
-            $headerStrings,
-            "The 'Set-Cookie' headers should include the regular cookie with name 'theme' and value 'dark'.",
-        );
-        self::assertStringContainsString(
-            'old_session=',
-            $headerStrings,
-            "The 'Set-Cookie' headers should include the deletion cookie with name 'old_session' and an empty value.",
         );
     }
 

--- a/tests/adapter/ResponseAdapterTest.php
+++ b/tests/adapter/ResponseAdapterTest.php
@@ -330,68 +330,6 @@ final class ResponseAdapterTest extends TestCase
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
-    public function testCookieWithEmptyValueIsIncludedInHeaders(): void
-    {
-        $response = new Response(
-            [
-                'charset' => 'UTF-8',
-                'cookieValidationKey' => self::COOKIE_VALIDATION_KEY,
-                'enableCookieValidation' => true,
-            ],
-        );
-
-        $deletionCookie = new Cookie(
-            [
-                'name' => 'session_id',
-                'value' => '', // empty value for deletion
-                'expire' => time() - 3600, // past expiration date
-                'path' => '/',
-                'domain' => 'example.com',
-            ],
-        );
-
-        $response->cookies->add($deletionCookie);
-
-        $adapter = new ResponseAdapter(
-            $response,
-            FactoryHelper::createResponseFactory(),
-            FactoryHelper::createStreamFactory(),
-            new Security(),
-        );
-
-        $psr7Response = $adapter->toPsr7();
-        $setCookieHeaders = $psr7Response->getHeader('Set-Cookie');
-
-        self::assertNotEmpty(
-            $setCookieHeaders,
-            "'Set-Cookie' header should be present when a cookie with an empty value is added for deletion.",
-        );
-
-        $deletionHeaderFound = false;
-
-        foreach ($setCookieHeaders as $header) {
-            if (str_starts_with($header, 'session_id=')) {
-                $deletionHeaderFound = true;
-
-                self::assertStringContainsString(
-                    'session_id=',
-                    $header,
-                    "'Set-Cookie' header for deletion should start with 'session_id=' and include the cookie name.",
-                );
-
-                break;
-            }
-        }
-
-        self::assertTrue(
-            $deletionHeaderFound,
-            "A 'Set-Cookie' header for the deletion cookie ('session_id=') must be present in the response headers.",
-        );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
     public function testDeletionCookiesWithValidationEnabled(): void
     {
         $response = new Response(
@@ -1819,6 +1757,68 @@ final class ResponseAdapterTest extends TestCase
             $hashedValue1,
             $hashedValue2,
             "Cookies with same value but different names should produce different hashes ('name' is included in hash).",
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testMultipleCookiesIncludingDeletionCookies(): void
+    {
+        $response = new Response(
+            [
+                'charset' => 'UTF-8',
+                'cookieValidationKey' => self::COOKIE_VALIDATION_KEY,
+                'enableCookieValidation' => false,
+            ],
+        );
+
+        $regularCookie = new Cookie(
+            [
+                'name' => 'theme',
+                'value' => 'dark',
+                'expire' => time() + 3600,
+            ],
+        );
+
+        $deletionCookie = new Cookie(
+            [
+                'name' => 'old_session',
+                'value' => '',
+                'expire' => time() - 3600,
+            ],
+        );
+
+        $response->cookies->add($regularCookie);
+        $response->cookies->add($deletionCookie);
+
+        $adapter = new ResponseAdapter(
+            $response,
+            FactoryHelper::createResponseFactory(),
+            FactoryHelper::createStreamFactory(),
+            new Security(),
+        );
+
+        $psr7Response = $adapter->toPsr7();
+        $setCookieHeaders = $psr7Response->getHeader('Set-Cookie');
+
+        self::assertCount(
+            2,
+            $setCookieHeaders,
+            "Should be exactly two 'Set-Cookie' headers: one for the regular cookie and one for the deletion cookie.",
+        );
+
+        $headerStrings = implode('|', $setCookieHeaders);
+
+        self::assertStringContainsString(
+            'theme=dark',
+            $headerStrings,
+            "The 'Set-Cookie' headers should include the regular cookie with name 'theme' and value 'dark'.",
+        );
+        self::assertStringContainsString(
+            'old_session=',
+            $headerStrings,
+            "The 'Set-Cookie' headers should include the deletion cookie with name 'old_session' and an empty value.",
         );
     }
 


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a changelog entry documenting removal of a redundant cookie-related test; no user-facing changes or API impact.

* **Tests**
  * Removed an overlapping cookie test to reduce duplication and maintenance overhead; test suite simplified with no change to product behavior or end-user expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->