### PR TITLE
Fix Request::getContentType() fallback null TypeError

### DIFF
--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -160,7 +160,7 @@ class Request extends \yii\web\Request
             return $this->getHeaders()->get('Content-Type') ?? '';
         }
 
-        return parent::getContentType();
+        return parent::getContentType() ?? '';
     }
 
     /**

--- a/tests/http/RequestTest.php
+++ b/tests/http/RequestTest.php
@@ -398,6 +398,20 @@ final class RequestTest extends TestCase
         $this->closeApplication();
     }
 
+
+    public function testGetContentTypeReturnsEmptyStringWithoutHeaderInFallbackMode(): void
+    {
+        unset($_SERVER['CONTENT_TYPE'], $_SERVER['HTTP_CONTENT_TYPE']);
+
+        $request = new Request();
+
+        self::assertSame(
+            '',
+            $request->getContentType(),
+            "'getContentType()' should return an empty string when no Content-Type header exists in fallback mode.",
+        );
+    }
+
     public function testCustomUnsafeMethodsCsrfHeaderValidation(): void
     {
         ApplicationFactory::web();

--- a/tests/http/RequestTest.php
+++ b/tests/http/RequestTest.php
@@ -398,7 +398,6 @@ final class RequestTest extends TestCase
         $this->closeApplication();
     }
 
-
     public function testGetContentTypeReturnsEmptyStringWithoutHeaderInFallbackMode(): void
     {
         unset($_SERVER['CONTENT_TYPE'], $_SERVER['HTTP_CONTENT_TYPE']);


### PR DESCRIPTION
### Motivation
- Prevent a PHP `TypeError` and request-level 500 when `Request::getContentType()` declares `: string` but `parent::getContentType()` can return `null` in fallback (non-PSR-7) mode.

### Description
- Coalesce the fallback return in `src/http/Request.php` so it always returns a string: `return parent::getContentType() ?? '';`.
- Add a regression unit test `tests/http/RequestTest.php::testGetContentTypeReturnsEmptyStringWithoutHeaderInFallbackMode()` which asserts `getContentType()` returns `''` when `CONTENT_TYPE`/`HTTP_CONTENT_TYPE` are absent.

### Testing
- Added the focused PHPUnit test `tests/http/RequestTest.php::testGetContentTypeReturnsEmptyStringWithoutHeaderInFallbackMode()` but running `vendor/bin/phpunit` was not possible in this environment because project dependencies/tooling are not installed, so the automated test could not be executed here (attempt to run `vendor/bin/phpunit tests/http/RequestTest.php --filter testGetContentTypeReturnsEmptyStringWithoutHeaderInFallbackMode` failed with missing binary).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17342558fc832ab8445fad7b5727ee)