### PR TITLE
fix(security): clear cached query params when replacing the PSR-7 request to prevent cross-request leakage in reused `Request` instances.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(docs): harden file upload and `YII_DEBUG` examples against path traversal and incorrect boolean parsing of string environment values.
 - fix(docs): keep CSRF and cookie validation enabled in the basic configuration example to avoid insecure copypaste deployments.
 - fix(docs): align `README.md` RoadRunner `YII_DEBUG` example with `docs/examples.md`.
+- fix(security): clear cached query params when replacing the PSR-7 request to prevent cross-request leakage in reused `Request` instances.
 
 ## 0.3.0 February 28, 2026
 

--- a/src/adapter/ServerRequestAdapter.php
+++ b/src/adapter/ServerRequestAdapter.php
@@ -57,7 +57,7 @@ final class ServerRequestAdapter
      *
      * @throws InvalidConfigException if a configured parser does not implement RequestParserInterface.
      *
-     * @phpstan-param array<string, class-string|array{class: class-string, ...}|callable(): object> $parsers
+     * @phpstan-param array<string, class-string<object>|array{class?: class-string<object>, __class?: class-string<object>, ...}|callable(): object> $parsers
      */
     public function __construct(ServerRequestInterface $psrRequest, array $parsers = [])
     {
@@ -481,7 +481,7 @@ final class ServerRequestAdapter
      *
      * @return ServerRequestInterface Request with parsed body set if parsing was performed, or unchanged.
      *
-     * @phpstan-param array<string, class-string|array{class: class-string, ...}|callable(): object> $parsers
+     * @phpstan-param array<string, class-string<object>|array{class?: class-string<object>, __class?: class-string<object>, ...}|callable(): object> $parsers
      */
     private function parseBody(ServerRequestInterface $request, array $parsers): ServerRequestInterface
     {

--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -37,7 +37,7 @@ use function strncasecmp;
  * $params = $request->getBodyParams();
  * ```
  *
- * @phpstan-property array<string, class-string|array{class: class-string, ...}|callable(): object> $parsers
+ * @phpstan-property array<string, class-string<object>|array{class?: class-string<object>, __class?: class-string<object>, ...}|callable(): object> $parsers
  *
  * @copyright Copyright (C) 2025 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.

--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -651,6 +651,8 @@ class Request extends \yii\web\Request
      */
     public function setPsr7Request(ServerRequestInterface $request): void
     {
+        $this->setQueryParams([]);
+
         $this->adapter = new ServerRequestAdapter(
             $request,
             $this->parsers,

--- a/tests/http/RequestTest.php
+++ b/tests/http/RequestTest.php
@@ -1943,7 +1943,9 @@ final class RequestTest extends TestCase
         );
 
         $request = new Request();
+
         $request->setPsr7Request(HelperFactory::createRequest('GET', '/posts?token=first'));
+
         $request->resolve();
 
         $request->setPsr7Request(HelperFactory::createRequest('GET', '/posts?token=second'));
@@ -1951,7 +1953,7 @@ final class RequestTest extends TestCase
         self::assertSame(
             ['token' => 'second'],
             $request->getQueryParams(),
-            "'setPsr7Request()' should clear stale cached query parameters before attaching a new PSR-7 request.",
+            "Should clear stale cached query parameters before attaching a new PSR-7 request.",
         );
     }
 

--- a/tests/http/RequestTest.php
+++ b/tests/http/RequestTest.php
@@ -1808,36 +1808,6 @@ final class RequestTest extends TestCase
         }
     }
 
-    public function testSetPsr7RequestClearsCachedQueryParamsFromPreviousRequest(): void
-    {
-        ApplicationFactory::web(
-            [
-                'components' => [
-                    'urlManager' => [
-                        'cache' => null,
-                        'enablePrettyUrl' => true,
-                        'showScriptName' => false,
-                        'rules' => [
-                            'posts' => 'post/list',
-                        ],
-                    ],
-                ],
-            ],
-        );
-
-        $request = new Request();
-        $request->setPsr7Request(HelperFactory::createRequest('GET', '/posts?token=first'));
-        $request->resolve();
-
-        $request->setPsr7Request(HelperFactory::createRequest('GET', '/posts?token=second'));
-
-        self::assertSame(
-            ['token' => 'second'],
-            $request->getQueryParams(),
-            "'setPsr7Request()' should clear stale cached query parameters before attaching a new PSR-7 request.",
-        );
-    }
-
     public function testReturnNullFromParentWhenRemoteHostNotSetInServerGlobals(): void
     {
         unset($_SERVER['REMOTE_HOST']);
@@ -1952,6 +1922,36 @@ final class RequestTest extends TestCase
             'servername.com',
             $request->getHostName(),
             "'getHostName()' should return the host name extracted from the value set by 'setHostInfo()'.",
+        );
+    }
+
+    public function testSetPsr7RequestClearsCachedQueryParamsFromPreviousRequest(): void
+    {
+        ApplicationFactory::web(
+            [
+                'components' => [
+                    'urlManager' => [
+                        'cache' => null,
+                        'enablePrettyUrl' => true,
+                        'showScriptName' => false,
+                        'rules' => [
+                            'posts' => 'post/list',
+                        ],
+                    ],
+                ],
+            ],
+        );
+
+        $request = new Request();
+        $request->setPsr7Request(HelperFactory::createRequest('GET', '/posts?token=first'));
+        $request->resolve();
+
+        $request->setPsr7Request(HelperFactory::createRequest('GET', '/posts?token=second'));
+
+        self::assertSame(
+            ['token' => 'second'],
+            $request->getQueryParams(),
+            "'setPsr7Request()' should clear stale cached query parameters before attaching a new PSR-7 request.",
         );
     }
 

--- a/tests/http/RequestTest.php
+++ b/tests/http/RequestTest.php
@@ -1953,7 +1953,7 @@ final class RequestTest extends TestCase
         self::assertSame(
             ['token' => 'second'],
             $request->getQueryParams(),
-            "Should clear stale cached query parameters before attaching a new PSR-7 request.",
+            'Should clear stale cached query parameters before attaching a new PSR-7 request.',
         );
     }
 

--- a/tests/http/RequestTest.php
+++ b/tests/http/RequestTest.php
@@ -1808,6 +1808,36 @@ final class RequestTest extends TestCase
         }
     }
 
+    public function testSetPsr7RequestClearsCachedQueryParamsFromPreviousRequest(): void
+    {
+        ApplicationFactory::web(
+            [
+                'components' => [
+                    'urlManager' => [
+                        'cache' => null,
+                        'enablePrettyUrl' => true,
+                        'showScriptName' => false,
+                        'rules' => [
+                            'posts' => 'post/list',
+                        ],
+                    ],
+                ],
+            ],
+        );
+
+        $request = new Request();
+        $request->setPsr7Request(HelperFactory::createRequest('GET', '/posts?token=first'));
+        $request->resolve();
+
+        $request->setPsr7Request(HelperFactory::createRequest('GET', '/posts?token=second'));
+
+        self::assertSame(
+            ['token' => 'second'],
+            $request->getQueryParams(),
+            "'setPsr7Request()' should clear stale cached query parameters before attaching a new PSR-7 request.",
+        );
+    }
+
     public function testReturnNullFromParentWhenRemoteHostNotSetInServerGlobals(): void
     {
         unset($_SERVER['REMOTE_HOST']);

--- a/tests/support/stub/SiteController.php
+++ b/tests/support/stub/SiteController.php
@@ -70,7 +70,7 @@ final class SiteController extends Controller
     }
 
     /**
-     * @phpstan-return  array{isGuest: bool, Identity?: string|null}
+     * @phpstan-return  array{isGuest: bool, identity: string|null}
      */
     public function actionCheckauth(): array
     {


### PR DESCRIPTION
### Motivation
- Prevent cross-request leakage of sensitive query/route parameters when the same `Request` instance is reused, because merged params were being stored on the Yii `Request` parent and not cleared when a new PSR-7 request is attached.

### Description
- Call `setQueryParams([])` at the start of `Request::setPsr7Request()` to clear the Yii-level cached query parameters before installing the new `ServerRequestAdapter`, and add a regression test `testSetPsr7RequestClearsCachedQueryParamsFromPreviousRequest` that verifies a second PSR-7 request does not receive stale params from the previous request.

### Testing
- Ran `php -l src/http/Request.php` and `php -l tests/http/RequestTest.php`, both reported no syntax errors, and added the PHPUnit regression test `tests/http/RequestTest.php::testSetPsr7RequestClearsCachedQueryParamsFromPreviousRequest`; running `vendor/bin/phpunit` could not be completed in this environment because dependencies are not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1737e09534832a808f1524c58747cb)