### PR TITLE
fix(http): finalize the Yii `after-send` lifecycle and worker cleanup in new `Application::finalize()`, called after the runtime emits the response.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(security): bound `ErrorHandler::clearOutput()` buffer loop to prevent worker hangs when an output buffer cannot be removed.
 - fix(security): reject safe-method (`GET`/`HEAD`/`OPTIONS`) `X-Http-Method-Override` overrides and normalize to uppercase to prevent CSRF method-downgrade.
 - fix(security): skip stream access for failed uploads in `UploadedFileCreator` and `Request::getUploadedFiles()` to prevent unauthenticated request DoS.
+- fix(http): finalize the Yii `after-send` lifecycle and worker cleanup in new `Application::finalize()`, called after the runtime emits the response.
 
 ## 0.3.0 February 28, 2026
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -207,6 +207,47 @@ Use non-default values only for advanced scenarios:
 - `syncCookieValidation=false` skips cookie validation synchronization between request and response.
 - Keep `resetUploadedFiles=true` to preserve per-request uploaded-file isolation in worker deployments.
 
+## Response lifecycle finalization
+
+`Application::handle()` runs the request and returns a PSR-7 response, but it intentionally stops at the **pre-send**
+phase: it triggers `EVENT_BEFORE_SEND`, prepares the body, and triggers `EVENT_AFTER_PREPARE`. It does **not** trigger
+`EVENT_AFTER_SEND` or mark the Yii response as sent, because the runtime emits the body afterward and lazy file streams
+(`sendFile()`, `sendStreamAsFile()`) must still be readable at that point.
+
+After the response has been emitted, call `Application::finalize()` to run the **post-send** phase: it triggers
+`EVENT_AFTER_SEND`, marks the response sent, and cleans up per-request event handlers so long-running workers stay
+isolated across requests. Pass `false` when emission failed so after-send is skipped (the response was not delivered)
+while worker cleanup still runs.
+
+The official runners (FrankenPHP, RoadRunner) call this for you. When you drive the bridge yourself, you **must** call
+it after emitting; otherwise after-send handlers (temporary file cleanup, audit/metrics logging, per-request state
+reset) never run and worker state leaks across requests.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use yii2\extensions\psrbridge\emitter\SapiEmitter;
+use yii2\extensions\psrbridge\http\Application;
+
+$app = new Application($config);
+
+$psr7Response = $app->handle($psr7Request);
+
+try {
+    (new SapiEmitter())->emit($psr7Response);
+
+    // finalize: triggers EVENT_AFTER_SEND, marks the response sent, cleans up worker event state
+    $app->finalize();
+} catch (\Throwable $e) {
+    // emission failed: skip after-send, but still clean up worker state
+    $app->finalize(false);
+
+    throw $e;
+}
+```
+
 ## Next steps
 
 - 📚 [Installation Guide](installation.md)

--- a/src/http/Application.php
+++ b/src/http/Application.php
@@ -39,7 +39,7 @@ use function strtoupper;
 class Application extends \yii\web\Application implements RequestHandlerInterface
 {
     /**
-     * Flushes the logger during {@see terminate()} when set to `true`.
+     * Flushes the logger during {@see finalize()} when set to `true`.
      */
     public bool $flushLogger = true;
 
@@ -84,6 +84,11 @@ class Application extends \yii\web\Application implements RequestHandlerInterfac
      * @phpstan-var callable(Event $event): void
      */
     private $eventHandler;
+
+    /**
+     * Stores the converted Yii response awaiting after-send finalization.
+     */
+    private Response|null $lastResponse = null;
 
     /**
      * Caches the memory limit in bytes.
@@ -166,6 +171,40 @@ class Application extends \yii\web\Application implements RequestHandlerInterfac
                 ],
             ],
         );
+    }
+
+    /**
+     * Finalizes the request lifecycle after the runtime emits the PSR-7 response.
+     *
+     * On success, completes the converted Yii response through {@see Response::completeSend()} (triggers
+     * `EVENT_AFTER_SEND` and marks it sent). Always detaches request-scoped event handlers and flushes the logger so
+     * long-running workers stay isolated across requests.
+     *
+     * Pass `false` when emission failed: after-send finalization is skipped because the response was not delivered,
+     * while worker cleanup still runs.
+     *
+     * Usage example:
+     * ```php
+     * $psr7Response = $app->handle($psr7Request);
+     * (new \yii2\extensions\psrbridge\emitter\SapiEmitter())->emit($psr7Response);
+     * $app->finalize();
+     * ```
+     *
+     * @param bool $success Whether the runtime emitted the response successfully.
+     */
+    public function finalize(bool $success = true): void
+    {
+        if ($success) {
+            $this->lastResponse?->completeSend();
+        }
+
+        $this->cleanupEvents();
+
+        if ($this->flushLogger) {
+            $this->getLog()->getLogger()->flush(true);
+        }
+
+        $this->lastResponse = null;
     }
 
     /**
@@ -393,20 +432,21 @@ class Application extends \yii\web\Application implements RequestHandlerInterfac
     }
 
     /**
-     * Finalizes request handling and returns a PSR-7 response.
+     * Converts the Yii response to PSR-7 and stores it for deferred after-send finalization.
      *
-     * @param Response $response Yii response to finalize.
+     * Runs the pre-send conversion only. After-send finalization, event cleanup, and logger flushing are deferred to
+     * {@see finalize()}, which the runtime calls once the PSR-7 response has been emitted.
+     *
+     * @param Response $response Yii response to convert.
+     *
      * @throws InvalidConfigException When configuration is invalid.
      * @throws NotInstantiableException When a service cannot be instantiated.
-     * @return ResponseInterface Final PSR-7 response.
+     *
+     * @return ResponseInterface PSR-7 response produced by the conversion.
      */
     protected function terminate(Response $response): ResponseInterface
     {
-        $this->cleanupEvents();
-
-        if ($this->flushLogger) {
-            $this->getLog()->getLogger()->flush(true);
-        }
+        $this->lastResponse = $response;
 
         return $response->getPsr7Response();
     }

--- a/src/http/Application.php
+++ b/src/http/Application.php
@@ -177,8 +177,9 @@ class Application extends \yii\web\Application implements RequestHandlerInterfac
      * Finalizes the request lifecycle after the runtime emits the PSR-7 response.
      *
      * On success, completes the converted Yii response through {@see Response::completeSend()} (triggers
-     * `EVENT_AFTER_SEND` and marks it sent). Always detaches request-scoped event handlers and flushes the logger so
-     * long-running workers stay isolated across requests.
+     * `EVENT_AFTER_SEND` and marks it sent). Detaches request-scoped event handlers and flushes the logger so
+     * long-running workers stay isolated across requests, even when an after-send handler throws (the exception is
+     * rethrown after cleanup runs).
      *
      * Pass `false` when emission failed: after-send finalization is skipped because the response was not delivered,
      * while worker cleanup still runs.
@@ -194,17 +195,19 @@ class Application extends \yii\web\Application implements RequestHandlerInterfac
      */
     public function finalize(bool $success = true): void
     {
-        if ($success) {
-            $this->lastResponse?->completeSend();
+        try {
+            if ($success) {
+                $this->lastResponse?->completeSend();
+            }
+        } finally {
+            $this->cleanupEvents();
+
+            if ($this->flushLogger && $this->lastResponse !== null) {
+                $this->getLog()->getLogger()->flush(true);
+            }
+
+            $this->lastResponse = null;
         }
-
-        $this->cleanupEvents();
-
-        if ($this->flushLogger) {
-            $this->getLog()->getLogger()->flush(true);
-        }
-
-        $this->lastResponse = null;
     }
 
     /**

--- a/src/http/Response.php
+++ b/src/http/Response.php
@@ -43,6 +43,34 @@ class Response extends \yii\web\Response
     private ResponseAdapter|null $adapter = null;
 
     /**
+     * Completes the Yii response send lifecycle after the runtime emits the PSR-7 body.
+     *
+     * Triggers {@see EVENT_AFTER_SEND} and marks the response as sent, running the back half of {@see send()} that
+     * {@see getPsr7Response()} intentionally defers. Returns immediately when the response is already sent.
+     *
+     * Call this after the PSR-7 response has been emitted so lazy body streams (such as {@see sendFile()} or
+     * {@see sendStreamAsFile()}) are consumed before after-send handlers run.
+     *
+     * Usage example:
+     * ```php
+     * $response = new \yii2\extensions\psrbridge\http\Response();
+     * $psr7Response = $response->getPsr7Response();
+     * // emit $psr7Response through the runtime, then finalize the Yii lifecycle:
+     * $response->completeSend();
+     * ```
+     */
+    public function completeSend(): void
+    {
+        if ($this->isSent) {
+            return;
+        }
+
+        $this->trigger(self::EVENT_AFTER_SEND);
+
+        $this->isSent = true;
+    }
+
+    /**
      * Converts the Yii Response component to a PSR-7 ResponseInterface instance.
      *
      * Delegates the conversion process to a {@see ResponseAdapter}, triggering Yii Response lifecycle events and

--- a/tests/http/ResponseTest.php
+++ b/tests/http/ResponseTest.php
@@ -25,6 +25,45 @@ use function urlencode;
 #[Group('http')]
 final class ResponseTest extends TestCase
 {
+    public function testCompleteSendTriggersAfterSendAndMarksResponseSent(): void
+    {
+        $eventsAfter = [];
+
+        $response = new Response();
+
+        $response->on(
+            Response::EVENT_AFTER_SEND,
+            static function () use (&$eventsAfter): void {
+                $eventsAfter[] = 'EVENT_AFTER_SEND';
+            },
+        );
+
+        self::assertFalse(
+            $response->isSent,
+            'Fresh response must not be marked as sent.',
+        );
+
+        $response->completeSend();
+
+        self::assertContains(
+            'EVENT_AFTER_SEND',
+            $eventsAfter,
+            "'EVENT_AFTER_SEND' must fire on finalization.",
+        );
+        self::assertTrue(
+            $response->isSent,
+            'Response must be marked as sent after finalization.',
+        );
+
+        $response->completeSend();
+
+        self::assertCount(
+            1,
+            $eventsAfter,
+            'Repeated finalization must be a no-op.',
+        );
+    }
+
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      * @throws NotInstantiableException if a class or service can't be instantiated.

--- a/tests/http/stateless/ApplicationCoreTest.php
+++ b/tests/http/stateless/ApplicationCoreTest.php
@@ -103,6 +103,9 @@ final class ApplicationCoreTest extends TestCase
 
         $response = $app->handle(HelperFactory::createRequest('GET', 'site/index'));
 
+        // the logger flush now runs in `finalize()`, after the runtime emits the response.
+        $app->finalize();
+
         $this->assertSiteIndexJsonResponse(
             $response,
         );

--- a/tests/http/stateless/ApplicationCoreTest.php
+++ b/tests/http/stateless/ApplicationCoreTest.php
@@ -103,12 +103,13 @@ final class ApplicationCoreTest extends TestCase
 
         $response = $app->handle(HelperFactory::createRequest('GET', 'site/index'));
 
-        // the logger flush now runs in `finalize()`, after the runtime emits the response.
-        $app->finalize();
-
         $this->assertSiteIndexJsonResponse(
             $response,
         );
+
+        // the logger flush now runs in `finalize()`, after the runtime emits the response.
+        $app->finalize();
+
         self::assertFileExists(
             $this->logFile,
             "Log file should exist after 'flush(true)'.",

--- a/tests/http/stateless/ApplicationEventTest.php
+++ b/tests/http/stateless/ApplicationEventTest.php
@@ -107,12 +107,13 @@ final class ApplicationEventTest extends TestCase
 
         $response = $app->handle(HelperFactory::createRequest('GET', '/site/index'));
 
-        // cleanup is deferred to `finalize()`, called by the runtime after emission.
-        $app->finalize();
-
         $this->assertSiteIndexJsonResponse(
             $response,
         );
+
+        // cleanup is deferred to `finalize()`, called by the runtime after emission.
+        $app->finalize();
+
         self::assertCount(
             1,
             $mockComponent1->offCalls,
@@ -180,11 +181,12 @@ final class ApplicationEventTest extends TestCase
 
         $response = $app->handle(HelperFactory::createRequest('GET', '/site/index'));
 
-        $app->finalize();
-
         $this->assertSiteIndexJsonResponse(
             $response,
         );
+
+        $app->finalize();
+
         self::assertGreaterThanOrEqual(
             2,
             $trackedCounts[0] ?? 0,
@@ -212,8 +214,6 @@ final class ApplicationEventTest extends TestCase
 
         $response = $app->handle(HelperFactory::createRequest('GET', '/site/statuscode'));
 
-        $app->finalize();
-
         self::assertSame(
             201,
             $response->getStatusCode(),
@@ -228,6 +228,9 @@ final class ApplicationEventTest extends TestCase
             $response->getBody()->getContents(),
             'Expected Response body should be empty.',
         );
+
+        $app->finalize();
+
         self::assertCount(
             2,
             $eventsCaptured,
@@ -269,11 +272,12 @@ final class ApplicationEventTest extends TestCase
 
         $response = $app->handle(HelperFactory::createRequest('GET', '/site/index'));
 
-        $app->finalize();
-
         $this->assertSiteIndexJsonResponse(
             $response,
         );
+
+        $app->finalize();
+
         self::assertCount(
             2,
             $eventsTriggered,
@@ -305,8 +309,6 @@ final class ApplicationEventTest extends TestCase
 
         $response = $app->handle(HelperFactory::createRequest('GET', 'site/statuscode'));
 
-        $app->finalize();
-
         self::assertSame(
             201,
             $response->getStatusCode(),
@@ -321,6 +323,9 @@ final class ApplicationEventTest extends TestCase
             $response->getBody()->getContents(),
             'Expected Response body should be empty.',
         );
+
+        $app->finalize();
+
         self::assertCount(
             1,
             $eventsTriggered,
@@ -358,11 +363,11 @@ final class ApplicationEventTest extends TestCase
 
         $response = $app->handle(HelperFactory::createRequest('GET', 'site/index'));
 
-        $app->finalize();
-
         $this->assertSiteIndexJsonResponse(
             $response,
         );
+
+        $app->finalize();
 
         Event::trigger('', 'test.global.event');
 
@@ -400,9 +405,6 @@ final class ApplicationEventTest extends TestCase
 
         $response = $app->handle(HelperFactory::createRequest('GET', '/site/index'));
 
-        // detaches the global tracker so the post-request manual trigger is not recorded.
-        $app->finalize();
-
         $this->assertSiteIndexJsonResponse(
             $response,
         );
@@ -414,6 +416,9 @@ final class ApplicationEventTest extends TestCase
             $component,
             'Event component should be an instance of EventComponent.',
         );
+
+        // detaches the global tracker so the post-request manual trigger is not recorded.
+        $app->finalize();
 
         $component->triggerTestEvent();
 

--- a/tests/http/stateless/ApplicationEventTest.php
+++ b/tests/http/stateless/ApplicationEventTest.php
@@ -107,6 +107,9 @@ final class ApplicationEventTest extends TestCase
 
         $response = $app->handle(HelperFactory::createRequest('GET', '/site/index'));
 
+        // cleanup is deferred to `finalize()`, called by the runtime after emission.
+        $app->finalize();
+
         $this->assertSiteIndexJsonResponse(
             $response,
         );
@@ -177,6 +180,8 @@ final class ApplicationEventTest extends TestCase
 
         $response = $app->handle(HelperFactory::createRequest('GET', '/site/index'));
 
+        $app->finalize();
+
         $this->assertSiteIndexJsonResponse(
             $response,
         );
@@ -206,6 +211,8 @@ final class ApplicationEventTest extends TestCase
         );
 
         $response = $app->handle(HelperFactory::createRequest('GET', '/site/statuscode'));
+
+        $app->finalize();
 
         self::assertSame(
             201,
@@ -262,6 +269,8 @@ final class ApplicationEventTest extends TestCase
 
         $response = $app->handle(HelperFactory::createRequest('GET', '/site/index'));
 
+        $app->finalize();
+
         $this->assertSiteIndexJsonResponse(
             $response,
         );
@@ -295,6 +304,8 @@ final class ApplicationEventTest extends TestCase
         );
 
         $response = $app->handle(HelperFactory::createRequest('GET', 'site/statuscode'));
+
+        $app->finalize();
 
         self::assertSame(
             201,
@@ -347,6 +358,8 @@ final class ApplicationEventTest extends TestCase
 
         $response = $app->handle(HelperFactory::createRequest('GET', 'site/index'));
 
+        $app->finalize();
+
         $this->assertSiteIndexJsonResponse(
             $response,
         );
@@ -386,6 +399,9 @@ final class ApplicationEventTest extends TestCase
         );
 
         $response = $app->handle(HelperFactory::createRequest('GET', '/site/index'));
+
+        // detaches the global tracker so the post-request manual trigger is not recorded.
+        $app->finalize();
 
         $this->assertSiteIndexJsonResponse(
             $response,

--- a/tests/http/stateless/ApplicationFinalizeTest.php
+++ b/tests/http/stateless/ApplicationFinalizeTest.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\psrbridge\tests\http\stateless;
+
+use PHPForge\Support\ReflectionHelper;
+use PHPUnit\Framework\Attributes\Group;
+use ReflectionException;
+use yii\base\{Event, InvalidConfigException};
+use yii2\extensions\psrbridge\http\Response;
+use yii2\extensions\psrbridge\tests\support\{ApplicationFactory, HelperFactory, TestCase};
+
+/**
+ * Unit tests for {@see \yii2\extensions\psrbridge\http\Application::finalize()} after-send finalization in stateless
+ * mode.
+ */
+#[Group('http')]
+final class ApplicationFinalizeTest extends TestCase
+{
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     * @throws ReflectionException if the property does not exist or is inaccessible.
+     */
+    public function testFinalizeFiresAfterSendAndMarksSentOnSuccessfulEmission(): void
+    {
+        $afterSend = 0;
+
+        Event::on(
+            Response::class,
+            Response::EVENT_AFTER_SEND,
+            static function () use (&$afterSend): void {
+                $afterSend++;
+            },
+        );
+
+        $app = ApplicationFactory::stateless();
+
+        $response = $app->handle(HelperFactory::createRequest('GET', 'site/index'));
+
+        $this->assertSiteIndexJsonResponse(
+            $response,
+        );
+        self::assertSame(
+            0,
+            $afterSend,
+            'After-send must be deferred past conversion.',
+        );
+        self::assertFalse(
+            $app->response->isSent,
+            'Conversion alone must not mark the response sent.',
+        );
+
+        $app->finalize();
+
+        self::assertSame(
+            1,
+            $afterSend,
+            "'EVENT_AFTER_SEND' must fire once on success.",
+        );
+        self::assertTrue(
+            $app->response->isSent,
+            'Response must be marked sent after finalization.',
+        );
+        self::assertEmpty(
+            ReflectionHelper::inaccessibleProperty($app, 'registeredEvents'),
+            'Worker events must be cleaned on finalization.',
+        );
+        self::assertNull(
+            ReflectionHelper::inaccessibleProperty($app, 'lastResponse'),
+            'Stored response reference must be cleared.',
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     * @throws ReflectionException if the property does not exist or is inaccessible.
+     */
+    public function testFinalizeIsIdempotentAcrossRepeatedCalls(): void
+    {
+        $afterSend = 0;
+
+        Event::on(
+            Response::class,
+            Response::EVENT_AFTER_SEND,
+            static function () use (&$afterSend): void {
+                $afterSend++;
+            },
+        );
+
+        $app = ApplicationFactory::stateless();
+
+        $app->handle(HelperFactory::createRequest('GET', 'site/index'));
+
+        $app->finalize();
+        $app->finalize();
+
+        self::assertSame(
+            1,
+            $afterSend,
+            "'EVENT_AFTER_SEND' must fire exactly once.",
+        );
+        self::assertEmpty(
+            ReflectionHelper::inaccessibleProperty($app, 'registeredEvents'),
+            'Events must remain clean after repeated calls.',
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     * @throws ReflectionException if the property does not exist or is inaccessible.
+     */
+    public function testFinalizeIsSafeWithoutPriorRequest(): void
+    {
+        $afterSend = 0;
+
+        Event::on(
+            Response::class,
+            Response::EVENT_AFTER_SEND,
+            static function () use (&$afterSend): void {
+                $afterSend++;
+            },
+        );
+
+        $app = ApplicationFactory::stateless();
+
+        // the application defers parent initialization to the first handle(); skip the logger flush so the no-op path
+        // does not resolve the uninitialized 'log' component
+        $app->flushLogger = false;
+
+        $app->finalize();
+
+        self::assertSame(
+            0,
+            $afterSend,
+            'No stored response means no after-send.',
+        );
+        self::assertEmpty(
+            ReflectionHelper::inaccessibleProperty($app, 'registeredEvents'),
+            'Cleanup must remain a safe no-op.',
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     * @throws ReflectionException if the property does not exist or is inaccessible.
+     */
+    public function testFinalizeRunsAfterSendOnceLazyStreamBodyIsConsumed(): void
+    {
+        $afterSend = 0;
+
+        Event::on(
+            Response::class,
+            Response::EVENT_AFTER_SEND,
+            static function () use (&$afterSend): void {
+                $afterSend++;
+            },
+        );
+
+        $app = ApplicationFactory::stateless();
+
+        $response = $app->handle(HelperFactory::createRequest('GET', 'site/stream'));
+
+        self::assertSame(
+            'This is a test file content.',
+            $response->getBody()->getContents(),
+            'Lazy stream body must be fully readable before finalization.',
+        );
+        self::assertSame(
+            0,
+            $afterSend,
+            'After-send must not run before the body is consumed.',
+        );
+
+        $app->finalize();
+
+        self::assertSame(
+            1,
+            $afterSend,
+            'After-send must run once the runtime finalizes.',
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     * @throws ReflectionException if the property does not exist or is inaccessible.
+     */
+    public function testFinalizeSkipsAfterSendOnFailedEmissionButStillCleansUp(): void
+    {
+        $afterSend = 0;
+
+        Event::on(
+            Response::class,
+            Response::EVENT_AFTER_SEND,
+            static function () use (&$afterSend): void {
+                $afterSend++;
+            },
+        );
+
+        $app = ApplicationFactory::stateless();
+
+        $response = $app->handle(HelperFactory::createRequest('GET', 'site/index'));
+
+        $this->assertSiteIndexJsonResponse(
+            $response,
+        );
+
+        $app->finalize(false);
+
+        self::assertSame(
+            0,
+            $afterSend,
+            "Failed emission must not fire 'EVENT_AFTER_SEND'.",
+        );
+        self::assertFalse(
+            $app->response->isSent,
+            'Undelivered response must stay unsent.',
+        );
+        self::assertEmpty(
+            ReflectionHelper::inaccessibleProperty($app, 'registeredEvents'),
+            'Worker events must be cleaned even on failure.',
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     * @throws ReflectionException if the property does not exist or is inaccessible.
+     */
+    public function testFinalizeTargetsEmittedResponseWhenActionReturnsOwnInstance(): void
+    {
+        $app = ApplicationFactory::stateless();
+
+        $response = $app->handle(HelperFactory::createRequest('GET', 'site/fresh-response'));
+
+        /** @phpstan-var Response $emitted */
+        $emitted = ReflectionHelper::inaccessibleProperty($app, 'lastResponse');
+
+        $component = $app->response;
+
+        self::assertNotSame(
+            $component,
+            $emitted,
+            'Action-returned Response must differ from the component instance.',
+        );
+        self::assertJsonStringEqualsJsonString(
+            '{"fresh":true}',
+            (string) $response->getBody(),
+            'Emitted body must come from the action-returned Response.',
+        );
+        self::assertFalse(
+            $emitted->isSent,
+            'Emitted response must be unsent before finalization.',
+        );
+        self::assertFalse(
+            $component->isSent,
+            'Component must be unsent before finalization.',
+        );
+
+        $app->finalize();
+
+        self::assertTrue(
+            $emitted->isSent,
+            'Finalization must mark the emitted response sent.',
+        );
+        self::assertFalse(
+            $component->isSent,
+            'Component must stay unsent: it was never emitted.',
+        );
+    }
+}

--- a/tests/http/stateless/ApplicationFinalizeTest.php
+++ b/tests/http/stateless/ApplicationFinalizeTest.php
@@ -7,6 +7,7 @@ namespace yii2\extensions\psrbridge\tests\http\stateless;
 use PHPForge\Support\ReflectionHelper;
 use PHPUnit\Framework\Attributes\Group;
 use ReflectionException;
+use RuntimeException;
 use yii\base\{Event, InvalidConfigException};
 use yii2\extensions\psrbridge\http\Response;
 use yii2\extensions\psrbridge\tests\support\{ApplicationFactory, HelperFactory, TestCase};
@@ -18,6 +19,46 @@ use yii2\extensions\psrbridge\tests\support\{ApplicationFactory, HelperFactory, 
 #[Group('http')]
 final class ApplicationFinalizeTest extends TestCase
 {
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     * @throws ReflectionException if the property does not exist or is inaccessible.
+     */
+    public function testFinalizeCleansUpWorkerStateWhenAfterSendHandlerThrows(): void
+    {
+        Event::on(
+            Response::class,
+            Response::EVENT_AFTER_SEND,
+            static function (): void {
+                throw new RuntimeException('after-send failure');
+            },
+        );
+
+        $app = ApplicationFactory::stateless();
+
+        $app->handle(HelperFactory::createRequest('GET', 'site/index'));
+
+        try {
+            $app->finalize();
+
+            self::fail('After-send handler exception must propagate.');
+        } catch (RuntimeException $e) {
+            self::assertSame(
+                'after-send failure',
+                $e->getMessage(),
+                'Original after-send exception must propagate.',
+            );
+        }
+
+        self::assertEmpty(
+            ReflectionHelper::inaccessibleProperty($app, 'registeredEvents'),
+            'Worker events must be cleaned even when after-send throws.',
+        );
+        self::assertNull(
+            ReflectionHelper::inaccessibleProperty($app, 'lastResponse'),
+            'Stored reference must be cleared even when after-send throws.',
+        );
+    }
+
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      * @throws ReflectionException if the property does not exist or is inaccessible.
@@ -124,9 +165,10 @@ final class ApplicationFinalizeTest extends TestCase
 
         $app = ApplicationFactory::stateless();
 
-        // the application defers parent initialization to the first handle(); skip the logger flush so the no-op path
-        // does not resolve the uninitialized 'log' component
-        $app->flushLogger = false;
+        self::assertTrue(
+            $app->flushLogger,
+            'Default logger flushing must remain enabled.',
+        );
 
         $app->finalize();
 

--- a/tests/support/TestCase.php
+++ b/tests/support/TestCase.php
@@ -7,7 +7,7 @@ namespace yii2\extensions\psrbridge\tests\support;
 use Psr\Http\Message\ResponseInterface;
 use RuntimeException;
 use Yii;
-use yii\base\Security;
+use yii\base\{Event, Security};
 use yii2\extensions\psrbridge\tests\support\stub\MockerFunctions;
 
 use function array_pop;
@@ -226,6 +226,9 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $_GET = [];
         $_POST = [];
         $_SERVER = $this->originalServer;
+
+        // detach any global event handlers left attached when a test does not call `finalize()`.
+        Event::offAll();
 
         $this->closeApplication();
         parent::tearDown();

--- a/tests/support/stub/SiteController.php
+++ b/tests/support/stub/SiteController.php
@@ -7,7 +7,8 @@ namespace yii2\extensions\psrbridge\tests\support\stub;
 use Yii;
 use yii\base\{Exception, InvalidRouteException, UserException};
 use yii\captcha\CaptchaAction;
-use yii\web\{Application, Controller, Cookie, RangeNotSatisfiableHttpException, Response};
+use yii\web\{Controller, Cookie, RangeNotSatisfiableHttpException};
+use yii2\extensions\psrbridge\http\{Application, Response};
 
 use function fwrite;
 use function htmlspecialchars;
@@ -18,6 +19,8 @@ use function tmpfile;
 
 /**
  * Controller stub for testing various HTTP actions and behaviors in Yii applications.
+ *
+ * @property Response $response The PSR bridge response component bound to the current request.
  *
  * @extends Controller<Application>
  */
@@ -185,6 +188,17 @@ final class SiteController extends Controller
         $tmpFilePath = stream_get_meta_data($tmpFile)['uri'] ?? '';
 
         return $this->response->sendFile($tmpFilePath, 'testfile.txt', ['mimeType' => 'text/plain']);
+    }
+
+    public function actionFreshResponse(): Response
+    {
+        // returns a brand-new Response instance, not $this->response, to exercise lifecycle finalization
+        return new Response(
+            [
+                'format' => Response::FORMAT_JSON,
+                'data' => ['fresh' => true],
+            ],
+        );
     }
 
     public function actionGet(): mixed


### PR DESCRIPTION
# Pull Request

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] CI/build configuration
- [ ] Documentation update
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)