### PR TITLE
fix(security): ignore scalar request-parser results so scalar JSON bodies no longer break PSR-7 request handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(security): prevent `RangeStream` bypass via `detach()` and metadata `uri` exposure.
 - fix(security): always reset uploaded-file state during request preparation to preserve worker request isolation, even when `resetUploadedFiles` is set to `false`.
 - fix(security): open the session before `bootstrap()` so worker bootstrap components observe the current request session, and finalize the session via `try`/`finally` to prevent lock leaks when bootstrap throws.
+- fix(security): ignore scalar request-parser results so scalar JSON bodies no longer break PSR-7 request handling.
 
 ## 0.3.0 February 28, 2026
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "psr/http-factory": "^1.1",
         "psr/http-message": "^2.0",
         "psr/http-server-handler": "^1.0",
-        "yiisoft/yii2": "^2.0.54|^22"
+        "yiisoft/yii2": "2.0.*@dev || ^22.0@dev"
     },
     "require-dev": {
         "httpsoft/http-message": "^1.1",

--- a/src/adapter/ServerRequestAdapter.php
+++ b/src/adapter/ServerRequestAdapter.php
@@ -13,6 +13,7 @@ use yii2\extensions\psrbridge\exception\Message;
 use function implode;
 use function in_array;
 use function is_array;
+use function is_object;
 use function is_string;
 use function strpos;
 use function strtoupper;
@@ -517,6 +518,10 @@ final class ServerRequestAdapter
             $parsedParams = $parser->parse((string) $request->getBody(), $rawContentType);
         }
 
-        return $request->withParsedBody($parsedParams);
+        if ($parsedParams === null || is_array($parsedParams) || is_object($parsedParams)) {
+            return $request->withParsedBody($parsedParams);
+        }
+
+        return $request;
     }
 }

--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -17,6 +17,7 @@ use function explode;
 use function filter_var;
 use function is_array;
 use function is_numeric;
+use function is_object;
 use function is_string;
 use function mb_check_encoding;
 use function mb_substr;
@@ -139,7 +140,7 @@ class Request extends \yii\web\Request
             return $this->adapter->getBodyParams($this->methodParam);
         }
 
-        return parent::getBodyParams();
+        return $this->normalizeParentBodyParams() ?? [];
     }
 
     /**
@@ -276,7 +277,7 @@ class Request extends \yii\web\Request
             return $this->adapter->getParsedBody();
         }
 
-        return parent::getBodyParams();
+        return $this->normalizeParentBodyParams();
     }
 
     /**
@@ -725,5 +726,24 @@ class Request extends \yii\web\Request
         }
 
         return ''; // script-less worker mode fallback
+    }
+
+    /**
+     * Normalizes the parent body parameters to the bridge's `array|object|null` contract.
+     *
+     * Yii types {@see \yii\web\Request::getBodyParams()} as `mixed` because request parsers may return scalar values
+     * for valid scalar payloads; the bridge guarantees `array|object`, so scalar results are discarded.
+     *
+     * @throws InvalidConfigException if a registered parser does not implement RequestParserInterface.
+     *
+     * @return array|object|null Parsed body parameters, or `null` when the parser yields a scalar value.
+     *
+     * @phpstan-return array<array-key, mixed>|object|null
+     */
+    private function normalizeParentBodyParams(): array|object|null
+    {
+        $bodyParams = parent::getBodyParams();
+
+        return is_array($bodyParams) || is_object($bodyParams) ? $bodyParams : null;
     }
 }

--- a/tests/adapter/ServerRequestAdapterTest.php
+++ b/tests/adapter/ServerRequestAdapterTest.php
@@ -108,6 +108,36 @@ final class ServerRequestAdapterTest extends TestCase
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
+    public function testScalarParsedBodyFromParserIsIgnored(): void
+    {
+        $stream = HelperFactory::createStream();
+        $stream->write('false');
+
+        $request = new Request();
+        $request->parsers = ['application/json' => JsonParser::class];
+
+        $request->setPsr7Request(
+            HelperFactory::createRequest(
+                'POST',
+                '/api/items',
+                ['Content-Type' => 'application/json; charset=UTF-8'],
+            )->withBody($stream),
+        );
+
+        self::assertNull(
+            $request->getPsr7Request()->getParsedBody(),
+            "PSR-7 request parsed body should remain 'null' when parser returns a scalar value.",
+        );
+        self::assertSame(
+            [],
+            $request->getBodyParams(),
+            "Body parameters should fallback to an empty array when parser returns a scalar value.",
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
     public function testParsedBodyIsNullWhenParsersArrayIsEmpty(): void
     {
         $jsonData = '{"action":"create","item":"product"}';

--- a/tests/adapter/ServerRequestAdapterTest.php
+++ b/tests/adapter/ServerRequestAdapterTest.php
@@ -108,36 +108,6 @@ final class ServerRequestAdapterTest extends TestCase
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
-    public function testScalarParsedBodyFromParserIsIgnored(): void
-    {
-        $stream = HelperFactory::createStream();
-        $stream->write('false');
-
-        $request = new Request();
-        $request->parsers = ['application/json' => JsonParser::class];
-
-        $request->setPsr7Request(
-            HelperFactory::createRequest(
-                'POST',
-                '/api/items',
-                ['Content-Type' => 'application/json; charset=UTF-8'],
-            )->withBody($stream),
-        );
-
-        self::assertNull(
-            $request->getPsr7Request()->getParsedBody(),
-            "PSR-7 request parsed body should remain 'null' when parser returns a scalar value.",
-        );
-        self::assertSame(
-            [],
-            $request->getBodyParams(),
-            'Body parameters should fallback to an empty array when parser returns a scalar value.',
-        );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
     public function testParsedBodyIsNullWhenParsersArrayIsEmpty(): void
     {
         $jsonData = '{"action":"create","item":"product"}';
@@ -791,6 +761,36 @@ final class ServerRequestAdapterTest extends TestCase
             $expectedUrl,
             $request->getUrl(),
             "URL should match the expected value for: {$url}.",
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testScalarParsedBodyFromParserIsIgnored(): void
+    {
+        $stream = HelperFactory::createStream();
+        $stream->write('false');
+
+        $request = new Request();
+        $request->parsers = ['application/json' => JsonParser::class];
+
+        $request->setPsr7Request(
+            HelperFactory::createRequest(
+                'POST',
+                '/api/items',
+                ['Content-Type' => 'application/json; charset=UTF-8'],
+            )->withBody($stream),
+        );
+
+        self::assertNull(
+            $request->getPsr7Request()->getParsedBody(),
+            "PSR-7 request parsed body should remain 'null' when parser returns a scalar value.",
+        );
+        self::assertSame(
+            [],
+            $request->getBodyParams(),
+            'Body parameters should fallback to an empty array when parser returns a scalar value.',
         );
     }
 }

--- a/tests/adapter/ServerRequestAdapterTest.php
+++ b/tests/adapter/ServerRequestAdapterTest.php
@@ -131,7 +131,7 @@ final class ServerRequestAdapterTest extends TestCase
         self::assertSame(
             [],
             $request->getBodyParams(),
-            "Body parameters should fallback to an empty array when parser returns a scalar value.",
+            'Body parameters should fallback to an empty array when parser returns a scalar value.',
         );
     }
 

--- a/tests/http/RequestTest.php
+++ b/tests/http/RequestTest.php
@@ -882,6 +882,55 @@ final class RequestTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     *
+     * @phpstan-param array<array-key, mixed>|null $expected
+     */
+    #[TestWith(['{"foo":"bar"}', ['foo' => 'bar']])]
+    #[TestWith(['false', null])]
+    public function testGetParsedBodyNormalizesNativeBodyWithoutAdapter(string $rawBody, array|null $expected): void
+    {
+        $_SERVER['CONTENT_TYPE'] = 'application/json';
+
+        $request = new Request();
+
+        $request->parsers = ['application/json' => JsonParser::class];
+
+        $request->setRawBody($rawBody);
+
+        self::assertSame(
+            $expected,
+            $request->getParsedBody(),
+            'Scalar yields `null`; structured body passes through.',
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testGetParsedBodyReturnsObjectForNativeObjectBodyWithoutAdapter(): void
+    {
+        $_SERVER['CONTENT_TYPE'] = 'application/json';
+
+        $request = new Request();
+
+        $request->parsers = [
+            'application/json' => [
+                'class' => JsonParser::class,
+                'asArray' => false,
+            ],
+        ];
+
+        $request->setRawBody('{"foo":"bar"}');
+
+        self::assertInstanceOf(
+            stdClass::class,
+            $request->getParsedBody(),
+            'Object body must pass through.',
+        );
+    }
+
     public function testGetQueryStringWhenEmpty(): void
     {
         $_SERVER['QUERY_STRING'] = '';

--- a/tests/provider/RequestProvider.php
+++ b/tests/provider/RequestProvider.php
@@ -97,6 +97,11 @@ final class RequestProvider
                     'baz' => 1,
                 ],
             ],
+            'json scalar' => [
+                'application/json',
+                'false',
+                [],
+            ],
         ];
     }
 

--- a/tests/support/HelperFactory.php
+++ b/tests/support/HelperFactory.php
@@ -105,17 +105,15 @@ final class HelperFactory
         string $protocol = '1.1',
         string $reasonPhrase = '',
     ): ResponseInterface {
-        $response = new Response($statusCode, $headers, $body, $protocol, $reasonPhrase);
-
-        if ($body instanceof StreamInterface) {
-            return $response->withBody($body);
-        }
-
         if (is_string($body)) {
+            $response = new Response($statusCode, $headers, null, $protocol, $reasonPhrase);
+
             $response->getBody()->write($body);
+
+            return $response;
         }
 
-        return $response;
+        return new Response($statusCode, $headers, $body, $protocol, $reasonPhrase);
     }
 
     /**


### PR DESCRIPTION
### Motivation
- A recent change parsed PSR-7 request bodies and wrote parser output back into the PSR-7 request without validating types, allowing scalar parser returns (e.g. JSON `false`, number, or string) to be passed to `withParsedBody()` and cause `InvalidArgumentException` or later `TypeError` during request handling.
- The intent of this PR is to enforce the PSR-7 parsed body contract by only writing parser output when it is `null`, `array`, or `object` to avoid request-level failures while preserving existing behavior for valid parser outputs.

### Description
- Guard `ServerRequestAdapter::parseBody()` so the adapter only calls `$request->withParsedBody($parsedParams)` when `$parsedParams` is `null`, an `array`, or an `object`, otherwise returning the original request; added `is_object` import (changed file: `src/adapter/ServerRequestAdapter.php`).
- Add a regression test `testScalarParsedBodyFromParserIsIgnored()` exercising a JSON scalar payload (`false`) with `Content-Type: application/json; charset=UTF-8` and asserting the PSR-7 parsed body remains `null` and `getBodyParams()` falls back to an empty array (changed file: `tests/adapter/ServerRequestAdapterTest.php`).

### Testing
- Attempted to run `vendor/bin/phpunit tests/adapter/ServerRequestAdapterTest.php`, but `vendor/bin/phpunit` is not present in this environment so automated tests could not be executed here.
- The fix is covered by the added unit test and should be verified by the repository CI or locally after running `composer install` and executing the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a160fcd8b74832a9b7c62800478c639)