### PR TITLE
fix(docs): align `README.md` RoadRunner `YII_DEBUG` example with `docs/examples.md`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(security): ignore scalar request-parser results so scalar JSON bodies no longer break PSR-7 request handling.
 - fix(docs): harden file upload and `YII_DEBUG` examples against path traversal and incorrect boolean parsing of string environment values.
 - fix(docs): keep CSRF and cookie validation enabled in the basic configuration example to avoid insecure copypaste deployments.
-- fix(docs): align README RoadRunner `YII_DEBUG` example with `docs/examples.md`.
+- fix(docs): align `README.md` RoadRunner `YII_DEBUG` example with `docs/examples.md`.
 
 ## 0.3.0 February 28, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(security): ignore scalar request-parser results so scalar JSON bodies no longer break PSR-7 request handling.
 - fix(docs): harden file upload and `YII_DEBUG` examples against path traversal and incorrect boolean parsing of string environment values.
 - fix(docs): keep CSRF and cookie validation enabled in the basic configuration example to avoid insecure copypaste deployments.
+- fix(docs): align README RoadRunner `YII_DEBUG` example with `docs/examples.md`.
 
 ## 0.3.0 February 28, 2026
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__));
 $dotenv->safeLoad();
 
 // production default (change to 'true' for development)
-define('YII_DEBUG', $_ENV['YII_DEBUG'] ?? false);
+define('YII_DEBUG', filter_var($_ENV['YII_DEBUG'] ?? false, FILTER_VALIDATE_BOOLEAN));
 // production default (change to 'dev' for development)
 define('YII_ENV', $_ENV['YII_ENV'] ?? 'prod');
 
@@ -97,7 +97,7 @@ require __DIR__ . '/../vendor/autoload.php';
 use yii2\extensions\psrbridge\http\Application;
 use yii2\extensions\roadrunner\RoadRunner;
 
-define('YII_DEBUG', getenv('YII_DEBUG') ?? false);
+define('YII_DEBUG', filter_var(getenv('YII_DEBUG') ?? false, FILTER_VALIDATE_BOOLEAN));
 define('YII_ENV', getenv('YII_ENV') ?? 'prod');
 
 require __DIR__ . '/../vendor/yiisoft/yii2/Yii.php';

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ require __DIR__ . '/../vendor/autoload.php';
 use yii2\extensions\psrbridge\http\Application;
 use yii2\extensions\roadrunner\RoadRunner;
 
-define('YII_DEBUG', filter_var(getenv('YII_DEBUG') ?? false, FILTER_VALIDATE_BOOLEAN));
+define('YII_DEBUG', filter_var(getenv('YII_DEBUG'), FILTER_VALIDATE_BOOLEAN));
 define('YII_ENV', getenv('YII_ENV') ?? 'prod');
 
 require __DIR__ . '/../vendor/yiisoft/yii2/Yii.php';


### PR DESCRIPTION
### Motivation
- The quick-start worker examples defined `YII_DEBUG` directly from environment strings, and a common value like `YII_DEBUG=false` would be the non-empty string "false" which is truthy in PHP, unintentionally enabling debug output in production and risking information disclosure. 

### Description
- Update the FrankenPHP quick-start example to define `YII_DEBUG` using `filter_var($_ENV['YII_DEBUG'] ?? false, FILTER_VALIDATE_BOOLEAN)` in `README.md` to ensure proper boolean parsing. 
- Update the RoadRunner quick-start example to define `YII_DEBUG` using `filter_var(getenv('YII_DEBUG') ?? false, FILTER_VALIDATE_BOOLEAN)` in `README.md` to ensure proper boolean parsing. 

### Testing
- Ran `git diff -- README.md` to verify the two replacements were applied, which showed the expected diffs. 
- Ran `php -l README.md` as a quick lint check which is not applicable to a Markdown file and therefore returned a non-zero result (no PHP syntax validation was required). 
- Committed the change and created the PR containing the documentation fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a172b5b7d70832a87cc396021fc0355)