### PR TITLE
fix(docs): harden file upload and `YII_DEBUG` examples against path traversal and incorrect boolean parsing of string environment values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(security): always reset uploaded-file state during request preparation to preserve worker request isolation, even when `resetUploadedFiles` is set to `false`.
 - fix(security): open the session before `bootstrap()` so worker bootstrap components observe the current request session, and finalize the session via `try`/`finally` to prevent lock leaks when bootstrap throws.
 - fix(security): ignore scalar request-parser results so scalar JSON bodies no longer break PSR-7 request handling.
+- fix(docs): harden file upload and `YII_DEBUG` examples against path traversal and incorrect boolean parsing of string environment values.
 
 ## 0.3.0 February 28, 2026
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -116,7 +116,8 @@ final class FileController extends \yii\web\Controller
         $file = UploadedFile::getInstanceByName('avatar');
 
         if ($file !== null && $file->error === UPLOAD_ERR_OK) {
-            $file->saveAs('@webroot/uploads/' . $file->name);
+            $safeName = sprintf('%s_%s', Yii::$app->security->generateRandomString(8), basename((string) $file->name));
+            $file->saveAs('@webroot/uploads/' . $safeName);
         }
 
         return $this->asJson(['status' => 'uploaded']);
@@ -146,7 +147,7 @@ $dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__));
 $dotenv->safeLoad();
 
 // production default (change to 'true' for development)
-define('YII_DEBUG', $_ENV['YII_DEBUG'] ?? false);
+define('YII_DEBUG', filter_var($_ENV['YII_DEBUG'] ?? false, FILTER_VALIDATE_BOOLEAN));
 // production default (change to 'dev' for development)
 define('YII_ENV', $_ENV['YII_ENV'] ?? 'prod');
 
@@ -171,7 +172,7 @@ require __DIR__ . '/../vendor/autoload.php';
 use yii2\extensions\psrbridge\http\Application;
 use yii2\extensions\roadrunner\RoadRunner;
 
-define('YII_DEBUG', getenv('YII_DEBUG') ?? false);
+define('YII_DEBUG', filter_var(getenv('YII_DEBUG') ?: false, FILTER_VALIDATE_BOOLEAN));
 define('YII_ENV', getenv('YII_ENV') ?? 'prod');
 
 require __DIR__ . '/../vendor/yiisoft/yii2/Yii.php';

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -147,7 +147,7 @@ $dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__));
 $dotenv->safeLoad();
 
 // production default (change to 'true' for development)
-define('YII_DEBUG', filter_var($_ENV['YII_DEBUG'] ?? false, FILTER_VALIDATE_BOOLEAN));
+define('YII_DEBUG', ($_ENV['YII_DEBUG'] ?? 'false') === 'true');
 // production default (change to 'dev' for development)
 define('YII_ENV', $_ENV['YII_ENV'] ?? 'prod');
 
@@ -172,7 +172,7 @@ require __DIR__ . '/../vendor/autoload.php';
 use yii2\extensions\psrbridge\http\Application;
 use yii2\extensions\roadrunner\RoadRunner;
 
-define('YII_DEBUG', filter_var(getenv('YII_DEBUG') ?: false, FILTER_VALIDATE_BOOLEAN));
+define('YII_DEBUG', getenv('YII_DEBUG') === 'true');
 define('YII_ENV', getenv('YII_ENV') ?? 'prod');
 
 require __DIR__ . '/../vendor/yiisoft/yii2/Yii.php';

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -147,7 +147,7 @@ $dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__));
 $dotenv->safeLoad();
 
 // production default (change to 'true' for development)
-define('YII_DEBUG', ($_ENV['YII_DEBUG'] ?? 'false') === 'true');
+define('YII_DEBUG', filter_var($_ENV['YII_DEBUG'] ?? false, FILTER_VALIDATE_BOOLEAN));
 // production default (change to 'dev' for development)
 define('YII_ENV', $_ENV['YII_ENV'] ?? 'prod');
 
@@ -172,7 +172,7 @@ require __DIR__ . '/../vendor/autoload.php';
 use yii2\extensions\psrbridge\http\Application;
 use yii2\extensions\roadrunner\RoadRunner;
 
-define('YII_DEBUG', getenv('YII_DEBUG') === 'true');
+define('YII_DEBUG', filter_var(getenv('YII_DEBUG'), FILTER_VALIDATE_BOOLEAN));
 define('YII_ENV', getenv('YII_ENV') ?? 'prod');
 
 require __DIR__ . '/../vendor/yiisoft/yii2/Yii.php';


### PR DESCRIPTION
### Motivation

- The docs included examples that, if copied, could lead to path traversal or overwriting files by using the client-supplied upload filename directly and could accidentally enable debug mode when `YII_DEBUG` is set to common string values.

### Description

- Replace direct use of client-controlled `$file->name` in the upload example with a server-side randomized prefix and `basename()` of the client segment, e.g. `sprintf('%s_%s', Yii::$app->security->generateRandomString(8), basename((string) $file->name))`, before calling `saveAs()`.
- Parse `YII_DEBUG` with `filter_var(..., FILTER_VALIDATE_BOOLEAN)` in both the FrankenPHP and RoadRunner examples so strings like `"false"` are treated as boolean `false`.
- This is a documentation-only change in `docs/examples.md` and preserves the intent and usability of the examples while removing the documented unsafe patterns.

### Testing

- Verified the changes by inspecting the file diff with `git diff -- docs/examples.md` and by printing the modified section with `nl -ba docs/examples.md | sed -n '108,185p'`, both showing the intended replacements succeeded.
- No unit tests were modified or required because this is a docs-only remediation; no automated test-suite runs were executed against runtime code as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16f0d5bfd8832ab10091c5ea5e2768)