### PR TITLE
fix(security): open the session before `bootstrap()` so worker bootstrap components observe the current request session, and finalize the session via `try`/`finally` to prevent lock leaks when bootstrap throws.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - docs: Standardize PHPDoc across the project and add missing documentation.
 - fix(security): prevent `RangeStream` bypass via `detach()` and metadata `uri` exposure.
 - fix(security): always reset uploaded-file state during request preparation to preserve worker request isolation, even when `resetUploadedFiles` is set to `false`.
+- fix(security): open the session before `bootstrap()` so worker bootstrap components observe the current request session, and finalize the session via `try`/`finally` to prevent lock leaks when bootstrap throws.
 
 ## 0.3.0 February 28, 2026
 

--- a/src/http/Application.php
+++ b/src/http/Application.php
@@ -339,10 +339,13 @@ class Application extends \yii\web\Application implements RequestHandlerInterfac
             $this->syncCookieValidationState();
         }
 
+        if ($this->useSession) {
+            $this->openSessionFromRequestCookies();
+        }
+
         $this->bootstrap();
 
         if ($this->useSession) {
-            $this->openSessionFromRequestCookies();
             $this->finalizeSessionState();
         }
     }

--- a/src/http/Application.php
+++ b/src/http/Application.php
@@ -339,14 +339,16 @@ class Application extends \yii\web\Application implements RequestHandlerInterfac
             $this->syncCookieValidationState();
         }
 
-        if ($this->useSession) {
-            $this->openSessionFromRequestCookies();
-        }
+        try {
+            if ($this->useSession) {
+                $this->openSessionFromRequestCookies();
+            }
 
-        $this->bootstrap();
-
-        if ($this->useSession) {
-            $this->finalizeSessionState();
+            $this->bootstrap();
+        } finally {
+            if ($this->useSession) {
+                $this->finalizeSessionState();
+            }
         }
     }
 

--- a/tests/http/stateless/ApplicationHookTest.php
+++ b/tests/http/stateless/ApplicationHookTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\Group;
 use yii\base\{Action, InvalidConfigException};
 use yii2\extensions\psrbridge\http\UploadedFile;
 use yii2\extensions\psrbridge\tests\support\{ApplicationFactory, HelperFactory, TestCase};
+use yii2\extensions\psrbridge\tests\support\stub\ThrowingBootstrap;
 
 /**
  * Unit tests for the lifecycle hook overrides in {@see \yii2\extensions\psrbridge\tests\support\stub\ApplicationRest}.
@@ -43,11 +44,32 @@ final class ApplicationHookTest extends TestCase
                 'attachPsrRequest',
                 'syncCookieValidationState',
                 'openSessionFromRequestCookies',
+                'bootstrap',
                 'finalizeSessionState',
                 'terminate',
             ],
             $app->hookCallLog,
             'Lifecycle hooks must still fire in order when resetUploadedFiles is set to false.',
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testHandleFinalizesSessionStateWhenBootstrapThrows(): void
+    {
+        $app = ApplicationFactory::rest(['bootstrap' => [ThrowingBootstrap::class]]);
+
+        $response = $app->handle(HelperFactory::createRequest('GET', 'site/index'));
+
+        self::assertSame(
+            500,
+            $response->getStatusCode(),
+            "Status must be '500'.",
+        );
+        self::assertTrue(
+            $app->finalizeSessionStateCalled,
+            'Session must be finalized.',
         );
     }
 
@@ -73,6 +95,7 @@ final class ApplicationHookTest extends TestCase
                 'attachPsrRequest',
                 'syncCookieValidationState',
                 'openSessionFromRequestCookies',
+                'bootstrap',
                 'finalizeSessionState',
                 'terminate',
             ],
@@ -145,6 +168,7 @@ final class ApplicationHookTest extends TestCase
                 'prepareErrorHandler',
                 'attachPsrRequest',
                 'syncCookieValidationState',
+                'bootstrap',
                 'terminate',
             ],
             $app->hookCallLog,
@@ -176,6 +200,7 @@ final class ApplicationHookTest extends TestCase
                 'prepareErrorHandler',
                 'attachPsrRequest',
                 'openSessionFromRequestCookies',
+                'bootstrap',
                 'finalizeSessionState',
                 'terminate',
             ],

--- a/tests/http/stateless/ApplicationSessionTest.php
+++ b/tests/http/stateless/ApplicationSessionTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\Group;
 use yii\base\InvalidConfigException;
 use yii\helpers\Json;
 use yii2\extensions\psrbridge\tests\support\{ApplicationFactory, HelperFactory, TestCase};
+use yii2\extensions\psrbridge\tests\support\stub\SessionBootstrap;
 
 use function array_filter;
 use function array_key_exists;
@@ -25,6 +26,43 @@ use function uniqid;
 #[Group('http')]
 final class ApplicationSessionTest extends TestCase
 {
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testBootstrapObservesSessionOpenedFromRequestCookie(): void
+    {
+        SessionBootstrap::$active = false;
+        SessionBootstrap::$id = '';
+
+        $sessionName = session_name();
+
+        if ($sessionName === false) {
+            self::fail("Failed to retrieve session name using 'session_name()'.");
+        }
+
+        $sessionId = 'probe-session-id';
+
+        $_COOKIE = [$sessionName => $sessionId];
+        $_SERVER = [
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => 'site/index',
+        ];
+
+        $app = ApplicationFactory::stateless(['bootstrap' => [SessionBootstrap::class]]);
+
+        $app->handle(HelperFactory::createServerRequestCreator()->createFromGlobals());
+
+        self::assertTrue(
+            SessionBootstrap::$active,
+            'Session must be active during bootstrap.',
+        );
+        self::assertSame(
+            $sessionId,
+            SessionBootstrap::$id,
+            'Observed session `ID` must match the cookie.',
+        );
+    }
+
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */

--- a/tests/support/stub/ApplicationRest.php
+++ b/tests/support/stub/ApplicationRest.php
@@ -95,6 +95,13 @@ final class ApplicationRest extends Application
         parent::attachPsrRequest($request);
     }
 
+    protected function bootstrap(): void
+    {
+        $this->hookCallLog[] = 'bootstrap';
+
+        parent::bootstrap();
+    }
+
     protected function finalizeSessionState(): void
     {
         $this->hookCallLog[] = 'finalizeSessionState';

--- a/tests/support/stub/SessionBootstrap.php
+++ b/tests/support/stub/SessionBootstrap.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\psrbridge\tests\support\stub;
+
+use yii\base\BootstrapInterface;
+use yii\web\Session;
+
+/**
+ * Bootstrap stub that records the session state observed during the bootstrap stage.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class SessionBootstrap implements BootstrapInterface
+{
+    /**
+     * Whether the session was active when bootstrap ran.
+     */
+    public static bool $active = false;
+    /**
+     * Session 'ID' observed when bootstrap ran.
+     */
+    public static string $id = '';
+
+    /**
+     * @param \yii\base\Application $app Application currently bootstrapping.
+     */
+    public function bootstrap($app): void
+    {
+        $session = $app->get('session');
+
+        if ($session instanceof Session) {
+            self::$active = $session->getIsActive();
+            self::$id = $session->getId();
+        }
+    }
+}

--- a/tests/support/stub/ThrowingBootstrap.php
+++ b/tests/support/stub/ThrowingBootstrap.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\psrbridge\tests\support\stub;
+
+use RuntimeException;
+use yii\base\BootstrapInterface;
+
+/**
+ * Bootstrap stub that always throws to exercise session finalization on bootstrap failure.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class ThrowingBootstrap implements BootstrapInterface
+{
+    /**
+     * @param \yii\base\Application $app Application currently bootstrapping.
+     *
+     * @throws RuntimeException Always, to simulate a failing bootstrap component.
+     */
+    public function bootstrap($app): never
+    {
+        throw new RuntimeException('Bootstrap failure.');
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent bootstrap components from observing fallback or stale request/session state by ensuring the current PSR-7 request and (when enabled) session ID are bound before `bootstrap()` runs, which mitigates cross-request/session confusion in long-running workers.

### Description
- In `src/http/Application.php` `prepareForRequest()` now calls `openSessionFromRequestCookies()` (when `useSession` is enabled) before invoking `$this->bootstrap()` and still calls `finalizeSessionState()` after bootstrap to preserve the previous finalization behavior.
- This is a minimal reorder of lifecycle steps to ensure bootstrap runs with the correct request/session context and does not change other initialization semantics.

### Testing
- `php -l src/http/Application.php` reported no syntax errors (success).
- Attempted to run targeted tests with `vendor/bin/phpunit tests/http/stateless/ApplicationHookTest.php tests/http/stateless/ApplicationSessionTest.php`, but `vendor/bin/phpunit` is not available in this environment so PHPUnit could not be executed (unable to run automated test suite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13814aafc4832aa11930ab703b8694)