### PR TITLE
fix(docs): Correct grammatical error in docblock for `createErrorResponse` method in `ErrorHandler`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug #184: Remove redundant remote IP and server port from `ServerParamsPsr7Test` for clarity (@terabytesoftw)
 - Bug #185: Consolidate `paths-ignore` configuration across workflow files for consistency, add logos for badges in `README.md` (@terabytesoftw)
 - Bug #186: Remove redundant test cases from `ServerRequestAdapterTest` for clarity (@terabytesoftw)
+- Bug #187: Correct grammatical error in docblock for `createErrorResponse` method in `ErrorHandler` (@terabytesoftw)
 
 ## 0.1.0 September 26, 2025
 

--- a/src/http/ErrorHandler.php
+++ b/src/http/ErrorHandler.php
@@ -249,7 +249,7 @@ final class ErrorHandler extends \yii\web\ErrorHandler
     /**
      * Creates a Response instance for error handling.
      *
-     * Uses the Response if available, otherwise creates a new instance with default configuration.
+     * Uses the Response if available, otherwise create a new instance with default configuration.
      *
      * @return Response Clean Response instance ready for error content.
      */


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a minor grammatical error in internal documentation comments related to error response handling to improve clarity and consistency. No functional or behavioral changes.
  * Updated the changelog to reflect the documentation fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->