### PR TITLE
fix: clear Yii core `uploaded-file` cache when resetting bridge uploaded-file state to prevent cross-request upload leakage in workers.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,5 +21,6 @@ jobs:
     with:
       concurrency-group: phpunit-${{ github.workflow }}-${{ github.ref }}
       extensions: mbstring, gd, runkit7
+      php-version: '["8.3","8.4","8.5"]'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.3.1 Under development
 
+- fix: clear Yii core `uploaded-file` cache when resetting bridge uploaded-file state to prevent cross-request upload leakage in workers.
+
 ## 0.3.0 February 28, 2026
 
 - Bug #237: Preserve configured worker singletons and persistent components (`db`, `cache`) across requests while keeping request-scoped components reinitialized per request in `Application` (@terabytesoftw)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.1 Under development
 
+- fix(docs): warn against unsafe multipart body parser setup.
 - fix: clear Yii core `uploaded-file` cache when resetting bridge uploaded-file state to prevent cross-request upload leakage in workers.
 
 ## 0.3.0 February 28, 2026
@@ -12,7 +13,6 @@
 - Bug #243: Remove redundant comments in `ApplicationConfigTest` and `ApplicationCoreTest` for improved clarity and maintainability (@terabytesoftw)
 - Bug #244: Update unit tests for `Application` class to enhance clarity and coverage; add `ApplicationReinitializationTest` for reinitialization behavior validation and update related documentation (@terabytesoftw)
 - Bug #245: Bootstrap DI container during `Application` construction, remove per-request container bootstrap, and avoid masking initialization failures behind missing `errorHandler` secondary exceptions (@terabytesoftw)
-- fix(docs): warn against unsafe multipart body parser setup.
 
 ## 0.2.1 February 21, 2026
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "httpsoft/http-message": "^1.1",
         "infection/infection": "^0.27|^0.32",
         "maglnet/composer-require-checker": "^4.1",
-        "php-forge/coding-standard": "^0.3",
+        "php-forge/coding-standard": "^0.2|^0.3",
         "php-forge/support": "^0.3",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-strict-rules": "^2.0.3",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "httpsoft/http-message": "^1.1",
         "infection/infection": "^0.27|^0.32",
         "maglnet/composer-require-checker": "^4.1",
-        "php-forge/coding-standard": "^0.1",
+        "php-forge/coding-standard": "^0.3",
         "php-forge/support": "^0.3",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-strict-rules": "^2.0.3",

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
     },
     "require-dev": {
         "httpsoft/http-message": "^1.1",
-        "infection/infection": "^^0.33",
+        "infection/infection": "^0.33",
         "maglnet/composer-require-checker": "^4.1",
-        "php-forge/coding-standard": "^^0.3",
+        "php-forge/coding-standard": "^0.3",
         "php-forge/support": "^0.3",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-strict-rules": "^2.0.3",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.3",
         "ext-filter": "*",
         "ext-mbstring": "*",
         "psr/http-factory": "^1.1",
@@ -27,9 +27,9 @@
     },
     "require-dev": {
         "httpsoft/http-message": "^1.1",
-        "infection/infection": "^0.27|^0.32",
+        "infection/infection": "^^0.33",
         "maglnet/composer-require-checker": "^4.1",
-        "php-forge/coding-standard": "^0.2|^0.3",
+        "php-forge/coding-standard": "^^0.3",
         "php-forge/support": "^0.3",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-strict-rules": "^2.0.3",

--- a/ecs.php
+++ b/ecs.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-/** @var \Symplify\EasyCodingStandard\Configuration\ECSConfigBuilder $ecsConfigBuilder */
-$ecsConfigBuilder = require __DIR__ . '/vendor/php-forge/coding-standard/config/ecs.php';
+/** @var \Symplify\EasyCodingStandard\Configuration\ECSConfigBuilder $builder */
+$builder = require __DIR__ . '/vendor/php-forge/coding-standard/src/ecs-83.php';
 
-return $ecsConfigBuilder->withPaths(
+return $builder->withPaths(
     [
         __DIR__ . '/src',
         __DIR__ . '/tests',

--- a/src/exception/Message.php
+++ b/src/exception/Message.php
@@ -71,7 +71,7 @@ enum Message: string
      * Format: "Invalid optional '%s' array in multiple file specification for '%s'. Expected 'array' or 'null'."
      */
     case INVALID_OPTIONAL_ARRAY_IN_MULTI_SPEC = "Invalid optional '%s' array in multiple file specification for '%s'. "
-    . "Expected 'array' or 'null'.";
+        . "Expected 'array' or 'null'.";
 
     /**
      * Error when a specific request parser is invalid.
@@ -107,7 +107,7 @@ enum Message: string
      * Format: "Missing or invalid '%s' array in multiple file specification for '%s'."
      */
     case MISSING_OR_INVALID_ARRAY_IN_MULTI_SPEC = "Missing or invalid '%s' array in multiple file specification for "
-    . "'%s'.";
+        . "'%s'.";
 
     /**
      * Error when a required key is missing in file specification.
@@ -143,7 +143,7 @@ enum Message: string
      * Format: "Response stream must be an 'array' with exactly '3' elements: ['handle', 'begin', 'end']."
      */
     case RESPONSE_STREAM_FORMAT_INVALID = "Response stream must be an 'array' with exactly '3' elements: "
-    . "['handle', 'begin', 'end'].";
+        . "['handle', 'begin', 'end'].";
 
     /**
      * Error when the response stream handle is invalid.
@@ -159,7 +159,7 @@ enum Message: string
      * Received: (begin='%d', end='%d')."
      */
     case RESPONSE_STREAM_RANGE_INVALID = 'Response stream range values must be valid: '
-    . "('begin' >= '0' and 'end' >= 'begin'). Received: (begin='%d', end='%d').";
+        . "('begin' >= '0' and 'end' >= 'begin'). Received: (begin='%d', end='%d').";
 
     /**
      * Error when unable to read from the response stream.

--- a/src/http/UploadedFile.php
+++ b/src/http/UploadedFile.php
@@ -190,6 +190,7 @@ class UploadedFile extends \yii\web\UploadedFile
 
         self::$_files = [];
         self::$psr7Adapter = null;
+
         parent::reset();
     }
 

--- a/src/http/UploadedFile.php
+++ b/src/http/UploadedFile.php
@@ -377,7 +377,7 @@ class UploadedFile extends \yii\web\UploadedFile
          *       size: int|int[],
          *       error: int|int[],
          *       full_path?: string|string[]|null,
-         *       tmp_resource?: resource|null|array<mixed>,
+         *       tmp_resource?: resource|array<mixed>|null,
          *    }
          * > $_FILES
          */

--- a/src/http/UploadedFile.php
+++ b/src/http/UploadedFile.php
@@ -190,6 +190,7 @@ class UploadedFile extends \yii\web\UploadedFile
 
         self::$_files = [];
         self::$psr7Adapter = null;
+        parent::reset();
     }
 
     /**

--- a/tests/http/UploadedFileTest.php
+++ b/tests/http/UploadedFileTest.php
@@ -8,6 +8,7 @@ use yii2\extensions\psrbridge\adapter\ServerRequestAdapter;
 use yii2\extensions\psrbridge\http\UploadedFile;
 use yii2\extensions\psrbridge\tests\support\{HelperFactory, TestCase};
 use yii2\extensions\psrbridge\tests\support\stub\{ComplexUploadedFileModel, UploadedFileModel};
+use yii\web\UploadedFile as YiiUploadedFile;
 
 use const UPLOAD_ERR_CANT_WRITE;
 use const UPLOAD_ERR_OK;
@@ -1472,6 +1473,32 @@ final class UploadedFileTest extends TestCase
             0,
             $stillOpenAfterReset,
             "All resources should be closed after 'reset()' method.",
+        );
+    }
+
+    public function testResetShouldClearLegacyYiiUploadedFileCache(): void
+    {
+        $_FILES = [
+            'avatar' => [
+                'name' => 'alice-secret.txt',
+                'type' => 'text/plain',
+                'tmp_name' => '/tmp/php-avatar',
+                'error' => UPLOAD_ERR_OK,
+                'size' => 16,
+            ],
+        ];
+
+        self::assertInstanceOf(
+            YiiUploadedFile::class,
+            YiiUploadedFile::getInstanceByName('avatar'),
+            "Precondition failed: legacy Yii cache should contain an uploaded file before reset.",
+        );
+
+        UploadedFile::reset();
+
+        self::assertNull(
+            YiiUploadedFile::getInstanceByName('avatar'),
+            "Legacy Yii cache should be cleared when bridge UploadedFile::reset() is called.",
         );
     }
 

--- a/tests/http/UploadedFileTest.php
+++ b/tests/http/UploadedFileTest.php
@@ -8,7 +8,6 @@ use yii2\extensions\psrbridge\adapter\ServerRequestAdapter;
 use yii2\extensions\psrbridge\http\UploadedFile;
 use yii2\extensions\psrbridge\tests\support\{HelperFactory, TestCase};
 use yii2\extensions\psrbridge\tests\support\stub\{ComplexUploadedFileModel, UploadedFileModel};
-use yii\web\UploadedFile as YiiUploadedFile;
 
 use const UPLOAD_ERR_CANT_WRITE;
 use const UPLOAD_ERR_OK;
@@ -1489,16 +1488,18 @@ final class UploadedFileTest extends TestCase
         ];
 
         self::assertInstanceOf(
-            YiiUploadedFile::class,
-            YiiUploadedFile::getInstanceByName('avatar'),
+            \yii\web\UploadedFile::class,
+            \yii\web\UploadedFile::getInstanceByName('avatar'),
             'Precondition failed: legacy Yii cache should contain an uploaded file before reset.',
         );
+
+        $_FILES = [];
 
         UploadedFile::reset();
 
         self::assertNull(
-            YiiUploadedFile::getInstanceByName('avatar'),
-            'Legacy Yii cache should be cleared when bridge UploadedFile::reset() is called.',
+            \yii\web\UploadedFile::getInstanceByName('avatar'),
+            "Legacy Yii cache should be cleared when bridge 'UploadedFile::reset()' is called.",
         );
     }
 

--- a/tests/http/UploadedFileTest.php
+++ b/tests/http/UploadedFileTest.php
@@ -1491,14 +1491,14 @@ final class UploadedFileTest extends TestCase
         self::assertInstanceOf(
             YiiUploadedFile::class,
             YiiUploadedFile::getInstanceByName('avatar'),
-            "Precondition failed: legacy Yii cache should contain an uploaded file before reset.",
+            'Precondition failed: legacy Yii cache should contain an uploaded file before reset.',
         );
 
         UploadedFile::reset();
 
         self::assertNull(
             YiiUploadedFile::getInstanceByName('avatar'),
-            "Legacy Yii cache should be cleared when bridge UploadedFile::reset() is called.",
+            'Legacy Yii cache should be cleared when bridge UploadedFile::reset() is called.',
         );
     }
 


### PR DESCRIPTION
### Motivation
- The bridge `UploadedFile` maintained its own static cache and `reset()` logic but no longer cleared the core `yii\web\UploadedFile` static cache, allowing stale uploaded-file metadata to persist across requests in long-running workers.

### Description
- Invoke `parent::reset()` from `yii2\extensions\psrbridge\http\UploadedFile::reset()` so the core `yii\web\UploadedFile` static cache is also cleared.
- Add a regression test `testResetShouldClearLegacyYiiUploadedFileCache()` in `tests/http/UploadedFileTest.php` that seeds `$_FILES`, verifies `YiiUploadedFile::getInstanceByName()` returns an instance, calls the bridge `UploadedFile::reset()`, and asserts the legacy cache is cleared.
- Add `use yii\web\UploadedFile as YiiUploadedFile;` to the test file to reference the core class.

### Testing
- Ran `php -l src/http/UploadedFile.php` which reported no syntax errors.
- Ran `php -l tests/http/UploadedFileTest.php` which reported no syntax errors.
- Attempted `vendor/bin/phpunit tests/http/UploadedFileTest.php` but it could not be executed in this environment because `vendor/bin/phpunit` is not present (dependencies are not installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f58147928832abe7f2d1b0c974480)