### PR TITLE
fix(docs): warn against unsafe multipart body parser setup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Bug #243: Remove redundant comments in `ApplicationConfigTest` and `ApplicationCoreTest` for improved clarity and maintainability (@terabytesoftw)
 - Bug #244: Update unit tests for `Application` class to enhance clarity and coverage; add `ApplicationReinitializationTest` for reinitialization behavior validation and update related documentation (@terabytesoftw)
 - Bug #245: Bootstrap DI container during `Application` construction, remove per-request container bootstrap, and avoid masking initialization failures behind missing `errorHandler` secondary exceptions (@terabytesoftw)
+- fix(docs): warn against unsafe multipart body parser setup.
 
 ## 0.2.1 February 21, 2026
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,7 +65,6 @@ populated immediately after the request is handled.
 > server and application levels. Uploaded files are already available via the PSR-7
 > uploaded-file interfaces.
 
-
 #### Wildcard parsing
 
 You can also configure a fallback parser using the `*` wildcard for small trusted payloads (for example JSON-only APIs). Avoid permissive wildcard parsing for untrusted large body types in worker deployments.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,7 +22,7 @@ the `parsers` property.
 declare(strict_types=1);
 
 use yii2\extensions\psrbridge\http\{ErrorHandler, Request, Response};
-use yii\web\{JsonParser, MultipartFormDataParser};
+use yii\web\JsonParser;
 
 return [
     'components' => [
@@ -32,7 +32,6 @@ return [
             'enableCsrfValidation' => false,
             'parsers' => [
                 'application/json' => JsonParser::class,
-                'multipart/form-data' => MultipartFormDataParser::class,
             ],
         ],
         'response' => [
@@ -53,15 +52,23 @@ When `setPsr7Request()` is called (typically by the worker runner), the bridge w
 
 1. Detect the `Content-Type` of the incoming PSR-7 request.
 2. Check the `parsers` configuration for a matching parser.
-3. Parse the body content.
+3. Parse the body content with the configured parser.
 4. Update the PSR-7 Request instance using `withParsedBody()`.
 
 This ensures that `Yii::$app->request->post()` and `Yii::$app->request->bodyParams` are correctly
 populated immediately after the request is handled.
 
+> [!WARNING]
+> In worker runtimes (for example RoadRunner or FrankenPHP), configured body parsers
+> receive the full request body as a string. Avoid enabling automatic parsing for
+> `multipart/form-data` unless strict upload/body size limits are enforced at the
+> server and application levels. Uploaded files are already available via the PSR-7
+> uploaded-file interfaces.
+
+
 #### Wildcard parsing
 
-You can also configure a fallback parser using the `*` wildcard.
+You can also configure a fallback parser using the `*` wildcard for small trusted payloads (for example JSON-only APIs). Avoid permissive wildcard parsing for untrusted large body types in worker deployments.
 
 ```php
 'request' => [

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,15 +59,14 @@ This ensures that `Yii::$app->request->post()` and `Yii::$app->request->bodyPara
 populated immediately after the request is handled.
 
 > [!WARNING]
-> In worker runtimes (for example RoadRunner or FrankenPHP), configured body parsers
-> receive the full request body as a string. Avoid enabling automatic parsing for
-> `multipart/form-data` unless strict upload/body size limits are enforced at the
-> server and application levels. Uploaded files are already available via the PSR-7
-> uploaded-file interfaces.
+> In worker runtimes (for example RoadRunner or FrankenPHP), configured body parsers receive the full request body as a
+> string. Avoid enabling automatic parsing for `multipart/form-data` unless strict upload/body size limits are enforced
+> at the server and application levels. Uploaded files are already available via the PSR-7 uploaded-file interfaces.
 
 #### Wildcard parsing
 
-You can also configure a fallback parser using the `*` wildcard for small trusted payloads (for example JSON-only APIs). Avoid permissive wildcard parsing for untrusted large body types in worker deployments.
+You can also configure a fallback parser using the `*` wildcard for small trusted payloads (for example JSON-only APIs).
+Avoid permissive wildcard parsing for untrusted large body types in worker deployments.
 
 ```php
 'request' => [


### PR DESCRIPTION
### Motivation
- The docs previously recommended enabling `multipart/form-data` and permissive `*` fallback parsers which, because `setPsr7Request()` casts the PSR-7 body to a string before parsing, can force full-body buffering in worker runtimes and enable memory DoS; the documentation should not promote that unsafe default.

### Description
- Removed the `MultipartFormDataParser` import and the `'multipart/form-data' => MultipartFormDataParser::class` line from the basic `parsers` example, added a prominent warning that configured parsers receive the full request body in worker runtimes and clarified that the `'*'` wildcard should only be used for small trusted payloads.

### Testing
- Documentation-only change; no automated tests were applicable or run, and repository file checks and the commit finished successfully (`docs/configuration.md` updated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f5572a8c0832aaddc8fd20d2ec49a)