### PR TITLE
fix(security): hide exception details in `FORMAT_RAW` error responses when `YII_DEBUG` is disabled to prevent stack trace and file path disclosure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(docs): align `README.md` RoadRunner `YII_DEBUG` example with `docs/examples.md`.
 - fix(security): clear cached query params when replacing the PSR-7 request to prevent cross-request leakage in reused `Request` instances.
 - refactor: consolidate package metadata in `composer.json` (`authors`) and `LICENSE`; drop redundant per-file `@copyright`/`@license` headers.
+- fix(security): hide exception details in `FORMAT_RAW` error responses when `YII_DEBUG` is disabled to prevent stack trace and file path disclosure.
 
 ## 0.3.0 February 28, 2026
 

--- a/src/http/ErrorHandler.php
+++ b/src/http/ErrorHandler.php
@@ -228,12 +228,32 @@ class ErrorHandler extends \yii\web\ErrorHandler
                 $response->data = $this->renderFile($file, ['exception' => $exception]);
             }
         } elseif ($response->format === Response::FORMAT_RAW) {
-            $response->data = self::convertExceptionToString($exception);
+            $response->data = $this->convertExceptionToRawString($exception);
         } else {
             $response->data = $this->convertExceptionToArray($exception);
         }
 
         return $response;
+    }
+
+    /**
+     * Converts an exception to a RAW response string without exposing sensitive details in production.
+     *
+     * @param Throwable $exception Exception to convert.
+     *
+     * @return string Safe RAW response body.
+     */
+    private function convertExceptionToRawString(Throwable $exception): string
+    {
+        if (YII_DEBUG) {
+            return self::convertExceptionToString($exception);
+        }
+
+        if ($exception instanceof UserException) {
+            return $exception->getMessage();
+        }
+
+        return 'An internal server error occurred.';
     }
 
     /**

--- a/tests/http/ErrorHandlerTest.php
+++ b/tests/http/ErrorHandlerTest.php
@@ -430,6 +430,59 @@ final class ErrorHandlerTest extends TestCase
         );
     }
 
+    #[RequiresPhpExtension('runkit7')]
+    public function testRawErrorResponseHidesNonUserExceptionDetailsWhenDebugDisabled(): void
+    {
+        @\runkit_constant_redefine('YII_DEBUG', false);
+
+        try {
+            $errorHandler = new ErrorHandler();
+
+            $errorHandler->discardExistingOutput = false;
+
+            $response = new Response(['format' => Response::FORMAT_RAW]);
+
+            $errorHandler->setResponse($response);
+
+            $exception = new RuntimeException('SECRET_DSN=mysql://user:pass@db/internal');
+
+            $response = $errorHandler->handleException($exception);
+
+            self::assertSame(
+                Response::FORMAT_RAW,
+                $response->format,
+                'RAW error responses should preserve the configured response format.',
+            );
+            self::assertSame(
+                500,
+                $response->getStatusCode(),
+                "Should set status code to '500' for runtime exception.",
+            );
+            self::assertSame(
+                'An internal server error occurred.',
+                $response->data,
+                'RAW error responses should use a generic message for non-user exceptions when debug is disabled.',
+            );
+            self::assertStringNotContainsString(
+                'SECRET_DSN',
+                $response->data,
+                'RAW error responses should not expose exception messages when debug is disabled.',
+            );
+            self::assertStringNotContainsString(
+                __FILE__,
+                $response->data,
+                'RAW error responses should not expose file paths when debug is disabled.',
+            );
+            self::assertStringNotContainsString(
+                'Stack trace:',
+                $response->data,
+                'RAW error responses should not expose stack traces when debug is disabled.',
+            );
+        } finally {
+            @\runkit_constant_redefine('YII_DEBUG', true);
+        }
+    }
+
     public function testResponseDataIsNotEmpty(): void
     {
         $errorHandler = new ErrorHandler();

--- a/tests/http/ErrorHandlerTest.php
+++ b/tests/http/ErrorHandlerTest.php
@@ -440,7 +440,7 @@ final class ErrorHandlerTest extends TestCase
 
             $errorHandler->discardExistingOutput = false;
 
-            $response = new Response(['format' => Response::FORMAT_RAW]);
+            $response = new Response(['charset' => 'UTF-8', 'format' => Response::FORMAT_RAW]);
 
             $errorHandler->setResponse($response);
 
@@ -451,32 +451,70 @@ final class ErrorHandlerTest extends TestCase
             self::assertSame(
                 Response::FORMAT_RAW,
                 $response->format,
-                'RAW error responses should preserve the configured response format.',
+                'RAW format must be preserved.',
             );
             self::assertSame(
                 500,
                 $response->getStatusCode(),
-                "Should set status code to '500' for runtime exception.",
+                'Status must be `500`.',
             );
             self::assertSame(
                 'An internal server error occurred.',
                 $response->data,
-                'RAW error responses should use a generic message for non-user exceptions when debug is disabled.',
+                'Generic message must replace the exception body.',
             );
             self::assertStringNotContainsString(
                 'SECRET_DSN',
                 $response->data,
-                'RAW error responses should not expose exception messages when debug is disabled.',
+                'Exception message must not leak.',
             );
             self::assertStringNotContainsString(
                 __FILE__,
                 $response->data,
-                'RAW error responses should not expose file paths when debug is disabled.',
+                'File path must not leak.',
             );
             self::assertStringNotContainsString(
                 'Stack trace:',
                 $response->data,
-                'RAW error responses should not expose stack traces when debug is disabled.',
+                'Stack trace must not leak.',
+            );
+        } finally {
+            @\runkit_constant_redefine('YII_DEBUG', true);
+        }
+    }
+
+    #[RequiresPhpExtension('runkit7')]
+    public function testRawErrorResponseReturnsUserExceptionMessageWhenDebugDisabled(): void
+    {
+        @\runkit_constant_redefine('YII_DEBUG', false);
+
+        try {
+            $errorHandler = new ErrorHandler();
+
+            $errorHandler->discardExistingOutput = false;
+
+            $response = new Response(['charset' => 'UTF-8', 'format' => Response::FORMAT_RAW]);
+
+            $errorHandler->setResponse($response);
+
+            $exception = new UserException('Invalid request parameters.');
+
+            $response = $errorHandler->handleException($exception);
+
+            self::assertSame(
+                Response::FORMAT_RAW,
+                $response->format,
+                'RAW format must be preserved.',
+            );
+            self::assertSame(
+                'Invalid request parameters.',
+                $response->data,
+                'User exception message must be returned verbatim.',
+            );
+            self::assertStringNotContainsString(
+                'Stack trace:',
+                $response->data,
+                'Stack trace must not leak.',
             );
         } finally {
             @\runkit_constant_redefine('YII_DEBUG', true);


### PR DESCRIPTION
### Motivation
- The error handler reused the application `Response` (preserving `FORMAT_RAW`) and unconditionally serialized full exception strings for raw responses, which could expose internal exception messages, file paths, and stack traces in production when `YII_DEBUG` is disabled.

### Description
- Change raw-format rendering to call a safe formatter: replace the unconditional `self::convertExceptionToString($exception)` in the `FORMAT_RAW` branch with a call to a new private method `convertExceptionToRawString(Throwable $exception)` in `src/http/ErrorHandler.php`.
- Implement `convertExceptionToRawString()` to return the full exception string only when `YII_DEBUG` is true, return the `UserException` message for user-facing exceptions, and otherwise return the generic string `"An internal server error occurred."` to avoid leaking sensitive details.
- Add a regression test `testRawErrorResponseHidesNonUserExceptionDetailsWhenDebugDisabled()` to `tests/http/ErrorHandlerTest.php` which verifies that RAW responses in non-debug mode do not expose secrets, file paths, or stack traces while preserving the response format and status code.
- Modified files: `src/http/ErrorHandler.php` and `tests/http/ErrorHandlerTest.php`.

### Testing
- Ran `composer validate --no-check-publish`, which completed successfully. 
- Verified PHP syntax with `php -l src/http/ErrorHandler.php` and `php -l tests/http/ErrorHandlerTest.php`, both reported no syntax errors. 
- Attempting to run `./vendor/bin/phpunit tests/http/ErrorHandlerTest.php` was not possible because dependencies are not installed in the environment (vendor binaries unavailable). 
- `composer install` could not be completed here due to an external `asset-packagist.org` CONNECT tunnel returning HTTP 403, so full test suite execution was not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1895be57dc832a820351b360c31e90)