### PR TITLE
fix(security): prevent RangeStream bypass via detach() and metadata 'uri' exposure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix!(security): stream PSR-7 response bodies by default in `SapiEmitter` to avoid memory exhaustion.
 - fix(security): bound Yii file response bodies to the declared byte range via `RangeStream` wrapper, streaming lazily without buffering in memory or disk-backed temporary storage.
 - docs: Standardize PHPDoc across the project and add missing documentation.
+- fix(security): prevent `RangeStream` bypass via `detach()` and metadata `uri` exposure.
 
 ## 0.3.0 February 28, 2026
 

--- a/src/adapter/RangeStream.php
+++ b/src/adapter/RangeStream.php
@@ -8,6 +8,7 @@ use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 use Throwable;
 
+use function is_array;
 use function max;
 use function min;
 
@@ -22,6 +23,10 @@ use const SEEK_SET;
  * bound so consumers cannot read past `$end` even when calling {@see StreamInterface::getContents()} or repeated
  * {@see StreamInterface::read()} calls. Reads proxy to the underlying stream chunk by chunk without buffering the range
  * into memory or temporary storage.
+ *
+ * This is a bounded view, not a transparent decorator for the wrapped stream. The wrapped stream resource and its
+ * original URI can represent bytes outside the declared range, so they are not exposed through {@see detach()} or
+ * `getMetadata('uri')`.
  *
  * Usage example:
  * ```php
@@ -111,22 +116,28 @@ final class RangeStream implements StreamInterface
     public function close(): void
     {
         $this->stream?->close();
+
         $this->stream = null;
     }
 
     /**
-     * Detaches the underlying resource from the wrapped stream and releases the internal reference.
+     * Closes the wrapped stream and releases the internal reference without exposing the underlying resource.
+     *
+     * The wrapped resource is not detached because it can contain bytes outside this bounded view. Returning that
+     * resource would allow consumers to bypass the range limit. Consumers that need the body contents must read through
+     * {@see read()} or {@see getContents()}.
      *
      * Usage example:
      * ```php
      * $resource = $rangeStream->detach();
      * ```
      *
-     * @return resource|null Detached resource handle, or `null` when no stream is available.
+     * @return resource|null Always returns `null` because no safe detachable resource represents this bounded view.
      */
     public function detach()
     {
         $this->stream?->close();
+
         $this->stream = null;
 
         return null;
@@ -184,7 +195,10 @@ final class RangeStream implements StreamInterface
     }
 
     /**
-     * Returns metadata associated with the underlying stream.
+     * Returns metadata associated with this bounded stream view.
+     *
+     * Resource locator metadata such as `uri` is omitted because the underlying URI identifies the unbounded wrapped
+     * stream, not this range-limited view.
      *
      * Usage example:
      * ```php
@@ -193,16 +207,21 @@ final class RangeStream implements StreamInterface
      *
      * @param string|null $key Specific metadata key, or `null` to return the full metadata array.
      *
-     * @return mixed Metadata value for `$key`, the full array when `$key` is `null`, or `null` when no stream is
-     * available and `$key` is provided.
+     * @return mixed Metadata value for `$key`, the full metadata array when `$key` is `null`, or `null` when no stream
+     * is available and `$key` is provided.
      */
-    public function getMetadata(string|null $key = null)
+    public function getMetadata(string|null $key = null): mixed
     {
         if ($this->stream === null) {
             return $key === null ? [] : null;
         }
 
         $metadata = $this->stream->getMetadata();
+
+        if (is_array($metadata) === false) {
+            return $key === null ? [] : null;
+        }
+
         unset($metadata['uri']);
 
         if ($key === null) {

--- a/src/adapter/RangeStream.php
+++ b/src/adapter/RangeStream.php
@@ -126,10 +126,10 @@ final class RangeStream implements StreamInterface
      */
     public function detach()
     {
-        $resource = $this->stream?->detach();
+        $this->stream?->close();
         $this->stream = null;
 
-        return $resource;
+        return null;
     }
 
     /**
@@ -202,7 +202,14 @@ final class RangeStream implements StreamInterface
             return $key === null ? [] : null;
         }
 
-        return $this->stream->getMetadata($key);
+        $metadata = $this->stream->getMetadata();
+        unset($metadata['uri']);
+
+        if ($key === null) {
+            return $metadata;
+        }
+
+        return $metadata[$key] ?? null;
     }
 
     /**

--- a/src/adapter/RangeStream.php
+++ b/src/adapter/RangeStream.php
@@ -129,7 +129,7 @@ final class RangeStream implements StreamInterface
      *
      * Usage example:
      * ```php
-     * $resource = $rangeStream->detach();
+     * $rangeStream->detach();
      * ```
      *
      * @return resource|null Always returns `null` because no safe detachable resource represents this bounded view.

--- a/tests/adapter/RangeStreamTest.php
+++ b/tests/adapter/RangeStreamTest.php
@@ -124,15 +124,24 @@ final class RangeStreamTest extends TestCase
         );
     }
 
-    public function testDetachReturnsUnderlyingResource(): void
+    public function testDetachReturnsNullAndClosesUnderlyingResource(): void
     {
-        $rangeStream = new RangeStream($this->stream('test'), 0, 3);
+        $resource = fopen('php://memory', 'r+');
+        fwrite($resource, 'test');
+        fseek($resource, 0);
 
-        $resource = $rangeStream->detach();
+        $stream = HelperFactory::createStreamFactory()->createStreamFromResource($resource);
+        $rangeStream = new RangeStream($stream, 0, 3);
 
-        self::assertIsResource(
-            $resource,
-            'Detach must return the underlying resource.',
+        $detached = $rangeStream->detach();
+
+        self::assertNull(
+            $detached,
+            'Detach must not expose the underlying resource.',
+        );
+        self::assertFalse(
+            is_resource($resource),
+            "Underlying resource must be closed by 'detach()'.",
         );
         self::assertNull(
             $rangeStream->getSize(),
@@ -250,6 +259,21 @@ final class RangeStreamTest extends TestCase
         self::assertNull(
             $rangeStream->getMetadata('uri'),
             'Metadata key must yield `null` after close.',
+        );
+    }
+
+    public function testGetMetadataDoesNotExposeUri(): void
+    {
+        $rangeStream = new RangeStream($this->stream('test'), 0, 3);
+
+        self::assertNull(
+            $rangeStream->getMetadata('uri'),
+            "Metadata key 'uri' must not be exposed.",
+        );
+        self::assertArrayNotHasKey(
+            'uri',
+            $rangeStream->getMetadata(),
+            "Metadata array must not contain the 'uri' key.",
         );
     }
 

--- a/tests/adapter/RangeStreamTest.php
+++ b/tests/adapter/RangeStreamTest.php
@@ -339,6 +339,25 @@ final class RangeStreamTest extends TestCase
         );
     }
 
+    /**
+     * @throws Exception if the mock object cannot be created.
+     */
+    public function testGetMetadataReturnsEmptyArrayWhenUnderlyingMetadataIsNotArray(): void
+    {
+        $stream = $this->createMock(StreamInterface::class);
+
+        $stream->method('isSeekable')->willReturn(false);
+        $stream->method('getMetadata')->willReturn('invalid-metadata');
+
+        $rangeStream = new RangeStream($stream, 0, 3);
+
+        self::assertSame(
+            [],
+            $rangeStream->getMetadata(),
+            "Metadata must be an empty 'array' when the underlying metadata is invalid.",
+        );
+    }
+
     public function testGetMetadataReturnsNullForKeyWhenClosed(): void
     {
         $rangeStream = new RangeStream($this->stream('test'), 0, 3);
@@ -348,6 +367,24 @@ final class RangeStreamTest extends TestCase
         self::assertNull(
             $rangeStream->getMetadata('uri'),
             'Metadata key must yield `null` after close.',
+        );
+    }
+
+    /**
+     * @throws Exception if the mock object cannot be created.
+     */
+    public function testGetMetadataReturnsNullForKeyWhenUnderlyingMetadataIsNotArray(): void
+    {
+        $stream = $this->createMock(StreamInterface::class);
+
+        $stream->method('isSeekable')->willReturn(false);
+        $stream->method('getMetadata')->willReturn('invalid-metadata');
+
+        $rangeStream = new RangeStream($stream, 0, 3);
+
+        self::assertNull(
+            $rangeStream->getMetadata('uri'),
+            "Metadata key must yield 'null' when the underlying metadata is invalid.",
         );
     }
 

--- a/tests/adapter/RangeStreamTest.php
+++ b/tests/adapter/RangeStreamTest.php
@@ -127,6 +127,12 @@ final class RangeStreamTest extends TestCase
     public function testDetachReturnsNullAndClosesUnderlyingResource(): void
     {
         $resource = fopen('php://memory', 'r+');
+
+        self::assertIsResource(
+            $resource,
+            'Setup: memory resource must be valid.',
+        );
+
         fwrite($resource, 'test');
         fseek($resource, 0);
 
@@ -146,6 +152,36 @@ final class RangeStreamTest extends TestCase
         self::assertNull(
             $rangeStream->getSize(),
             "Size must be 'null' after detach.",
+        );
+    }
+
+    public function testDetachReturnsNullForPartialRangeWithoutExposingUnderlyingResource(): void
+    {
+        $resource = fopen('php://memory', 'r+');
+
+        self::assertIsResource(
+            $resource,
+            'Setup: memory resource must be valid.',
+        );
+
+        fwrite($resource, '0123456789SECRET_AFTER_RANGE');
+        fseek($resource, 0);
+
+        $stream = HelperFactory::createStreamFactory()->createStreamFromResource($resource);
+        $rangeStream = new RangeStream($stream, 2, 5);
+
+        self::assertSame(
+            '23',
+            $rangeStream->read(2),
+            'Setup: range stream must read from the requested partial range.',
+        );
+        self::assertNull(
+            $rangeStream->detach(),
+            'Detach must not expose the unbounded underlying resource.',
+        );
+        self::assertFalse(
+            is_resource($resource),
+            "Underlying resource must be closed by 'detach()'.",
         );
     }
 
@@ -227,6 +263,59 @@ final class RangeStreamTest extends TestCase
         );
     }
 
+    public function testGetMetadataDoesNotExposeUnderlyingFileUri(): void
+    {
+        $tempFile = $this->createTempFileWithContent('0123456789SECRET_AFTER_RANGE');
+        $resource = fopen($tempFile, 'rb');
+
+        self::assertIsResource(
+            $resource,
+            'Setup: temporary file resource must be valid.',
+        );
+
+        $stream = HelperFactory::createStreamFactory()->createStreamFromResource($resource);
+        $rangeStream = new RangeStream($stream, 2, 5);
+        $metadata = $rangeStream->getMetadata();
+
+        self::assertIsArray(
+            $metadata,
+            "Metadata must be an 'array'.",
+        );
+
+        self::assertNull(
+            $rangeStream->getMetadata('uri'),
+            "Metadata key 'uri' must not expose the underlying file path.",
+        );
+        self::assertArrayNotHasKey(
+            'uri',
+            $metadata,
+            "Metadata array must not contain the underlying file path under 'uri'.",
+        );
+
+        $rangeStream->close();
+    }
+
+    public function testGetMetadataDoesNotExposeUri(): void
+    {
+        $rangeStream = new RangeStream($this->stream('test'), 0, 3);
+        $metadata = $rangeStream->getMetadata();
+
+        self::assertIsArray(
+            $metadata,
+            "Metadata must be an 'array'.",
+        );
+
+        self::assertNull(
+            $rangeStream->getMetadata('uri'),
+            "Metadata key 'uri' must not be exposed.",
+        );
+        self::assertArrayNotHasKey(
+            'uri',
+            $metadata,
+            "Metadata array must not contain the 'uri' key.",
+        );
+    }
+
     public function testGetMetadataReturnsArrayWhenStreamIsOpen(): void
     {
         $rangeStream = new RangeStream($this->stream('test'), 0, 3);
@@ -259,21 +348,6 @@ final class RangeStreamTest extends TestCase
         self::assertNull(
             $rangeStream->getMetadata('uri'),
             'Metadata key must yield `null` after close.',
-        );
-    }
-
-    public function testGetMetadataDoesNotExposeUri(): void
-    {
-        $rangeStream = new RangeStream($this->stream('test'), 0, 3);
-
-        self::assertNull(
-            $rangeStream->getMetadata('uri'),
-            "Metadata key 'uri' must not be exposed.",
-        );
-        self::assertArrayNotHasKey(
-            'uri',
-            $rangeStream->getMetadata(),
-            "Metadata array must not contain the 'uri' key.",
         );
     }
 


### PR DESCRIPTION
### Motivation
- `RangeStream::detach()` previously returned the underlying stream resource, allowing downstream PSR runtimes that call `detach()` to obtain the raw file handle and read past the declared byte range.  
- `RangeStream::getMetadata()` delegated straight through to the underlying stream metadata and exposed the `uri` key, which could enable consumers to bypass the wrapper by opening the original file directly.

### Description
- Hardened `RangeStream::detach()` to close the wrapped stream and return `null` instead of exposing the underlying resource handle, preventing resource escape via `detach()`.
- Sanitized `RangeStream::getMetadata()` to strip the `uri` key and return metadata from the wrapped stream without exposing the original file URI, while preserving other metadata access semantics.
- Updated unit tests in `tests/adapter/RangeStreamTest.php` to assert that `detach()` no longer returns a resource and that `getMetadata()` does not expose the `uri` key.

### Testing
- Updated and added unit tests in `tests/adapter/RangeStreamTest.php` to cover the new `detach()` and metadata behavior (tests committed but not executed here).  
- Attempted to run `vendor/bin/phpunit tests/adapter/RangeStreamTest.php` in this environment, but the test runner was not available and the command failed (`vendor/bin/phpunit: No such file or directory`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a111e635d38832ab43303743998cf3b)