### PR TITLE
fix(security): always reset uploaded-file state during request preparation to preserve worker request isolation, even when `resetUploadedFiles` is set to `false`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(security): bound Yii file response bodies to the declared byte range via `RangeStream` wrapper, streaming lazily without buffering in memory or disk-backed temporary storage.
 - docs: Standardize PHPDoc across the project and add missing documentation.
 - fix(security): prevent `RangeStream` bypass via `detach()` and metadata `uri` exposure.
+- fix(security): always reset uploaded-file state during request preparation to preserve worker request isolation, even when `resetUploadedFiles` is set to `false`.
 
 ## 0.3.0 February 28, 2026
 

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ Define lifecycle flags before `run()` (via config or property setters).
 ```php
 $config = [
     'class' => Application::class,
-    // disable session and cookie validation sync for stateless REST APIs; keep resetUploadedFiles=true (the default)
-    // unless you have a specific reason to retain uploaded file state across requests
+    // disable session and cookie validation sync for stateless REST APIs.
+    // keep resetUploadedFiles=true (default) for request isolation.
     'useSession' => false,
     'syncCookieValidation' => false,
     'resetUploadedFiles' => true,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -218,7 +218,7 @@ $app->persistentComponents = ['db', 'cache'];
 
 - `useSession`: keep `true` unless the application is strictly stateless. Setting it to `false` skips bridge session open/finalize hooks; custom code may still open sessions.
 - `syncCookieValidation`: keep `true` in most cases. Setting it to `false` disables request-to-response synchronization of cookie validation settings and can break login/identity flows.
-- `resetUploadedFiles`: keep `true` in long-running workers. Setting it to `false` is advanced and can leak static uploaded-file state between requests.
+- `resetUploadedFiles`: keep `true` in long-running workers to preserve per-request upload isolation.
 - `persistentComponents`: list of components to keep alive between requests (default: `['db', 'cache']`). Only include components proven to be request-safe.
 - Never include request-scoped components in `persistentComponents` (`request`, `response`, `errorHandler`, `session`, `user`).
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -204,7 +204,7 @@ Use non-default values only for advanced scenarios:
 
 - `useSession=false` skips bridge session hooks only.
 - `syncCookieValidation=false` skips cookie validation synchronization between request and response.
-- `resetUploadedFiles=false` can retain uploaded-file static state across requests and should be avoided in most worker deployments.
+- Keep `resetUploadedFiles=true` to preserve per-request uploaded-file isolation in worker deployments.
 
 ## Next steps
 

--- a/src/http/Application.php
+++ b/src/http/Application.php
@@ -58,7 +58,7 @@ class Application extends \yii\web\Application implements RequestHandlerInterfac
     /**
      * Controls whether uploaded file static state is reset for each request.
      *
-     * Set to `false` to retain static uploaded-file state across requests (advanced use only).
+     * This remains enabled for request isolation and is not intended to be disabled in workers.
      */
     public bool $resetUploadedFiles = true;
 
@@ -329,9 +329,7 @@ class Application extends \yii\web\Application implements RequestHandlerInterfac
         $this->startEventTracking();
         $this->reinitializeApplication();
 
-        if ($this->resetUploadedFiles) {
-            $this->resetUploadedFilesState();
-        }
+        $this->resetUploadedFilesState();
 
         $this->resetRequestState();
         $this->prepareErrorHandler();

--- a/tests/http/stateless/ApplicationHookTest.php
+++ b/tests/http/stateless/ApplicationHookTest.php
@@ -87,7 +87,7 @@ final class ApplicationHookTest extends TestCase
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
-    public function testHandleSkipsResetUploadedFilesHookWhenResetUploadedFilesIsDisabled(): void
+    public function testHandleAlwaysResetsUploadedFilesStateEvenWhenFlagIsDisabled(): void
     {
         $app = ApplicationFactory::rest(['resetUploadedFiles' => false]);
 
@@ -96,13 +96,14 @@ final class ApplicationHookTest extends TestCase
         $this->assertSiteIndexJsonResponse(
             $response,
         );
-        self::assertFalse(
+        self::assertTrue(
             $app->resetUploadedFilesStateCalled,
-            "'resetUploadedFilesState()' should not be invoked when 'resetUploadedFiles' is disabled.",
+            "'resetUploadedFilesState()' should always be invoked for request isolation.",
         );
         self::assertSame(
             [
                 'reinitializeApplication',
+                'resetUploadedFilesState',
                 'resetRequestState',
                 'prepareErrorHandler',
                 'attachPsrRequest',
@@ -112,7 +113,7 @@ final class ApplicationHookTest extends TestCase
                 'terminate',
             ],
             $app->hookCallLog,
-            'Remaining lifecycle hooks must still fire in order when resetUploadedFiles is disabled.',
+            'Lifecycle hooks must still fire in order when resetUploadedFiles is set to false.',
         );
     }
 

--- a/tests/http/stateless/ApplicationHookTest.php
+++ b/tests/http/stateless/ApplicationHookTest.php
@@ -21,6 +21,38 @@ final class ApplicationHookTest extends TestCase
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
+    public function testHandleAlwaysResetsUploadedFilesStateEvenWhenFlagIsDisabled(): void
+    {
+        $app = ApplicationFactory::rest(['resetUploadedFiles' => false]);
+
+        $response = $app->handle(HelperFactory::createRequest('GET', 'site/index'));
+
+        $this->assertSiteIndexJsonResponse(
+            $response,
+        );
+        self::assertTrue(
+            $app->resetUploadedFilesStateCalled,
+            "'resetUploadedFilesState()' should always be invoked for request isolation.",
+        );
+        self::assertSame(
+            [
+                'reinitializeApplication',
+                'resetUploadedFilesState',
+                'resetRequestState',
+                'prepareErrorHandler',
+                'attachPsrRequest',
+                'syncCookieValidationState',
+                'openSessionFromRequestCookies',
+                'finalizeSessionState',
+                'terminate',
+            ],
+            $app->hookCallLog,
+            'Lifecycle hooks must still fire in order when resetUploadedFiles is set to false.',
+        );
+    }
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
     public function testHandleInvokesOverriddenCoreLifecycleHooks(): void
     {
         $app = ApplicationFactory::rest();
@@ -81,39 +113,6 @@ final class ApplicationHookTest extends TestCase
         self::assertTrue(
             $app->terminateCalled,
             "Overridden 'terminate()' hook should be invoked by 'handle()'.",
-        );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testHandleAlwaysResetsUploadedFilesStateEvenWhenFlagIsDisabled(): void
-    {
-        $app = ApplicationFactory::rest(['resetUploadedFiles' => false]);
-
-        $response = $app->handle(HelperFactory::createRequest('GET', 'site/index'));
-
-        $this->assertSiteIndexJsonResponse(
-            $response,
-        );
-        self::assertTrue(
-            $app->resetUploadedFilesStateCalled,
-            "'resetUploadedFilesState()' should always be invoked for request isolation.",
-        );
-        self::assertSame(
-            [
-                'reinitializeApplication',
-                'resetUploadedFilesState',
-                'resetRequestState',
-                'prepareErrorHandler',
-                'attachPsrRequest',
-                'syncCookieValidationState',
-                'openSessionFromRequestCookies',
-                'finalizeSessionState',
-                'terminate',
-            ],
-            $app->hookCallLog,
-            'Lifecycle hooks must still fire in order when resetUploadedFiles is set to false.',
         );
     }
 

--- a/tests/http/stateless/ApplicationHookTest.php
+++ b/tests/http/stateless/ApplicationHookTest.php
@@ -50,6 +50,7 @@ final class ApplicationHookTest extends TestCase
             'Lifecycle hooks must still fire in order when resetUploadedFiles is set to false.',
         );
     }
+
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */


### PR DESCRIPTION
### Motivation
- A recent change made the per-request uploaded-file static reset conditional (`resetUploadedFiles`), which can leave `UploadedFile::$_files` populated across requests in long-running workers and risk cross-request disclosure.
- The goal is to restore per-request isolation by ensuring uploaded-file state is always cleared at the start of each request.

### Description
- Restore unconditional uploaded-file reset by calling `resetUploadedFilesState()` unconditionally from `Application::prepareForRequest()` instead of guarding it with `resetUploadedFiles`.
- Update the `resetUploadedFiles` property docblock to state that resetting remains enabled for request isolation and is not intended to be disabled in workers.
- Update `tests/http/stateless/ApplicationHookTest.php` to assert that `resetUploadedFilesState()` is always invoked (even when `resetUploadedFiles => false`) and adjust the expected hook order accordingly.
- Update `README.md`, `docs/configuration.md`, and `docs/examples.md` to consistently recommend keeping `resetUploadedFiles=true` for per-request uploaded-file isolation.

### Testing
- Ran `php -l src/http/Application.php` and `php -l tests/http/stateless/ApplicationHookTest.php`, both reported no syntax errors.
- Attempted to run `vendor/bin/phpunit tests/http/stateless/ApplicationHookTest.php` but it failed in this environment because `vendor/bin/phpunit` is not available (test dependencies not installed).
- No additional automated test suites were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13723ee614832a99714d37b36bfd05)