### PR TITLE
fix(docs): keep CSRF and cookie validation enabled in the basic configuration example to avoid insecure copypaste deployments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(security): open the session before `bootstrap()` so worker bootstrap components observe the current request session, and finalize the session via `try`/`finally` to prevent lock leaks when bootstrap throws.
 - fix(security): ignore scalar request-parser results so scalar JSON bodies no longer break PSR-7 request handling.
 - fix(docs): harden file upload and `YII_DEBUG` examples against path traversal and incorrect boolean parsing of string environment values.
+- fix(docs): keep CSRF and cookie validation enabled in the basic configuration example to avoid insecure copy-paste deployments.
 
 ## 0.3.0 February 28, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(security): open the session before `bootstrap()` so worker bootstrap components observe the current request session, and finalize the session via `try`/`finally` to prevent lock leaks when bootstrap throws.
 - fix(security): ignore scalar request-parser results so scalar JSON bodies no longer break PSR-7 request handling.
 - fix(docs): harden file upload and `YII_DEBUG` examples against path traversal and incorrect boolean parsing of string environment values.
-- fix(docs): keep CSRF and cookie validation enabled in the basic configuration example to avoid insecure copy-paste deployments.
+- fix(docs): keep CSRF and cookie validation enabled in the basic configuration example to avoid insecure copypaste deployments.
 
 ## 0.3.0 February 28, 2026
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,8 +28,10 @@ return [
     'components' => [
         'request' => [
             'class' => Request::class,
-            'enableCookieValidation' => false,
-            'enableCsrfValidation' => false,
+            // Keep validation enabled in production.
+            'enableCookieValidation' => true,
+            'enableCsrfValidation' => true,
+            'cookieValidationKey' => getenv('COOKIE_VALIDATION_KEY'),
             'parsers' => [
                 'application/json' => JsonParser::class,
             ],

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,18 +46,18 @@ return [
 ```
 
 > [!WARNING]
-> Keep `enableCookieValidation` and `enableCsrfValidation` enabled. They are Yii's secure defaults: CSRF validation 
-> protects browser users from cross-site state-changing requests, and cookie validation guarantees the integrity of 
-> incoming and outgoing cookies (the bridge propagates the request setting to `Response` so cookies are signed by 
+> Keep `enableCookieValidation` and `enableCsrfValidation` enabled. They are Yii's secure defaults: CSRF validation
+> protects browser users from cross-site state-changing requests, and cookie validation guarantees the integrity of
+> incoming and outgoing cookies (the bridge propagates the request setting to `Response` so cookies are signed by
 > `ResponseAdapter`).
 >
-> Provide your own `cookieValidationKey` (a long, random secret). It is **required** whenever `enableCookieValidation` 
-> is `true`: when it is missing, the bridge throws `InvalidConfigException` instead of accepting unsigned cookies, so a 
+> Provide your own `cookieValidationKey` (a long, random secret). It is **required** whenever `enableCookieValidation`
+> is `true`: when it is missing, the bridge throws `InvalidConfigException` instead of accepting unsigned cookies, so a
 > misconfiguration fails fast rather than degrading security silently. Keep the key out of version control and protect
-> it like any other credential. Because Yii stores the CSRF token in a signed cookie (`enableCsrfCookie`), cookie 
+> it like any other credential. Because Yii stores the CSRF token in a signed cookie (`enableCsrfCookie`), cookie
 > validation must stay enabled alongside CSRF.
 >
-> Disable CSRF only for a purely stateless, token-authenticated API that never relies on browser cookies or sessions, 
+> Disable CSRF only for a purely stateless, token-authenticated API that never relies on browser cookies or sessions,
 > and do so as a deliberate, documented decision, never by default.
 
 ### Request body parsing

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,7 +31,6 @@ return [
             // Keep validation enabled in production.
             'enableCookieValidation' => true,
             'enableCsrfValidation' => true,
-            'cookieValidationKey' => getenv('COOKIE_VALIDATION_KEY'),
             'parsers' => [
                 'application/json' => JsonParser::class,
             ],
@@ -45,6 +44,21 @@ return [
     ],
 ];
 ```
+
+> [!WARNING]
+> Keep `enableCookieValidation` and `enableCsrfValidation` enabled. They are Yii's secure defaults: CSRF validation 
+> protects browser users from cross-site state-changing requests, and cookie validation guarantees the integrity of 
+> incoming and outgoing cookies (the bridge propagates the request setting to `Response` so cookies are signed by 
+> `ResponseAdapter`).
+>
+> Provide your own `cookieValidationKey` (a long, random secret). It is **required** whenever `enableCookieValidation` 
+> is `true`: when it is missing, the bridge throws `InvalidConfigException` instead of accepting unsigned cookies, so a 
+> misconfiguration fails fast rather than degrading security silently. Keep the key out of version control and protect
+> it like any other credential. Because Yii stores the CSRF token in a signed cookie (`enableCsrfCookie`), cookie 
+> validation must stay enabled alongside CSRF.
+>
+> Disable CSRF only for a purely stateless, token-authenticated API that never relies on browser cookies or sessions, 
+> and do so as a deliberate, documented decision, never by default.
 
 ### Request body parsing
 

--- a/tests/http/stateless/ApplicationCsrfTest.php
+++ b/tests/http/stateless/ApplicationCsrfTest.php
@@ -1,0 +1,277 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\psrbridge\tests\http\stateless;
+
+use PHPUnit\Framework\Attributes\Group;
+use yii\base\{InvalidConfigException, Security};
+use yii\helpers\Json;
+use yii2\extensions\psrbridge\tests\support\{ApplicationFactory, HelperFactory, TestCase};
+
+use function array_filter;
+use function array_values;
+use function str_starts_with;
+use function strlen;
+use function strpos;
+use function substr;
+use function urldecode;
+
+/**
+ * Unit tests for {@see \yii2\extensions\psrbridge\http\Application} CSRF validation in stateless mode.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('http')]
+final class ApplicationCsrfTest extends TestCase
+{
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testIsolateCsrfTokenStateBetweenRequestsOnSameApplicationInstance(): void
+    {
+        $security = new Security();
+
+        $rawTokenA = $security->generateRandomString();
+        $maskedTokenA = $security->maskToken($rawTokenA);
+
+        $cookiesA = $this->signCookies(['_csrf' => $rawTokenA]);
+
+        $rawTokenB = $security->generateRandomString();
+        $maskedTokenB = $security->maskToken($rawTokenB);
+
+        $cookiesB = $this->signCookies(['_csrf' => $rawTokenB]);
+
+        $app = ApplicationFactory::stateless($this->csrfConfig());
+
+        $responseA = $app->handle(
+            HelperFactory::createRequest(
+                'POST',
+                '/site/post',
+                ['Content-Type' => 'application/x-www-form-urlencoded'],
+                ['action' => 'a', '_csrf' => $maskedTokenA],
+            )->withCookieParams($cookiesA),
+        );
+        $responseB = $app->handle(
+            HelperFactory::createRequest(
+                'POST',
+                '/site/post',
+                ['Content-Type' => 'application/x-www-form-urlencoded'],
+                ['action' => 'b', '_csrf' => $maskedTokenB],
+            )->withCookieParams($cookiesB),
+        );
+        $responseMismatched = $app->handle(
+            HelperFactory::createRequest(
+                'POST',
+                '/site/post',
+                ['Content-Type' => 'application/x-www-form-urlencoded'],
+                ['action' => 'c', '_csrf' => $maskedTokenA],
+            )->withCookieParams($cookiesB),
+        );
+
+        self::assertSame(
+            200,
+            $responseA->getStatusCode(),
+            'First request must pass with its own CSRF token.',
+        );
+        self::assertSame(
+            200,
+            $responseB->getStatusCode(),
+            'Second request must pass with its own CSRF token.',
+        );
+        self::assertSame(
+            400,
+            $responseMismatched->getStatusCode(),
+            'Token paired with a different cookie must be rejected.',
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnBadRequestResponseForPostWithMissingCsrfToken(): void
+    {
+        $rawToken = (new Security())->generateRandomString();
+
+        $cookies = $this->signCookies(['_csrf' => $rawToken]);
+
+        $app = ApplicationFactory::stateless($this->csrfConfig());
+
+        $response = $app->handle(
+            HelperFactory::createRequest(
+                'POST',
+                '/site/post',
+                ['Content-Type' => 'application/x-www-form-urlencoded'],
+                ['action' => 'upload'],
+            )->withCookieParams($cookies),
+        );
+
+        self::assertSame(
+            400,
+            $response->getStatusCode(),
+            "Expected HTTP '400' for route 'site/post'.",
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnBadRequestResponseForPostWithTamperedCsrfToken(): void
+    {
+        $security = new Security();
+
+        $rawToken = $security->generateRandomString();
+
+        $cookies = $this->signCookies(['_csrf' => $rawToken]);
+
+        $tamperedToken = $security->maskToken($security->generateRandomString());
+
+        $app = ApplicationFactory::stateless($this->csrfConfig());
+
+        $response = $app->handle(
+            HelperFactory::createRequest(
+                'POST',
+                '/site/post',
+                ['Content-Type' => 'application/x-www-form-urlencoded'],
+                ['action' => 'upload', '_csrf' => $tamperedToken],
+            )->withCookieParams($cookies),
+        );
+
+        self::assertSame(
+            400,
+            $response->getStatusCode(),
+            "Expected HTTP '400' for route 'site/post'.",
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnSignedCsrfCookieInResponseSetCookieHeader(): void
+    {
+        $app = ApplicationFactory::stateless($this->csrfConfig());
+
+        $response = $app->handle(HelperFactory::createRequest('GET', '/site/csrf'));
+
+        $csrfCookies = array_filter(
+            $response->getHeader('Set-Cookie'),
+            static fn(string $header): bool => str_starts_with($header, '_csrf='),
+        );
+
+        self::assertCount(
+            1,
+            $csrfCookies,
+            'Response must emit exactly one CSRF Set-Cookie header.',
+        );
+
+        $header = array_values($csrfCookies)[0] ?? '';
+        $rawValue = substr($header, strlen('_csrf='));
+        $semicolon = strpos($rawValue, ';');
+        $signedValue = urldecode($semicolon === false ? $rawValue : substr($rawValue, 0, $semicolon));
+
+        self::assertIsString(
+            (new Security())->validateData($signedValue, self::COOKIE_VALIDATION_KEY),
+            'CSRF cookie value must be signed with the validation key.',
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnSuccessResponseForPostWithValidCsrfTokenInBody(): void
+    {
+        $security = new Security();
+
+        $rawToken = $security->generateRandomString();
+        $maskedToken = $security->maskToken($rawToken);
+
+        $cookies = $this->signCookies(['_csrf' => $rawToken]);
+
+        $app = ApplicationFactory::stateless($this->csrfConfig());
+
+        $response = $app->handle(
+            HelperFactory::createRequest(
+                'POST',
+                '/site/post',
+                ['Content-Type' => 'application/x-www-form-urlencoded'],
+                ['action' => 'upload', '_csrf' => $maskedToken],
+            )->withCookieParams($cookies),
+        );
+
+        self::assertSame(
+            200,
+            $response->getStatusCode(),
+            "Expected HTTP '200' for route 'site/post'.",
+        );
+        self::assertSame(
+            'application/json; charset=UTF-8',
+            $response->getHeaderLine('Content-Type'),
+            "Expected Content-Type 'application/json; charset=UTF-8' for route 'site/post'.",
+        );
+        self::assertJsonStringEqualsJsonString(
+            Json::encode(['action' => 'upload', '_csrf' => $maskedToken]),
+            $response->getBody()->getContents(),
+            'Body must echo posted parameters when the CSRF token is valid.',
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnSuccessResponseForPostWithValidCsrfTokenInHeader(): void
+    {
+        $security = new Security();
+
+        $rawToken = $security->generateRandomString();
+        $maskedToken = $security->maskToken($rawToken);
+
+        $cookies = $this->signCookies(['_csrf' => $rawToken]);
+
+        $app = ApplicationFactory::stateless($this->csrfConfig());
+
+        $response = $app->handle(
+            HelperFactory::createRequest(
+                'POST',
+                '/site/post',
+                [
+                    'Content-Type' => 'application/x-www-form-urlencoded',
+                    'X-CSRF-Token' => $maskedToken,
+                ],
+                ['action' => 'upload'],
+            )->withCookieParams($cookies),
+        );
+
+        self::assertSame(
+            200,
+            $response->getStatusCode(),
+            "Expected HTTP '200' for route 'site/post'.",
+        );
+        self::assertJsonStringEqualsJsonString(
+            Json::encode(['action' => 'upload']),
+            $response->getBody()->getContents(),
+            'Body must echo posted parameters when the token is sent via header.',
+        );
+    }
+
+    /**
+     * Stateless application configuration overrides enabling CSRF and cookie validation.
+     *
+     * @return array Configuration overrides for {@see ApplicationFactory::stateless()}.
+     *
+     * @phpstan-return array<string, mixed>
+     */
+    private function csrfConfig(): array
+    {
+        return [
+            'components' => [
+                'request' => [
+                    'cookieValidationKey' => self::COOKIE_VALIDATION_KEY,
+                    'enableCookieValidation' => true,
+                    'enableCsrfCookie' => true,
+                    'enableCsrfValidation' => true,
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/support/stub/SiteController.php
+++ b/tests/support/stub/SiteController.php
@@ -85,6 +85,16 @@ final class SiteController extends Controller
         ];
     }
 
+    /**
+     * @phpstan-return array{csrf: string|null}
+     */
+    public function actionCsrf(): array
+    {
+        $this->response->format = Response::FORMAT_JSON;
+
+        return ['csrf' => $this->request->getCsrfToken()];
+    }
+
     public function actionDeletecookie(): Response
     {
         MockerFunctions::setMockedTime(self::MOCK_TIME);


### PR DESCRIPTION
### Motivation
- The basic configuration example in `docs/configuration.md` previously disabled `enableCookieValidation` and `enableCsrfValidation`, which can cause production deployments to lose cookie integrity and CSRF protection when copied verbatim.

### Description
- Update the Basic configuration snippet in `docs/configuration.md` to keep `enableCookieValidation` and `enableCsrfValidation` enabled and add a `cookieValidationKey` (using `getenv('COOKIE_VALIDATION_KEY')`) so example configurations preserve signed cookies and safe defaults.

### Testing
- Verified the updated file contents with `sed -n '1,220p' docs/configuration.md` and inspected the snippet with `nl -ba docs/configuration.md | sed -n '18,55p'`, and both commands showed the new secure example as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a170f61a114832a9ed334981a42dad8)