### PR TITLE
fix(security): treat falsy non-boolean `YII_DEBUG` values (e.g. `0`) as debug-disabled in `ErrorHandler` to avoid leaking the debug exception page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(security): clear cached query params when replacing the PSR-7 request to prevent cross-request leakage in reused `Request` instances.
 - refactor: consolidate package metadata in `composer.json` (`authors`) and `LICENSE`; drop redundant per-file `@copyright`/`@license` headers.
 - fix(security): hide exception details in `FORMAT_RAW` error responses when `YII_DEBUG` is disabled to prevent stack trace and file path disclosure.
+- fix(security): treat falsy non-boolean `YII_DEBUG` values (e.g. `0`) as debug-disabled in `ErrorHandler` to avoid leaking the debug exception page.
 
 ## 0.3.0 February 28, 2026
 

--- a/src/http/ErrorHandler.php
+++ b/src/http/ErrorHandler.php
@@ -205,7 +205,7 @@ class ErrorHandler extends \yii\web\ErrorHandler
         $response->setStatusCodeByException($exception);
 
         $useErrorView = $response->format === Response::FORMAT_HTML
-            && (YII_DEBUG === false || $exception instanceof UserException);
+            && (!YII_DEBUG || $exception instanceof UserException);
 
         if ($useErrorView && $this->errorAction !== null) {
             $result = Yii::$app->runAction($this->errorAction);

--- a/tests/http/stateless/ApplicationErrorHandlerTest.php
+++ b/tests/http/stateless/ApplicationErrorHandlerTest.php
@@ -37,7 +37,7 @@ final class ApplicationErrorHandlerTest extends TestCase
     #[DataProviderExternal(ApplicationProvider::class, 'errorViewLogic')]
     #[RequiresPhpExtension('runkit7')]
     public function testErrorViewLogic(
-        bool $debug,
+        bool|int $debug,
         string $route,
         string $action,
         int $expectedStatusCode,
@@ -46,33 +46,35 @@ final class ApplicationErrorHandlerTest extends TestCase
     ): void {
         @\runkit_constant_redefine('YII_DEBUG', $debug);
 
-        $app = ApplicationFactory::stateless(
-            [
-                'components' => [
-                    'errorHandler' => ['errorAction' => $action],
+        try {
+            $app = ApplicationFactory::stateless(
+                [
+                    'components' => [
+                        'errorHandler' => ['errorAction' => $action],
+                    ],
                 ],
-            ],
-        );
+            );
 
-        $response = $app->handle(HelperFactory::createRequest('GET', $route));
+            $response = $app->handle(HelperFactory::createRequest('GET', $route));
 
-        self::assertSame(
-            $expectedStatusCode,
-            $response->getStatusCode(),
-            "Expected HTTP '{$expectedStatusCode}' for route '{$route}'.",
-        );
-        self::assertSame(
-            'text/html; charset=UTF-8',
-            $response->getHeaderLine('Content-Type'),
-            "Expected Content-Type 'text/html; charset=UTF-8' for route '{$route}'.",
-        );
-        self::assertSame(
-            LineEndingNormalizer::normalize($expectedErrorViewContent),
-            LineEndingNormalizer::normalize($response->getBody()->getContents()),
-            $expectedAssertMessage,
-        );
-
-        @\runkit_constant_redefine('YII_DEBUG', true);
+            self::assertSame(
+                $expectedStatusCode,
+                $response->getStatusCode(),
+                "Expected HTTP '{$expectedStatusCode}' for route '{$route}'.",
+            );
+            self::assertSame(
+                'text/html; charset=UTF-8',
+                $response->getHeaderLine('Content-Type'),
+                "Expected Content-Type 'text/html; charset=UTF-8' for route '{$route}'.",
+            );
+            self::assertSame(
+                LineEndingNormalizer::normalize($expectedErrorViewContent),
+                LineEndingNormalizer::normalize($response->getBody()->getContents()),
+                $expectedAssertMessage,
+            );
+        } finally {
+            @\runkit_constant_redefine('YII_DEBUG', true);
+        }
     }
 
     /**

--- a/tests/provider/ApplicationProvider.php
+++ b/tests/provider/ApplicationProvider.php
@@ -197,7 +197,7 @@ final class ApplicationProvider
     }
 
     /**
-     * @phpstan-return array<string, array{bool, string, string, int, string, string}>
+     * @phpstan-return array<string, array{bool|int, string, string, int, string, string}>
      */
     public static function errorViewLogic(): array
     {
@@ -239,6 +239,25 @@ final class ApplicationProvider
                 HTML,
                 "Response body should contain 'Custom error page from errorAction' when UserException is triggered "
                 . "and YII_DEBUG mode is disabled with 'errorAction' configured.",
+            ],
+            'debug zero with Exception' => [
+                0,
+                'site/trigger-exception',
+                'site/error',
+                500,
+                <<<HTML
+                <div id="custom-error-action">
+                Custom error page from errorAction.
+                <span class="exception-type">
+                yii\base\Exception
+                </span>
+                <span class="exception-message">
+                Exception error message.
+                </span>
+                </div>
+                HTML,
+                "Response body should contain 'Custom error page from errorAction' when Exception is triggered and "
+                . "YII_DEBUG is a falsy non-boolean value with 'errorAction' configured.",
             ],
             'debug true with UserException' => [
                 true,


### PR DESCRIPTION
### Motivation

- The error rendering logic used a strict `YII_DEBUG === false` check which allowed falsy non-boolean values (e.g. `0`) to be treated as debug-enabled and thus exposed detailed exception pages instead of the configured production `errorAction`.
- The change restores the original Yii-style truthy/falsy semantics so deployments that define `YII_DEBUG` as `0` continue to use the safe production error view.

### Description

- Replaced the strict comparison in `ErrorHandler::renderException()` with a truthiness check so `$useErrorView` is computed using `!YII_DEBUG` instead of `YII_DEBUG === false` (file: `src/http/ErrorHandler.php`).
- Added a regression test case for `YII_DEBUG` set to integer `0` in the data provider (file: `tests/provider/ApplicationProvider.php`).
- Updated the stateless error-view test to accept `bool|int` debug values and wrapped the test body in a `try`/`finally` to ensure `YII_DEBUG` is always restored (file: `tests/http/stateless/ApplicationErrorHandlerTest.php`).

### Testing

- Ran PHP syntax checks: `php -l src/http/ErrorHandler.php`, `php -l tests/http/stateless/ApplicationErrorHandlerTest.php`, `php -l tests/provider/ApplicationProvider.php` — all files reported no syntax errors.
- Ran `composer validate --no-interaction --strict` — validation passed.
- Attempted `composer install --no-interaction --no-progress` but dependency installation was blocked by a network error fetching `asset-packagist.org` (HTTP 403) in this environment, so vendor test runner was not available.
- Attempted to run PHPUnit (`./vendor/bin/phpunit --filter testErrorViewLogic`) but could not run because vendor dependencies were unavailable due to the blocked `composer install`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18e3505c9c832aa3426cb491ad7656)