### PR TITLE
fix(security): skip stream access for failed uploads in `UploadedFileCreator` and `Request::getUploadedFiles()` to prevent unauthenticated request DoS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(security): treat falsy non-boolean `YII_DEBUG` values (e.g. `0`) as debug-disabled in `ErrorHandler` to avoid leaking the debug exception page.
 - fix(security): bound `ErrorHandler::clearOutput()` buffer loop to prevent worker hangs when an output buffer cannot be removed.
 - fix(security): reject safe-method (`GET`/`HEAD`/`OPTIONS`) `X-Http-Method-Override` overrides and normalize to uppercase to prevent CSRF method-downgrade.
+- fix(security): skip stream access for failed uploads in `UploadedFileCreator` and `Request::getUploadedFiles()` to prevent unauthenticated request DoS.
 
 ## 0.3.0 February 28, 2026
 

--- a/src/creator/UploadedFileCreator.php
+++ b/src/creator/UploadedFileCreator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace yii2\extensions\psrbridge\creator;
 
-use Psr\Http\Message\{StreamFactoryInterface, UploadedFileFactoryInterface, UploadedFileInterface};
+use Psr\Http\Message\{StreamFactoryInterface, StreamInterface, UploadedFileFactoryInterface, UploadedFileInterface};
 use Throwable;
 use yii\base\InvalidArgumentException;
 use yii2\extensions\psrbridge\exception\Message;
@@ -14,6 +14,8 @@ use function array_map;
 use function is_array;
 use function is_int;
 use function is_string;
+
+use const UPLOAD_ERR_OK;
 
 /**
  * Creates PSR-7 uploaded files from PHP file specifications.
@@ -100,13 +102,7 @@ final class UploadedFileCreator
     {
         $this->validateFileSpec($file);
 
-        try {
-            $stream = $this->streamFactory->createStreamFromFile($file['tmp_name']);
-        } catch (Throwable) {
-            throw new InvalidArgumentException(
-                Message::FAILED_CREATE_STREAM_FROM_TMP_FILE->getMessage($file['tmp_name']),
-            );
-        }
+        $stream = $this->createStreamForUpload($file['tmp_name'], $file['error']);
 
         return $this->uploadedFileFactory->createUploadedFile(
             $stream,
@@ -309,12 +305,41 @@ final class UploadedFileCreator
         string|null $type = null,
     ): UploadedFileInterface {
         return $this->uploadedFileFactory->createUploadedFile(
-            $this->streamFactory->createStreamFromFile($tmpName),
+            $this->createStreamForUpload($tmpName, $error),
             $size,
             $error,
             $name,
             $type,
         );
+    }
+
+    /**
+     * Creates a stream for an uploaded file without opening failed upload temporary paths.
+     *
+     * PHP uses an empty or otherwise unusable temporary path for failed upload entries, including
+     * {@see \UPLOAD_ERR_NO_FILE}. The PSR uploaded file still carries the error code, so failed uploads receive a
+     * safe empty stream instead of opening the reported temporary path.
+     *
+     * @param string $tmpName Temporary file name reported by PHP.
+     * @param int $error PHP upload error code.
+     *
+     * @throws InvalidArgumentException if opening a successful upload temporary file fails.
+     *
+     * @return StreamInterface Stream for the uploaded file.
+     */
+    private function createStreamForUpload(string $tmpName, int $error): StreamInterface
+    {
+        if ($error !== UPLOAD_ERR_OK) {
+            return $this->streamFactory->createStream();
+        }
+
+        try {
+            return $this->streamFactory->createStreamFromFile($tmpName);
+        } catch (Throwable) {
+            throw new InvalidArgumentException(
+                Message::FAILED_CREATE_STREAM_FROM_TMP_FILE->getMessage($tmpName),
+            );
+        }
     }
 
     /**

--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -24,6 +24,8 @@ use function mb_substr;
 use function str_starts_with;
 use function strncasecmp;
 
+use const UPLOAD_ERR_OK;
+
 /**
  * Extends Yii request handling with PSR-7 request data.
  *
@@ -693,20 +695,40 @@ class Request extends \yii\web\Request
      * Converts a {@see UploadedFileInterface} object to a Yii {@see UploadedFile} instance by extracting the error
      * code, client filename, file size, temporary file path, and media type from the PSR-7 UploadedFileInterface.
      *
+     * For failed uploads (`error` other than `UPLOAD_ERR_OK`), the temporary path and resource stay empty and the
+     * PSR-7 stream is never accessed, since PSR-7 implementations reject `getStream()` on error-state uploads.
+     *
      * @param UploadedFileInterface $psrFile PSR-7 UploadedFileInterface instance to convert.
      *
      * @return UploadedFile Yii UploadedFile instance created from the PSR-7 UploadedFileInterface.
      */
     private function createUploadedFile(UploadedFileInterface $psrFile): UploadedFile
     {
+        $error = $psrFile->getError();
+
+        if ($error !== UPLOAD_ERR_OK) {
+            return new UploadedFile(
+                [
+                    'error' => $error,
+                    'name' => $psrFile->getClientFilename() ?? '',
+                    'size' => $psrFile->getSize(),
+                    'tempName' => '',
+                    'type' => $psrFile->getClientMediaType() ?? '',
+                    'tempResource' => null,
+                ],
+            );
+        }
+
+        $stream = $psrFile->getStream();
+
         return new UploadedFile(
             [
-                'error' => $psrFile->getError(),
+                'error' => $error,
                 'name' => $psrFile->getClientFilename() ?? '',
                 'size' => $psrFile->getSize(),
-                'tempName' => $psrFile->getStream()->getMetadata('uri') ?? '',
+                'tempName' => $stream->getMetadata('uri') ?? '',
                 'type' => $psrFile->getClientMediaType() ?? '',
-                'tempResource' => $psrFile->getStream()->detach(),
+                'tempResource' => $stream->detach(),
             ],
         );
     }

--- a/tests/adapter/UploadedFilesPsr7Test.php
+++ b/tests/adapter/UploadedFilesPsr7Test.php
@@ -140,6 +140,50 @@ final class UploadedFilesPsr7Test extends TestCase
         );
     }
 
+    public function testReturnUploadedFileForFailedUploadWithoutAccessingStream(): void
+    {
+        $uploadedFileFactory = HelperFactory::createUploadedFileFactory();
+        $streamFactory = HelperFactory::createStreamFactory();
+
+        $failedUpload = $uploadedFileFactory->createUploadedFile(
+            $streamFactory->createStream(),
+            0,
+            UPLOAD_ERR_NO_FILE,
+            '',
+            '',
+        );
+
+        $psr7Request = HelperFactory::createRequest('POST', '/upload')
+            ->withUploadedFiles(['avatar' => $failedUpload]);
+        $request = new Request();
+
+        $request->setPsr7Request($psr7Request);
+        $files = $request->getUploadedFiles();
+
+        $avatar = $files['avatar'] ?? null;
+
+        self::assertInstanceOf(
+            UploadedFile::class,
+            $avatar,
+            "Failed upload must still yield an 'UploadedFile'.",
+        );
+        self::assertSame(
+            UPLOAD_ERR_NO_FILE,
+            $avatar->error,
+            'Error code must be preserved.',
+        );
+        self::assertSame(
+            '',
+            $avatar->tempName,
+            'Temp name must be empty for failed uploads.',
+        );
+        self::assertSame(
+            0,
+            $avatar->size,
+            'Size must be preserved as `int`.',
+        );
+    }
+
     public function testReturnUploadedFilesRecursivelyConvertsNestedArrays(): void
     {
         $file1 = dirname(__DIR__) . '/support/stub/files/test1.txt';

--- a/tests/creator/ServerRequestCreatorTest.php
+++ b/tests/creator/ServerRequestCreatorTest.php
@@ -9,6 +9,7 @@ use Psr\Http\Message\{StreamFactoryInterface, StreamInterface, UploadedFileInter
 use RuntimeException;
 use yii2\extensions\psrbridge\creator\ServerRequestCreator;
 use yii2\extensions\psrbridge\tests\support\{HelperFactory, TestCase};
+use yii2\extensions\psrbridge\tests\support\stub\StreamFactorySpy;
 
 use function fclose;
 use function is_resource;
@@ -1114,37 +1115,6 @@ final class ServerRequestCreatorTest extends TestCase
         );
     }
 
-    public function testCreateFromGlobalsWithUploadErrorDoesNotOpenEmptyTmpName(): void
-    {
-        $_FILES['avatar'] = [
-            'name' => '',
-            'type' => '',
-            'tmp_name' => '',
-            'error' => UPLOAD_ERR_NO_FILE,
-            'size' => 0,
-        ];
-
-        $creator = new ServerRequestCreator(
-            HelperFactory::createServerRequestFactory(),
-            HelperFactory::createStreamFactory(),
-            HelperFactory::createUploadedFileFactory(),
-        );
-
-        $request = $creator->createFromGlobals();
-        $uploadedFile = $request->getUploadedFiles()['avatar'] ?? null;
-
-        self::assertInstanceOf(
-            UploadedFileInterface::class,
-            $uploadedFile,
-            "Should create an 'UploadedFileInterface' for failed upload entries.",
-        );
-        self::assertSame(
-            UPLOAD_ERR_NO_FILE,
-            $uploadedFile->getError(),
-            "Should preserve the failed 'upload error' code during request creation.",
-        );
-    }
-
     public function testCreateFromGlobalsWithSingleUploadedFile(): void
     {
         $_FILES['avatar'] = [
@@ -1202,6 +1172,44 @@ final class ServerRequestCreatorTest extends TestCase
             UPLOAD_ERR_OK,
             $uploadedFile->getError(),
             'Should preserve error code from \'$_FILES\'.',
+        );
+    }
+
+    public function testCreateFromGlobalsWithUploadErrorDoesNotOpenEmptyTmpName(): void
+    {
+        $_FILES['avatar'] = [
+            'name' => '',
+            'type' => '',
+            'tmp_name' => '',
+            'error' => UPLOAD_ERR_NO_FILE,
+            'size' => 0,
+        ];
+
+        $streamFactory = new StreamFactorySpy(
+            HelperFactory::createStreamFactory(),
+        );
+        $creator = new ServerRequestCreator(
+            HelperFactory::createServerRequestFactory(),
+            $streamFactory,
+            HelperFactory::createUploadedFileFactory(),
+        );
+
+        $request = $creator->createFromGlobals();
+        $uploadedFile = $request->getUploadedFiles()['avatar'] ?? null;
+
+        self::assertInstanceOf(
+            UploadedFileInterface::class,
+            $uploadedFile,
+            "Should create an 'UploadedFileInterface' for failed upload entries.",
+        );
+        self::assertSame(
+            UPLOAD_ERR_NO_FILE,
+            $uploadedFile->getError(),
+            "Should preserve the failed 'upload error' code during request creation.",
+        );
+        self::assertFalse(
+            $streamFactory->createdFromFile,
+            "Should not open 'tmp_name' for failed upload entries during request creation.",
         );
     }
 }

--- a/tests/creator/ServerRequestCreatorTest.php
+++ b/tests/creator/ServerRequestCreatorTest.php
@@ -14,6 +14,7 @@ use function fclose;
 use function is_resource;
 use function stream_get_meta_data;
 
+use const UPLOAD_ERR_NO_FILE;
 use const UPLOAD_ERR_OK;
 
 /**
@@ -1110,6 +1111,37 @@ final class ServerRequestCreatorTest extends TestCase
             '/api/users?page=1',
             (string) $request->getUri(),
             "Should use 'REQUEST_URI' from '\$_SERVER' when set.",
+        );
+    }
+
+    public function testCreateFromGlobalsWithUploadErrorDoesNotOpenEmptyTmpName(): void
+    {
+        $_FILES['avatar'] = [
+            'name' => '',
+            'type' => '',
+            'tmp_name' => '',
+            'error' => UPLOAD_ERR_NO_FILE,
+            'size' => 0,
+        ];
+
+        $creator = new ServerRequestCreator(
+            HelperFactory::createServerRequestFactory(),
+            HelperFactory::createStreamFactory(),
+            HelperFactory::createUploadedFileFactory(),
+        );
+
+        $request = $creator->createFromGlobals();
+        $uploadedFile = $request->getUploadedFiles()['avatar'] ?? null;
+
+        self::assertInstanceOf(
+            UploadedFileInterface::class,
+            $uploadedFile,
+            "Should create an 'UploadedFileInterface' for failed upload entries.",
+        );
+        self::assertSame(
+            UPLOAD_ERR_NO_FILE,
+            $uploadedFile->getError(),
+            "Should preserve the failed 'upload error' code during request creation.",
         );
     }
 

--- a/tests/creator/UploadedFileCreatorTest.php
+++ b/tests/creator/UploadedFileCreatorTest.php
@@ -432,9 +432,11 @@ final class UploadedFileCreatorTest extends TestCase
 
     public function testCreateFromGlobalsWithMultipleUploadErrorUsesEmptyStream(): void
     {
+        $successfulTmpName = $this->createTmpFile();
+
         $files = [
             'documents' => [
-                'tmp_name' => [$this->createTmpFile(), ''],
+                'tmp_name' => [$successfulTmpName, ''],
                 'size' => [128, 0],
                 'error' => [UPLOAD_ERR_OK, UPLOAD_ERR_NO_FILE],
                 'name' => ['document.txt', ''],
@@ -477,9 +479,10 @@ final class UploadedFileCreatorTest extends TestCase
             $failedDocument->getError(),
             "Should preserve 'upload error' code for failed multiple upload entries.",
         );
-        self::assertTrue(
-            $streamFactory->createdFromFile,
-            "Should still open 'tmp_name' for successful multiple upload entries.",
+        self::assertSame(
+            [$successfulTmpName],
+            $streamFactory->createdFromFileNames,
+            "Only the successful 'tmp_name' must be opened.",
         );
         self::assertTrue(
             $streamFactory->createdFromString,

--- a/tests/creator/UploadedFileCreatorTest.php
+++ b/tests/creator/UploadedFileCreatorTest.php
@@ -10,7 +10,9 @@ use yii\base\InvalidArgumentException;
 use yii2\extensions\psrbridge\creator\UploadedFileCreator;
 use yii2\extensions\psrbridge\exception\Message;
 use yii2\extensions\psrbridge\tests\support\{HelperFactory, TestCase};
+use yii2\extensions\psrbridge\tests\support\stub\StreamFactorySpy;
 
+use const UPLOAD_ERR_NO_FILE;
 use const UPLOAD_ERR_OK;
 
 /**
@@ -123,6 +125,97 @@ final class UploadedFileCreatorTest extends TestCase
             UPLOAD_ERR_OK,
             $uploadedFile->getError(),
             "Should preserve 'error code' from file specification.",
+        );
+    }
+
+    public function testCreateFromArrayWithUploadErrorUsesEmptyStream(): void
+    {
+        $fileSpec = [
+            'tmp_name' => '',
+            'size' => 0,
+            'error' => UPLOAD_ERR_NO_FILE,
+            'name' => '',
+            'type' => '',
+        ];
+        $streamFactory = new StreamFactorySpy(HelperFactory::createStreamFactory());
+
+        $creator = new UploadedFileCreator(
+            HelperFactory::createUploadedFileFactory(),
+            $streamFactory,
+        );
+
+        $uploadedFile = $creator->createFromArray($fileSpec);
+
+        self::assertSame(
+            UPLOAD_ERR_NO_FILE,
+            $uploadedFile->getError(),
+            "Should preserve 'upload error' code for failed upload entries.",
+        );
+        self::assertSame(
+            0,
+            $uploadedFile->getSize(),
+            "Should preserve 'file size' for failed upload entries.",
+        );
+        self::assertTrue(
+            $streamFactory->createdFromString,
+            "Should create a safe empty 'stream' for failed upload entries.",
+        );
+        self::assertFalse(
+            $streamFactory->createdFromFile,
+            "Should not open 'tmp_name' for failed upload entries.",
+        );
+    }
+
+    public function testCreateFromGlobalsWithMultipleUploadErrorUsesEmptyStream(): void
+    {
+        $files = [
+            'documents' => [
+                'tmp_name' => [$this->createTmpFile(), ''],
+                'size' => [128, 0],
+                'error' => [UPLOAD_ERR_OK, UPLOAD_ERR_NO_FILE],
+                'name' => ['document.txt', ''],
+                'type' => ['text/plain', ''],
+            ],
+        ];
+        $streamFactory = new StreamFactorySpy(HelperFactory::createStreamFactory());
+
+        $creator = new UploadedFileCreator(
+            HelperFactory::createUploadedFileFactory(),
+            $streamFactory,
+        );
+
+        $result = $creator->createFromGlobals($files);
+        $documents = $result['documents'] ?? null;
+
+        self::assertIsArray(
+            $documents,
+            "Should create 'uploaded files' for multiple upload entries.",
+        );
+        self::assertInstanceOf(
+            UploadedFileInterface::class,
+            $documents[0] ?? null,
+            "Should create an 'UploadedFileInterface' for successful multiple upload entries.",
+        );
+        self::assertInstanceOf(
+            UploadedFileInterface::class,
+            $documents[1] ?? null,
+            "Should create an 'UploadedFileInterface' for failed multiple upload entries.",
+        );
+        /** @var UploadedFileInterface $failedDocument */
+        $failedDocument = $documents[1];
+
+        self::assertSame(
+            UPLOAD_ERR_NO_FILE,
+            $failedDocument->getError(),
+            "Should preserve 'upload error' code for failed multiple upload entries.",
+        );
+        self::assertTrue(
+            $streamFactory->createdFromFile,
+            "Should still open 'tmp_name' for successful multiple upload entries.",
+        );
+        self::assertTrue(
+            $streamFactory->createdFromString,
+            "Should create a safe empty 'stream' for failed multiple upload entries.",
         );
     }
 

--- a/tests/creator/UploadedFileCreatorTest.php
+++ b/tests/creator/UploadedFileCreatorTest.php
@@ -89,45 +89,6 @@ final class UploadedFileCreatorTest extends TestCase
         );
     }
 
-    public function testCreateFromArrayWithValidFileSpec(): void
-    {
-        $fileSpec = [
-            'tmp_name' => $this->createTmpFile(),
-            'size' => 1024,
-            'error' => UPLOAD_ERR_OK,
-            'name' => 'test.txt',
-            'type' => 'text/plain',
-        ];
-
-        $creator = new UploadedFileCreator(
-            HelperFactory::createUploadedFileFactory(),
-            HelperFactory::createStreamFactory(),
-        );
-
-        $uploadedFile = $creator->createFromArray($fileSpec);
-
-        self::assertSame(
-            'test.txt',
-            $uploadedFile->getClientFilename(),
-            "Should preserve 'client filename' from file specification.",
-        );
-        self::assertSame(
-            'text/plain',
-            $uploadedFile->getClientMediaType(),
-            "Should preserve 'client media type' from file specification.",
-        );
-        self::assertSame(
-            1024,
-            $uploadedFile->getSize(),
-            "Should preserve 'file size' from file specification.",
-        );
-        self::assertSame(
-            UPLOAD_ERR_OK,
-            $uploadedFile->getError(),
-            "Should preserve 'error code' from file specification.",
-        );
-    }
-
     public function testCreateFromArrayWithUploadErrorUsesEmptyStream(): void
     {
         $fileSpec = [
@@ -166,56 +127,42 @@ final class UploadedFileCreatorTest extends TestCase
         );
     }
 
-    public function testCreateFromGlobalsWithMultipleUploadErrorUsesEmptyStream(): void
+    public function testCreateFromArrayWithValidFileSpec(): void
     {
-        $files = [
-            'documents' => [
-                'tmp_name' => [$this->createTmpFile(), ''],
-                'size' => [128, 0],
-                'error' => [UPLOAD_ERR_OK, UPLOAD_ERR_NO_FILE],
-                'name' => ['document.txt', ''],
-                'type' => ['text/plain', ''],
-            ],
+        $fileSpec = [
+            'tmp_name' => $this->createTmpFile(),
+            'size' => 1024,
+            'error' => UPLOAD_ERR_OK,
+            'name' => 'test.txt',
+            'type' => 'text/plain',
         ];
-        $streamFactory = new StreamFactorySpy(HelperFactory::createStreamFactory());
 
         $creator = new UploadedFileCreator(
             HelperFactory::createUploadedFileFactory(),
-            $streamFactory,
+            HelperFactory::createStreamFactory(),
         );
 
-        $result = $creator->createFromGlobals($files);
-        $documents = $result['documents'] ?? null;
-
-        self::assertIsArray(
-            $documents,
-            "Should create 'uploaded files' for multiple upload entries.",
-        );
-        self::assertInstanceOf(
-            UploadedFileInterface::class,
-            $documents[0] ?? null,
-            "Should create an 'UploadedFileInterface' for successful multiple upload entries.",
-        );
-        self::assertInstanceOf(
-            UploadedFileInterface::class,
-            $documents[1] ?? null,
-            "Should create an 'UploadedFileInterface' for failed multiple upload entries.",
-        );
-        /** @var UploadedFileInterface $failedDocument */
-        $failedDocument = $documents[1];
+        $uploadedFile = $creator->createFromArray($fileSpec);
 
         self::assertSame(
-            UPLOAD_ERR_NO_FILE,
-            $failedDocument->getError(),
-            "Should preserve 'upload error' code for failed multiple upload entries.",
+            'test.txt',
+            $uploadedFile->getClientFilename(),
+            "Should preserve 'client filename' from file specification.",
         );
-        self::assertTrue(
-            $streamFactory->createdFromFile,
-            "Should still open 'tmp_name' for successful multiple upload entries.",
+        self::assertSame(
+            'text/plain',
+            $uploadedFile->getClientMediaType(),
+            "Should preserve 'client media type' from file specification.",
         );
-        self::assertTrue(
-            $streamFactory->createdFromString,
-            "Should create a safe empty 'stream' for failed multiple upload entries.",
+        self::assertSame(
+            1024,
+            $uploadedFile->getSize(),
+            "Should preserve 'file size' from file specification.",
+        );
+        self::assertSame(
+            UPLOAD_ERR_OK,
+            $uploadedFile->getError(),
+            "Should preserve 'error code' from file specification.",
         );
     }
 
@@ -480,6 +427,63 @@ final class UploadedFileCreatorTest extends TestCase
             1536,
             $secondFile->getSize(),
             "Should preserve 'file size' for second file in 'documents'.",
+        );
+    }
+
+    public function testCreateFromGlobalsWithMultipleUploadErrorUsesEmptyStream(): void
+    {
+        $files = [
+            'documents' => [
+                'tmp_name' => [$this->createTmpFile(), ''],
+                'size' => [128, 0],
+                'error' => [UPLOAD_ERR_OK, UPLOAD_ERR_NO_FILE],
+                'name' => ['document.txt', ''],
+                'type' => ['text/plain', ''],
+            ],
+        ];
+
+        $streamFactory = new StreamFactorySpy(
+            HelperFactory::createStreamFactory(),
+        );
+        $creator = new UploadedFileCreator(
+            HelperFactory::createUploadedFileFactory(),
+            $streamFactory,
+        );
+
+        $result = $creator->createFromGlobals($files);
+
+        $documents = $result['documents'] ?? null;
+
+        self::assertIsArray(
+            $documents,
+            "Should create 'uploaded files' for multiple upload entries.",
+        );
+        self::assertInstanceOf(
+            UploadedFileInterface::class,
+            $documents[0] ?? null,
+            "Should create an 'UploadedFileInterface' for successful multiple upload entries.",
+        );
+        self::assertInstanceOf(
+            UploadedFileInterface::class,
+            $documents[1] ?? null,
+            "Should create an 'UploadedFileInterface' for failed multiple upload entries.",
+        );
+
+        /** @var UploadedFileInterface $failedDocument */
+        $failedDocument = $documents[1];
+
+        self::assertSame(
+            UPLOAD_ERR_NO_FILE,
+            $failedDocument->getError(),
+            "Should preserve 'upload error' code for failed multiple upload entries.",
+        );
+        self::assertTrue(
+            $streamFactory->createdFromFile,
+            "Should still open 'tmp_name' for successful multiple upload entries.",
+        );
+        self::assertTrue(
+            $streamFactory->createdFromString,
+            "Should create a safe empty 'stream' for failed multiple upload entries.",
         );
     }
 

--- a/tests/support/stub/StreamFactorySpy.php
+++ b/tests/support/stub/StreamFactorySpy.php
@@ -12,6 +12,11 @@ use Psr\Http\Message\{StreamFactoryInterface, StreamInterface};
 final class StreamFactorySpy implements StreamFactoryInterface
 {
     public bool $createdFromFile = false;
+
+    /**
+     * @var list<string>
+     */
+    public array $createdFromFileNames = [];
     public bool $createdFromResource = false;
     public bool $createdFromString = false;
 
@@ -27,6 +32,7 @@ final class StreamFactorySpy implements StreamFactoryInterface
     public function createStreamFromFile(string $filename, string $mode = 'r'): StreamInterface
     {
         $this->createdFromFile = true;
+        $this->createdFromFileNames[] = $filename;
 
         return $this->streamFactory->createStreamFromFile($filename, $mode);
     }

--- a/tests/support/stub/StreamFactorySpy.php
+++ b/tests/support/stub/StreamFactorySpy.php
@@ -11,11 +11,9 @@ use Psr\Http\Message\{StreamFactoryInterface, StreamInterface};
  */
 final class StreamFactorySpy implements StreamFactoryInterface
 {
-    public bool $createdFromResource = false;
-
-    public bool $createdFromString = false;
-
     public bool $createdFromFile = false;
+    public bool $createdFromResource = false;
+    public bool $createdFromString = false;
 
     public function __construct(private readonly StreamFactoryInterface $streamFactory) {}
 

--- a/tests/support/stub/StreamFactorySpy.php
+++ b/tests/support/stub/StreamFactorySpy.php
@@ -15,6 +15,8 @@ final class StreamFactorySpy implements StreamFactoryInterface
 
     public bool $createdFromString = false;
 
+    public bool $createdFromFile = false;
+
     public function __construct(private readonly StreamFactoryInterface $streamFactory) {}
 
     public function createStream(string $content = ''): StreamInterface
@@ -26,6 +28,8 @@ final class StreamFactorySpy implements StreamFactoryInterface
 
     public function createStreamFromFile(string $filename, string $mode = 'r'): StreamInterface
     {
+        $this->createdFromFile = true;
+
         return $this->streamFactory->createStreamFromFile($filename, $mode);
     }
 


### PR DESCRIPTION
### Motivation
- Prevent request-level DoS caused by opening `$_FILES` `tmp_name` paths for uploads that failed (e.g. `UPLOAD_ERR_NO_FILE`) which can be empty or invalid.
- Preserve existing behavior for successful uploads while ensuring failed uploads are represented safely without attempting to read a temp file.

### Description
- Add `createStreamForUpload(string $tmpName, int $error): StreamInterface` to `UploadedFileCreator` and use it for both single-file and multi-file creation paths so streams are created via a single helper.
- For non-`UPLOAD_ERR_OK` error codes return a safe empty stream instead of calling `createStreamFromFile()`; for `UPLOAD_ERR_OK` attempt to open the tmp file and throw a clear `InvalidArgumentException` only if opening fails.
- Extend `tests/support/stub/StreamFactorySpy.php` to track `createStreamFromFile()` calls for assertions.
- Add regression tests to `tests/creator/UploadedFileCreatorTest.php` and `tests/creator/ServerRequestCreatorTest.php` verifying failed single uploads, failed entries in multi-upload arrays, and that server-request creation does not crash on `UPLOAD_ERR_NO_FILE`.

### Testing
- Ran PHP syntax checks which succeeded via `php -l` for `src/creator/UploadedFileCreator.php`, `tests/creator/UploadedFileCreatorTest.php`, `tests/creator/ServerRequestCreatorTest.php`, and `tests/support/stub/StreamFactorySpy.php`.
- Ran `composer validate --no-check-publish --no-check-lock` which succeeded.
- Attempted to run dependency installation and `phpunit`, but `composer install` failed due to network/registry access (`asset-packagist.org` returned CONNECT tunnel 403) so `./vendor/bin/phpunit ...` could not be executed in this environment; the new unit tests are included and will run normally once dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1af21d7510832aa1f7580fbfebc2b3)