### PR TITLE
fix(security): reject safe-method (`GET`/`HEAD`/`OPTIONS`) `X-Http-Method-Override` overrides and normalize to uppercase to prevent CSRF method-downgrade.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(security): hide exception details in `FORMAT_RAW` error responses when `YII_DEBUG` is disabled to prevent stack trace and file path disclosure.
 - fix(security): treat falsy non-boolean `YII_DEBUG` values (e.g. `0`) as debug-disabled in `ErrorHandler` to avoid leaking the debug exception page.
 - fix(security): bound `ErrorHandler::clearOutput()` buffer loop to prevent worker hangs when an output buffer cannot be removed.
+- fix(security): reject safe-method (`GET`/`HEAD`/`OPTIONS`) `X-Http-Method-Override` overrides and normalize to uppercase to prevent CSRF method-downgrade.
 
 ## 0.3.0 February 28, 2026
 

--- a/src/adapter/ServerRequestAdapter.php
+++ b/src/adapter/ServerRequestAdapter.php
@@ -207,7 +207,11 @@ final class ServerRequestAdapter
             $overrideHeader = $this->psrRequest->getHeaderLine('X-Http-Method-Override');
 
             if ($overrideHeader !== '') {
-                return $overrideHeader;
+                $methodOverride = strtoupper($overrideHeader);
+
+                if (in_array($methodOverride, ['GET', 'HEAD', 'OPTIONS'], true) === false) {
+                    return $methodOverride;
+                }
             }
         }
 

--- a/tests/adapter/ServerRequestAdapterTest.php
+++ b/tests/adapter/ServerRequestAdapterTest.php
@@ -465,6 +465,24 @@ final class ServerRequestAdapterTest extends TestCase
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
+    public function testReturnHttpMethodWithoutOverrideWhenAdapterIsSet(): void
+    {
+        $request = new Request();
+
+        $request->setPsr7Request(
+            HelperFactory::createRequest('GET', '/test'),
+        );
+
+        self::assertSame(
+            'GET',
+            $request->getMethod(),
+            'HTTP method should return original method when no override is present and adapter is set.',
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
     #[TestWith(['GET'])]
     #[TestWith(['HEAD'])]
     #[TestWith(['OPTIONS'])]
@@ -481,24 +499,6 @@ final class ServerRequestAdapterTest extends TestCase
             'POST',
             $request->getMethod(),
             'HTTP method safe header override should be ignored when adapter is set.',
-        );
-    }
-
-    /**
-     * @throws InvalidConfigException if the configuration is invalid or incomplete.
-     */
-    public function testReturnHttpMethodWithoutOverrideWhenAdapterIsSet(): void
-    {
-        $request = new Request();
-
-        $request->setPsr7Request(
-            HelperFactory::createRequest('GET', '/test'),
-        );
-
-        self::assertSame(
-            'GET',
-            $request->getMethod(),
-            'HTTP method should return original method when no override is present and adapter is set.',
         );
     }
 

--- a/tests/adapter/ServerRequestAdapterTest.php
+++ b/tests/adapter/ServerRequestAdapterTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace yii2\extensions\psrbridge\tests\adapter;
 
-use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group, TestWith};
 use Psr\Http\Message\ServerRequestInterface;
 use yii\base\InvalidConfigException;
 use yii\web\JsonParser;
@@ -441,6 +441,46 @@ final class ServerRequestAdapterTest extends TestCase
             'DELETE',
             $request->getMethod(),
             'HTTP method should be overridden by header when adapter is set.',
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnHttpMethodWithLowercaseHeaderOverrideWhenAdapterIsSet(): void
+    {
+        $request = new Request();
+
+        $request->setPsr7Request(
+            HelperFactory::createRequest('POST', '/test', ['X-Http-Method-Override' => 'patch']),
+        );
+
+        self::assertSame(
+            'PATCH',
+            $request->getMethod(),
+            'HTTP method header override should be normalized to uppercase when adapter is set.',
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    #[TestWith(['GET'])]
+    #[TestWith(['HEAD'])]
+    #[TestWith(['OPTIONS'])]
+    #[TestWith(['get'])]
+    public function testReturnOriginalHttpMethodWithSafeHeaderOverrideWhenAdapterIsSet(string $overrideMethod): void
+    {
+        $request = new Request();
+
+        $request->setPsr7Request(
+            HelperFactory::createRequest('POST', '/test', ['X-Http-Method-Override' => $overrideMethod]),
+        );
+
+        self::assertSame(
+            'POST',
+            $request->getMethod(),
+            'HTTP method safe header override should be ignored when adapter is set.',
         );
     }
 


### PR DESCRIPTION
### Motivation
- Prevent attacker-controlled `HTTP_X_HTTP_METHOD_OVERRIDE` from downgrading the effective request method when globals are converted to PSR-7 and adapted back to Yii. 
- Ensure header-based overrides follow the same safety rules as body `_method` overrides to avoid method-confusion paths that could bypass CSRF/verb protections.

### Description
- Change `ServerRequestAdapter::getMethod()` to normalize `X-Http-Method-Override` to uppercase and apply the same rejection of safe methods (`GET`, `HEAD`, `OPTIONS`) that is used for body `_method` overrides (file: `src/adapter/ServerRequestAdapter.php`).
- Add unit tests covering lowercase header overrides and that safe header override values are ignored (file: `tests/adapter/ServerRequestAdapterTest.php`).
- Update test imports to include the `TestWith` attribute used by new parameterized tests (file: `tests/adapter/ServerRequestAdapterTest.php`).

### Testing
- Ran PHP syntax checks with `php -l` on modified files and they passed for `src/adapter/ServerRequestAdapter.php` and `tests/adapter/ServerRequestAdapterTest.php`.
- Attempted to run the adapter test suite via `./vendor/bin/phpunit tests/adapter/ServerRequestAdapterTest.php` but it could not be executed because project dependencies are not installed in the environment (vendor binaries missing).
- Attempted `composer install` to install test dependencies but it failed due to network/registry access errors in the environment (asset-packagist.org returned HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19a707aae0832aae5b2db88e118ce1)